### PR TITLE
display group information in message notifications

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -182,7 +182,7 @@ public class MessageNotifier {
 
     List<NotificationItem>     notifications       = notificationState.getNotifications();
     NotificationCompat.Builder builder             = new NotificationCompat.Builder(context);
-    Recipient                  recipient           = notifications.get(0).getIndividualRecipient();
+    Recipient                  recipient           = notifications.get(0).getPrimaryRecipient();
     Drawable                   recipientPhoto      = recipient.getContactPhoto();
     int                        largeIconTargetSize = context.getResources().getDimensionPixelSize(R.dimen.contact_photo_target_size);
 
@@ -219,7 +219,7 @@ public class MessageNotifier {
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
     while(iterator.hasPrevious()) {
       NotificationItem item = iterator.previous();
-      content.append(item.getBigStyleSummary());
+      content.append(item.getSingleThreadSummary());
       content.append('\n');
     }
 
@@ -242,6 +242,7 @@ public class MessageNotifier {
   {
     List<NotificationItem> notifications = notificationState.getNotifications();
     NotificationCompat.Builder builder   = new NotificationCompat.Builder(context);
+    Recipient recipient                  = notifications.get(0).getPrimaryRecipient();
 
     builder.setColor(context.getResources().getColor(R.color.textsecure_primary));
     builder.setSmallIcon(R.drawable.icon_notification);
@@ -250,9 +251,8 @@ public class MessageNotifier {
                                          notificationState.getMessageCount(),
                                          notificationState.getThreadCount()));
     builder.setContentText(context.getString(R.string.MessageNotifier_most_recent_from_s,
-                                             notifications.get(0).getIndividualRecipientName()));
+                                             recipient.toShortString()));
     builder.setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, ConversationListActivity.class), 0));
-    
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
     builder.setNumber(notificationState.getMessageCount());
     builder.setCategory(NotificationCompat.CATEGORY_MESSAGE);
@@ -276,8 +276,8 @@ public class MessageNotifier {
     while(iterator.hasPrevious()) {
       NotificationItem item = iterator.previous();
       style.addLine(item.getTickerText());
-      if (item.getIndividualRecipient().getContactUri() != null) {
-        builder.addPerson(item.getIndividualRecipient().getContactUri().toString());
+      if (item.getPrimaryRecipient().getContactUri() != null) {
+        builder.addPerson(item.getPrimaryRecipient().getContactUri().toString());
       }
     }
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -34,12 +34,21 @@ public class NotificationItem {
     this.timestamp           = timestamp;
   }
 
-  public Recipient getIndividualRecipient() {
-    return individualRecipient;
+  private Recipient getGroupRecipient() {
+    if (threadRecipients != null && threadRecipients.isGroupRecipient()) {
+      return threadRecipients.getPrimaryRecipient();
+    } else {
+      return null;
+    }
   }
 
-  public String getIndividualRecipientName() {
-    return individualRecipient.toShortString();
+  private boolean hasGroupRecipient() {
+    return getGroupRecipient() != null;
+  }
+
+  public Recipient getPrimaryRecipient() {
+    if (hasGroupRecipient()) return getGroupRecipient();
+    else                     return individualRecipient;
   }
 
   public CharSequence getText() {
@@ -62,13 +71,24 @@ public class NotificationItem {
     return threadId;
   }
 
-  public CharSequence getBigStyleSummary() {
-    return (text == null) ? "" : text;
+  public CharSequence getSingleThreadSummary() {
+    SpannableStringBuilder bigSummary = new SpannableStringBuilder();
+
+    if (hasGroupRecipient()) {
+      bigSummary.append(Util.getBoldedString(individualRecipient.toShortString() + ": "));
+    }
+
+    return bigSummary.append(getText());
   }
 
   public CharSequence getTickerText() {
     SpannableStringBuilder builder = new SpannableStringBuilder();
-    builder.append(Util.getBoldedString(getIndividualRecipientName()));
+
+    if (hasGroupRecipient()) {
+      builder.append(Util.getBoldedString(getGroupRecipient().toShortString()));
+    } else {
+      builder.append(Util.getBoldedString(individualRecipient.toShortString()));
+    }
     builder.append(": ");
     builder.append(getText());
 


### PR DESCRIPTION
1) replaced NotificationItem getIndividualRecipient() with getPrimaryRecipient() to favor group information in notifications.
2) fixed NotificationItem to display group information in notifications.
3) updated MessageNotifier to work with NotificationItem changes.

Fixes #1033
Fixes #2558
// FREEBIE

## single thread group notification format
```
__________
| group  | <group  name>
|  icon  | <contact name>: <message text>
---------- <contact name>: <message text>
```

## multiple thread notification where one is from a group
```
____________
|  notify  | 2 new messages
|  icon    | <group name>: <message text>
------------ <contact name>: <message text>
```