### PR TITLE
Changing app appearance fixes user jumping to root settings

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -18,6 +18,8 @@ package org.thoughtcrime.securesms;
 
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.support.annotation.NonNull;
@@ -70,7 +72,10 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   @Override
   protected void onCreate(Bundle icicle, @NonNull MasterSecret masterSecret) {
     this.getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-    initFragment(android.R.id.content, new ApplicationPreferenceFragment(), masterSecret);
+
+    if (icicle == null) {
+      initFragment(android.R.id.content, new ApplicationPreferenceFragment(), masterSecret);
+    }
   }
 
   @Override
@@ -105,9 +110,17 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
   @Override
   public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
     if (key.equals(TextSecurePreferences.THEME_PREF)) {
-      dynamicTheme.onResume(this);
+      if (VERSION.SDK_INT >= VERSION_CODES.HONEYCOMB) {
+        recreate();
+      } else {
+        dynamicTheme.onResume(this);
+      }
     } else if (key.equals(TextSecurePreferences.LANGUAGE_PREF)) {
-      dynamicLanguage.onResume(this);
+      if (VERSION.SDK_INT >= VERSION_CODES.HONEYCOMB) {
+        recreate();
+      } else {
+        dynamicLanguage.onResume(this);
+      }
 
       Intent intent = new Intent(this, KeyCachingService.class);
       intent.setAction(KeyCachingService.LOCALE_CHANGE_EVENT);


### PR DESCRIPTION
Changing the theme or language returns the user to the root settings screen, which can be jarring. If you accidentally tapped on the wrong language this also makes it harder find your way back. 

For Android 3.0 Honeycomb and up, this can be prevented by calling `recreate()` on the Activity instead of using `finish()` and manually starting a new instance.

Possibly a fix for #2476.

// FREEBIE