### PR TITLE
Fix for getting device number with national prefix

### DIFF
--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -1,12 +1,10 @@
 package org.thoughtcrime.securesms;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.v7.app.AlertDialog;
-import android.telephony.TelephonyManager;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -137,10 +135,10 @@ public class RegistrationActivity extends BaseActionBarActivity {
           this.number.setText(localNumberObject.getNationalNumber()+"");
         }
       } else {
-        String simCountryIso = ((TelephonyManager)getSystemService(Context.TELEPHONY_SERVICE)).getSimCountryIso();
+        String simCountryIso = Util.getSimCountryIso(this);
 
         if (!TextUtils.isEmpty(simCountryIso)) {
-          this.countryCode.setText(numberUtil.getCountryCodeForRegion(simCountryIso.toUpperCase())+"");
+          this.countryCode.setText(numberUtil.getCountryCodeForRegion(simCountryIso)+"");
         }
       }
     } catch (NumberParseException npe) {

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -38,6 +38,8 @@ import android.text.style.StyleSpan;
 import android.util.Log;
 import android.widget.EditText;
 
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+
 import org.thoughtcrime.securesms.BuildConfig;
 import org.thoughtcrime.securesms.mms.OutgoingLegacyMmsConnection;
 import org.whispersystems.textsecure.api.util.InvalidNumberException;
@@ -50,7 +52,6 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -218,18 +219,19 @@ public class Util {
   }
 
   public static String getDeviceE164Number(Context context) {
-    String localNumber = ((TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE))
-        .getLine1Number();
+    final String  localNumber = ((TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE)).getLine1Number();
+    final String  countryIso  = getSimCountryIso(context);
+    final Integer countryCode = PhoneNumberUtil.getInstance().getCountryCodeForRegion(countryIso);
 
-    if (!TextUtils.isEmpty(localNumber) && !localNumber.startsWith("+"))
-    {
-      if (localNumber.length() == 10) localNumber = "+1" + localNumber;
-      else                            localNumber = "+"  + localNumber;
+    if (TextUtils.isEmpty(localNumber)) return null;
 
-      return localNumber;
-    }
+    return localNumber.startsWith("+") ? localNumber
+                                       : PhoneNumberFormatter.formatE164(String.valueOf(countryCode), localNumber);
+  }
 
-    return null;
+  public static String getSimCountryIso(Context context) {
+    return ((TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE))
+           .getSimCountryIso().toUpperCase();
   }
 
   public static <T> List<List<T>> partition(List<T> list, int partitionSize) {

--- a/test/unitTest/java/org/thoughtcrime/securesms/util/PhoneNumberFormatterTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/util/PhoneNumberFormatterTest.java
@@ -8,21 +8,53 @@ import org.whispersystems.textsecure.api.util.PhoneNumberFormatter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class PhoneNumberFormatterTest {
-  private static final String LOCAL_NUMBER = "+15555555555";
+public class PhoneNumberFormatterTest extends TextSecureTestCase {
+  private static final String LOCAL_NUMBER_US  = "+15555555555";
+  private static final String NUMBER_CH        = "+41446681800";
+  private static final String NUMBER_UK        = "+442079460018";
+  private static final String NUMBER_DE        = "+4930123456";
+  private static final String NUMBER_MOBILE_DE = "+49171123456";
+  private static final String COUNTRY_CODE_CH  = "41";
+  private static final String COUNTRY_CODE_UK  = "44";
+  private static final String COUNTRY_CODE_DE  = "49";
 
-  @Test public void testFormatNumberE164() throws Exception, InvalidNumberException {
-    assertThat(PhoneNumberFormatter.formatNumber("(555) 555-5555", LOCAL_NUMBER)).isEqualTo(LOCAL_NUMBER);
-    assertThat(PhoneNumberFormatter.formatNumber("555-5555", LOCAL_NUMBER)).isEqualTo(LOCAL_NUMBER);
-    assertThat(PhoneNumberFormatter.formatNumber("(123) 555-5555", LOCAL_NUMBER)).isNotEqualTo(LOCAL_NUMBER);
+  @Test
+  public void testFormatNumber() throws Exception, InvalidNumberException {
+    assertThat(PhoneNumberFormatter.formatNumber("(555) 555-5555", LOCAL_NUMBER_US)).isEqualTo(LOCAL_NUMBER_US);
+    assertThat(PhoneNumberFormatter.formatNumber("555-5555", LOCAL_NUMBER_US)).isEqualTo(LOCAL_NUMBER_US);
+    assertThat(PhoneNumberFormatter.formatNumber("(123) 555-5555", LOCAL_NUMBER_US)).isNotEqualTo(LOCAL_NUMBER_US);
   }
 
-  @Test public void testFormatNumberEmail() throws Exception {
+  @Test
+  public void testFormatNumberEmail() throws Exception {
     try {
-      PhoneNumberFormatter.formatNumber("person@domain.com", LOCAL_NUMBER);
+      PhoneNumberFormatter.formatNumber("person@domain.com", LOCAL_NUMBER_US);
       throw new AssertionFailedError("should have thrown on email");
     } catch (InvalidNumberException ine) {
       // success
     }
   }
+
+  @Test
+  public void testFormatNumberE164() throws Exception, InvalidNumberException {
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_UK, "(020) 7946 0018").equals(NUMBER_UK));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_UK, "044 20 7946 0018").equals(NUMBER_UK));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_UK, "+442079460018").equals(NUMBER_UK));
+
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_CH, "+41 44 668 18 00").equals(NUMBER_CH));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_CH, "+41 (044) 6681800").equals(NUMBER_CH));
+
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "0049 030 123456").equals(NUMBER_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "0049 (0)30123456").equals(NUMBER_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "0049((0)30)123456").equals(NUMBER_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "+49 (0) 30  1 2  3 45 6 ").equals(NUMBER_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "030 123456").equals(NUMBER_DE));
+
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "0171123456").equals(NUMBER_MOBILE_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "0171/123456").equals(NUMBER_MOBILE_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "+490171/123456").equals(NUMBER_MOBILE_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "00490171/123456").equals(NUMBER_MOBILE_DE));
+    assertThat(PhoneNumberFormatter.formatE164(COUNTRY_CODE_DE, "0049171/123456").equals(NUMBER_MOBILE_DE));
+  }
+
 }


### PR DESCRIPTION
This also removes the forced country code '+1' when digit count equals ten. The 10 is not a US only privilege 😆

At least for my SIMs `((TelephonyManager)context.getSystemService(Context.TELEPHONY_SERVICE)).getLine1Number()` returns a number in national format like 0 123 4568. Which is National Prefix + Identification Code + Subscriber Number.

Right now a plus gets added which returns a wrong number: +01234568.
Where it should be like +44 123 4568
