### PR TITLE
Attach video npe

### DIFF
--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -24,12 +24,12 @@ import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.MediaUtil;
 
 import java.net.URLDecoder;
 
@@ -156,8 +156,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     String type = getContentResolver().getType(uri);
 
     if (type == null) {
-      String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
-      type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
+      type = MediaUtil.getMimeTyp(uri);
     }
 
     return type;

--- a/src/org/thoughtcrime/securesms/mms/AudioSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/AudioSlide.java
@@ -23,8 +23,10 @@ import android.net.Uri;
 import android.provider.MediaStore.Audio;
 import android.support.annotation.DrawableRes;
 
+import android.util.Log;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.ResUtil;
 
 import java.io.IOException;
@@ -66,10 +68,18 @@ public class AudioSlide extends Slide {
     try {
       cursor = context.getContentResolver().query(uri, new String[]{Audio.Media.MIME_TYPE}, null, null, null);
 
-      if (cursor != null && cursor.moveToFirst())
+      if (cursor != null && cursor.moveToFirst()) {
         part.setContentType(cursor.getString(0).getBytes());
-      else
-        throw new IOException("Unable to query content type.");
+      } else {
+         // query above does not give result for media set via ShareActivity (external share intents with files)
+         final String contentType = MediaUtil.getMimeTyp(uri);
+         if (contentType != null) {
+           Log.i("AudioSlide", "Setting mime type: " + contentType);
+           part.setContentType(contentType.getBytes());
+         }
+         else
+           throw new IOException("Unable to query content type.");
+      }
     } finally {
       if (cursor != null)
         cursor.close();

--- a/src/org/thoughtcrime/securesms/mms/VideoSlide.java
+++ b/src/org/thoughtcrime/securesms/mms/VideoSlide.java
@@ -27,6 +27,7 @@ import android.util.Log;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.ResUtil;
 
 import java.io.IOException;
@@ -64,12 +65,26 @@ public class VideoSlide extends Slide {
     PduPart         part     = new PduPart();
     ContentResolver resolver = context.getContentResolver();
     Cursor          cursor   = null;
+    String          contentType = null;
 
     try {
       cursor = resolver.query(uri, new String[] {MediaStore.Video.Media.MIME_TYPE}, null, null, null);
       if (cursor != null && cursor.moveToFirst()) {
-        Log.w("VideoSlide", "Setting mime type: " + cursor.getString(0));
-        part.setContentType(cursor.getString(0).getBytes());
+         contentType = cursor.getString(0);
+         Log.i("VideoSlide", "Setting mime type: " + contentType);
+         part.setContentType(contentType.getBytes());
+       }
+
+       // fallback:
+       // query above does not give result for media set via ShareActivity (external share intents with files)
+       if (contentType == null) {
+         contentType = MediaUtil.getMimeTyp(uri);
+         if (contentType != null) {
+           Log.i("VideoSlide", "Setting mime type: " + contentType);
+           part.setContentType(contentType.getBytes());
+         }
+         else
+           throw new IOException("Unable to query content type.");
       }
     } finally {
       if (cursor != null)

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.graphics.Bitmap;
 import android.net.Uri;
 import android.util.Log;
+import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -80,6 +81,11 @@ public class MediaUtil {
 
   public static boolean isVideo(PduPart part) {
     return ContentType.isVideoType(Util.toIsoString(part.getContentType()));
+  }
+
+  public static String getMimeTyp(Uri uri) {
+    final String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
+    return MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
   }
 
   public static class ThumbnailData {


### PR DESCRIPTION
fix for issue ##3453

Sending media files (audio / video) via Intent to Textsecure, it does check for media type in ShareActivity but does not set the media type correctly when creating the Slides from the URI.

TextSecure only checks the content resolver but fails on files not indexed there.
This patch adds fallback checks to get the mime type in this cases too to prevent crashes later on.