### PR TITLE
fix: issue 3027 (incomming bubble end at screen right border)

### DIFF
--- a/res/layout/conversation_bubble_incoming.xml
+++ b/res/layout/conversation_bubble_incoming.xml
@@ -23,7 +23,6 @@
                 android:id="@+id/image_view"
                 android:layout_width="wrap_content"
                 android:layout_height="@dimen/media_bubble_height"
-                android:layout_marginRight="@dimen/message_bubble_end_padding"
                 android:visibility="gone"
                 android:layout_gravity="center"
                 android:scaleType="centerInside"

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -2,7 +2,7 @@
 <org.thoughtcrime.securesms.ConversationItem android:id="@+id/conversation_item"
                                              android:layout_width="fill_parent"
                                              android:layout_height="wrap_content"
-                                             android:paddingRight="10dip"
+
                                              android:orientation="vertical"
                                              android:background="?conversation_item_background"
                                              xmlns:android="http://schemas.android.com/apk/res/android"
@@ -42,6 +42,7 @@
                 android:id="@+id/bubble"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginRight="@dimen/message_bubble_end_padding"
                 android:layout_marginLeft="29dp" />
 
         <LinearLayout android:id="@+id/indicators_parent"

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -130,11 +130,13 @@ public class ConversationItem extends LinearLayout {
     this.bubbleContainer     = (BubbleContainer)findViewById(R.id.bubble);
     this.mediaThumbnail      = (ThumbnailView)findViewById(R.id.image_view);
 
-    setOnClickListener(clickListener);
-    if (mmsDownloadButton != null) mmsDownloadButton.setOnClickListener(mmsDownloadClickListener);
-    if (mediaThumbnail != null) {
-      mediaThumbnail.setThumbnailClickListener(new ThumbnailClickListener());
-      mediaThumbnail.setOnLongClickListener(new MultiSelectLongClickListener());
+    if (this.isInEditMode()) {
+      setOnClickListener(clickListener);
+      if (mmsDownloadButton != null) mmsDownloadButton.setOnClickListener(mmsDownloadClickListener);
+      if (mediaThumbnail != null) {
+        mediaThumbnail.setThumbnailClickListener(new ThumbnailClickListener());
+        mediaThumbnail.setOnLongClickListener(new MultiSelectLongClickListener());
+      }
     }
   }
 


### PR DESCRIPTION
I just added a margin to the incoming bubble on its right side (50dp) . That may not be the right size for your grid(?) but I left it at that as it seems to accord with your intent  (assumed from the conversation _bubble_incomming.xml file) and just eye-ing the screen seems to balance the left hand image.
I also added an edit mode check to the ConversationItem view class so that it will be viewable in the designer. Being able to view layouts in the designer helps me to debug  faster -- so I left that check code in. You may feel the same way; otherwise just delete the check code.