### PR TITLE
Change 'Title' to 'Group name' in group update message

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -576,7 +576,7 @@
     <!-- GroupUtil -->
     <string name="GroupUtil_joined_the_group">%1$s joined the group.</string>
     <string name="GroupUtil_group_updated">Group updated.</string>
-    <string name="GroupUtil_title_is_now">Title is now \'%1$s\'.</string>
+    <string name="GroupUtil_group_name_is_now">Group name is now \'%1$s\'.</string>
 
     <!-- prompt_passphrase_activity -->
     <string name="prompt_passphrase_activity__unlock">Unlock</string>

--- a/src/org/thoughtcrime/securesms/util/GroupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/GroupUtil.java
@@ -48,7 +48,7 @@ public class GroupUtil {
 
       if (title != null && !title.trim().isEmpty()) {
         if (description.length() > 0) description.append(" ");
-        description.append(context.getString(R.string.GroupUtil_title_is_now, title));
+        description.append(context.getString(R.string.GroupUtil_group_name_is_now, title));
       }
 
       if (description.length() > 0) {


### PR DESCRIPTION
Feels more descriptive to me. 
`Title` could also be something else - at least for a non native speaker...