### PR TITLE
#2791 / #1901 - Backups to sub-folder

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -12,7 +12,8 @@ import java.io.IOException;
 
 public class PlaintextBackupExporter {
 
-  private final static String FILENAME = "TextSecurePlaintextBackup.xml";
+  private static final String FILENAME = "TextSecurePlaintextBackup.xml";
+  private static final String FOLDERNAME = "TextSecure";
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
@@ -29,7 +30,7 @@ public class PlaintextBackupExporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return getOldPlaintextExportDirectoryPath() + "TextSecure" + File.separator;
+    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator;
   }
 
   private static String getOldPlaintextExportDirectoryPath() {

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 
 public class PlaintextBackupExporter {
 
-  private final String FILENAME = "TextSecurePlaintextBackup.xml";
+  private final static String FILENAME = "TextSecurePlaintextBackup.xml";
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -14,6 +14,7 @@ public class PlaintextBackupExporter {
 
   private static final String FILENAME = "TextSecurePlaintextBackup.xml";
   private static final String FOLDERNAME = "TextSecure";
+  private static final String BACKUPFOLDERNAME = "Backup";
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
@@ -30,7 +31,7 @@ public class PlaintextBackupExporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + "Backup" + File.separator;
+    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + BACKUPFOLDERNAME + File.separator;
   }
 
   private static String getOldPlaintextExportDirectoryPath() {

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -12,10 +12,13 @@ import java.io.IOException;
 
 public class PlaintextBackupExporter {
 
+  private final String FILENAME = "TextSecurePlaintextBackup.xml";
+
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
     verifyExternalStorageForPlaintextExport();
+    moveOldPlaintextExportToDirectory();
     exportPlaintext(context, masterSecret);
   }
 
@@ -26,15 +29,29 @@ public class PlaintextBackupExporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+    return getOldPlaintextExportDirectoryPath() + "TextSecure" + File.separator;
+  }
+
+  private static String getOldPlaintextExportDirectoryPath() {
+    File sdDirectory = Environment.getExternalStorageDirectory();
+    return sdDirectory.getAbsolutePath() + File.separator;
+  }
+
+  private static void moveOldPlaintextExportToDirectory(){
+    File oldBackup = new File(getOldPlaintextExportDirectoryPath() + FILENAME);
+
+    if (oldBackup.isFile()) {
+        File newBackup = new File(getPlaintextExportDirectoryPath() + FILENAME);
+        if (! newBackup.isFile())
+            oldBackup.renameTo(newBackup);
+    }
   }
 
   private static void exportPlaintext(Context context, MasterSecret masterSecret)
-      throws IOException
+    throws IOException
   {
     int count               = DatabaseFactory.getSmsDatabase(context).getMessageCount();
-    XmlBackup.Writer writer = new XmlBackup.Writer(getPlaintextExportDirectoryPath(), count);
-
+    XmlBackup.Writer writer = new XmlBackup.Writer(getPlaintextExportDirectoryPath()+ FILENAME, count);
 
     SmsMessageRecord record;
     EncryptingSmsDatabase.Reader reader = null;

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -30,7 +30,7 @@ public class PlaintextBackupExporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator;
+    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + "Backup" + File.separator;
   }
 
   private static String getOldPlaintextExportDirectoryPath() {
@@ -40,11 +40,15 @@ public class PlaintextBackupExporter {
 
   private static void moveOldPlaintextExportToDirectory(){
     File oldBackup = new File(getOldPlaintextExportDirectoryPath() + FILENAME);
+    File newBackup = new File(getPlaintextExportDirectoryPath() + FILENAME);
+    File newDirectory = new File(getPlaintextExportDirectoryPath());
+
+    if (! newDirectory.isDirectory())
+      newDirectory.mkdirs();
 
     if (oldBackup.isFile()) {
-        File newBackup = new File(getPlaintextExportDirectoryPath() + FILENAME);
-        if (! newBackup.isFile())
-            oldBackup.renameTo(newBackup);
+      if (! newBackup.isFile())
+        oldBackup.renameTo(newBackup);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -21,7 +21,8 @@ import java.util.Set;
 
 public class PlaintextBackupImporter {
 
-  private final static String FILENAME = "TextSecurePlaintextBackup.xml";
+  private static final String FILENAME = "TextSecurePlaintextBackup.xml";
+  private static final String FOLDERNAME = "TextSecure";
 
   public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
@@ -41,7 +42,7 @@ public class PlaintextBackupImporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return getOldPlaintextExportDirectoryPath() + "TextSecure" + File.separator;
+    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + "Backups" + File.separator;
   }
 
   private static String getOldPlaintextExportDirectoryPath() {

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -42,7 +42,7 @@ public class PlaintextBackupImporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + "Backups" + File.separator;
+    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + "Backup" + File.separator;
   }
 
   private static String getOldPlaintextExportDirectoryPath() {
@@ -52,9 +52,13 @@ public class PlaintextBackupImporter {
 
   private static void moveOldPlaintextExportToDirectory(){
     File oldBackup = new File(getOldPlaintextExportDirectoryPath() + FILENAME);
+    File newBackup = new File(getPlaintextExportDirectoryPath() + FILENAME);
+    File newDirectory = new File(getPlaintextExportDirectoryPath());
+
+    if (! newDirectory.isDirectory())
+        newDirectory.mkdirs();
 
     if (oldBackup.isFile()) {
-      File newBackup = new File(getPlaintextExportDirectoryPath() + FILENAME);
       if (! newBackup.isFile())
         oldBackup.renameTo(newBackup);
     }

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -23,6 +23,7 @@ public class PlaintextBackupImporter {
 
   private static final String FILENAME = "TextSecurePlaintextBackup.xml";
   private static final String FOLDERNAME = "TextSecure";
+  private static final String BACKUPFOLDERNAME = "Backup";
 
   public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
@@ -42,7 +43,7 @@ public class PlaintextBackupImporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + "Backup" + File.separator;
+    return getOldPlaintextExportDirectoryPath() + FOLDERNAME + File.separator + BACKUPFOLDERNAME + File.separator;
   }
 
   private static String getOldPlaintextExportDirectoryPath() {

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -21,7 +21,7 @@ import java.util.Set;
 
 public class PlaintextBackupImporter {
 
-  private final String FILENAME = "TextSecurePlaintextBackup.xml";
+  private final static String FILENAME = "TextSecurePlaintextBackup.xml";
 
   public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -21,23 +21,42 @@ import java.util.Set;
 
 public class PlaintextBackupImporter {
 
+  private final String FILENAME = "TextSecurePlaintextBackup.xml";
+
   public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
     Log.w("PlaintextBackupImporter", "Importing plaintext...");
     verifyExternalStorageForPlaintextImport();
+    moveOldPlaintextExportToDirectory();
     importPlaintext(context, masterSecret);
   }
 
   private static void verifyExternalStorageForPlaintextImport() throws NoExternalStorageException {
     if (!Environment.getExternalStorageDirectory().canRead() ||
-        !(new File(getPlaintextExportDirectoryPath()).exists()))
+        !(new File(getPlaintextExportDirectoryPath() + FILENAME).exists() ||
+          new File(getOldPlaintextExportDirectoryPath() + FILENAME).exists()))
       throw new NoExternalStorageException();
   }
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+    return getOldPlaintextExportDirectoryPath() + "TextSecure" + File.separator;
+  }
+
+  private static String getOldPlaintextExportDirectoryPath() {
+    File sdDirectory = Environment.getExternalStorageDirectory();
+    return sdDirectory.getAbsolutePath() + File.separator;
+  }
+
+  private static void moveOldPlaintextExportToDirectory(){
+    File oldBackup = new File(getOldPlaintextExportDirectoryPath() + FILENAME);
+
+    if (oldBackup.isFile()) {
+      File newBackup = new File(getPlaintextExportDirectoryPath() + FILENAME);
+      if (! newBackup.isFile())
+        oldBackup.renameTo(newBackup);
+    }
   }
 
   private static void importPlaintext(Context context, MasterSecret masterSecret)
@@ -49,7 +68,7 @@ public class PlaintextBackupImporter {
 
     try {
       ThreadDatabase threads         = DatabaseFactory.getThreadDatabase(context);
-      XmlBackup      backup          = new XmlBackup(getPlaintextExportDirectoryPath());
+      XmlBackup      backup          = new XmlBackup(getPlaintextExportDirectoryPath() + FILENAME);
       MasterCipher   masterCipher    = new MasterCipher(masterSecret);
       Set<Long>      modifiedThreads = new HashSet<Long>();
       XmlBackup.XmlBackupItem item;

--- a/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -163,24 +163,20 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     return Environment.getExternalStorageDirectory().getAbsoluteFile() + File.separator + FOLDERNAME  + File.separator;
   }
 
-  private String getMediaFolder() {
-    return getTextSecureFolder() + "Media" + File.separator;
-  }
-
   private String getImageFolder() {
-    return getMediaFolder() + "Images" + File.separator;
+    return getTextSecureFolder() + "Images" + File.separator;
   }
 
   private String getVideoFolder() {
-    return getMediaFolder() + "Video" + File.separator;
+    return getTextSecureFolder() + "Video" + File.separator;
   }
 
   private String getAudioFolder() {
-    return getMediaFolder() + "Audio" + File.separator;
+    return getTextSecureFolder() + "Audio" + File.separator;
   }
 
   private String getMiscFolder() {
-    return getMediaFolder() + "Misc" + File.separator;
+    return getTextSecureFolder() + "Misc" + File.separator;
   }
 
 }

--- a/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -30,6 +30,10 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
   private static final int FAILURE              = 1;
   private static final int WRITE_ACCESS_FAILURE = 2;
   private static final String FOLDERNAME = "TextSecure";
+  private static final String IMAGEFOLDERNAME = "Images";
+  private static final String AUDIOFOLDERNAME = "Audio";
+  private static final String MISCFOLDERNAME = "Misc";
+  private static final String VIDEOFOLDERNAME = "Video";
 
   private final WeakReference<Context> contextReference;
   private final WeakReference<MasterSecret> masterSecretReference;
@@ -164,19 +168,19 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
   }
 
   private String getImageFolder() {
-    return getTextSecureFolder() + "Images" + File.separator;
+    return getTextSecureFolder() + IMAGEFOLDERNAME + File.separator;
   }
 
   private String getVideoFolder() {
-    return getTextSecureFolder() + "Video" + File.separator;
+    return getTextSecureFolder() + VIDEOFOLDERNAME + File.separator;
   }
 
   private String getAudioFolder() {
-    return getTextSecureFolder() + "Audio" + File.separator;
+    return getTextSecureFolder() + AUDIOFOLDERNAME + File.separator;
   }
 
   private String getMiscFolder() {
-    return getTextSecureFolder() + "Misc" + File.separator;
+    return getTextSecureFolder() + MISCFOLDERNAME + File.separator;
   }
 
 }

--- a/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -29,6 +29,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
   private static final int SUCCESS              = 0;
   private static final int FAILURE              = 1;
   private static final int WRITE_ACCESS_FAILURE = 2;
+  private static final String FOLDERNAME = "TextSecure";
 
   private final WeakReference<Context> contextReference;
   private final WeakReference<MasterSecret> masterSecretReference;
@@ -101,17 +102,16 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
   }
 
   private File constructOutputFile(String contentType, long timestamp) throws IOException {
-    File sdCard = Environment.getExternalStorageDirectory();
     File outputDirectory;
 
     if (contentType.startsWith("video/")) {
-      outputDirectory = new File(sdCard.getAbsoluteFile() + File.separator + Environment.DIRECTORY_MOVIES);
+      outputDirectory = new File(getVideoFolder());
     } else if (contentType.startsWith("audio/")) {
-      outputDirectory = new File(sdCard.getAbsolutePath() + File.separator + Environment.DIRECTORY_MUSIC);
+      outputDirectory = new File(getAudioFolder());
     } else if (contentType.startsWith("image/")) {
-      outputDirectory = new File(sdCard.getAbsolutePath() + File.separator + Environment.DIRECTORY_PICTURES);
+      outputDirectory = new File(getImageFolder());
     } else {
-      outputDirectory = new File(sdCard.getAbsolutePath() + File.separator + Environment.DIRECTORY_DOWNLOADS);
+      outputDirectory = new File(getMiscFolder());
     }
 
     if (!outputDirectory.mkdirs()) Log.w(TAG, "mkdirs() returned false, attempting to continue");
@@ -158,5 +158,30 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     builder.setNegativeButton(R.string.no, null);
     builder.show();
   }
+
+  private static String getTextSecureFolder() {
+    return Environment.getExternalStorageDirectory().getAbsoluteFile() + File.separator + FOLDERNAME  + File.separator;
+  }
+
+  private String getMediaFolder() {
+    return getTextSecureFolder() + "Media" + File.separator;
+  }
+
+  private String getImageFolder() {
+    return getMediaFolder() + "Images" + File.separator;
+  }
+
+  private String getVideoFolder() {
+    return getMediaFolder() + "Video" + File.separator;
+  }
+
+  private String getAudioFolder() {
+    return getMediaFolder() + "Audio" + File.separator;
+  }
+
+  private String getMiscFolder() {
+    return getMediaFolder() + "Misc" + File.separator;
+  }
+
 }
 


### PR DESCRIPTION
* first ever pull-request
* fixes Export backups to a sub-folder #2791 & #1901  (dublicates)

This patch checks everytime the export or import is used for old file and puts it into an 'TextSecure' folder.
I was not sure if this is a good way to go, or it would have been better to put a boolean into the SharedPreferences. But since I presumed ex- and imports are not too often performed I guessed it's ok.
(Only implemented for PlainText Backups - since encrypted ones are not enabled anyway.)

Changes required?