### PR TITLE
fix: bug #3562 messages received while in muted thread not marked as read

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -131,17 +131,27 @@ public class MessageNotifier {
                                            .getRecipientsForThreadId(threadId);
 
     if (!TextSecurePreferences.isNotificationsEnabled(context) ||
-        (recipients != null && recipients.isMuted()))
+    (recipients != null && recipients.isMuted()))
     {
-      return;
+      if (visibleThread == threadId) {
+        Log.w(TAG, "Notifications disabled, visibleThread == threadId.");
+        ThreadDatabase threads = DatabaseFactory.getThreadDatabase(context);
+        threads.setRead(threadId);
+        return;
+      }
+      else {
+        Log.w(TAG, "Notifications disabled, visibleThread != threadId.");
+        return;
+      }
     }
 
-
     if (visibleThread == threadId) {
+      Log.w(TAG, "Notifications enabled, visibleThread == threadId");
       ThreadDatabase threads = DatabaseFactory.getThreadDatabase(context);
       threads.setRead(threadId);
       sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
     } else {
+      Log.w(TAG, "Notifications enabled, visibleThread != threadId");
       updateNotification(context, masterSecret, true, 0);
     }
   }

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -153,6 +153,7 @@ public class MessageNotifier {
     } else {
       Log.w(TAG, "Notifications enabled, visibleThread != threadId");
       updateNotification(context, masterSecret, true, 0);
+      Log.w(TAG, "updateNotification() has returned.");
     }
   }
 

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -134,26 +134,21 @@ public class MessageNotifier {
     (recipients != null && recipients.isMuted()))
     {
       if (visibleThread == threadId) {
-        Log.w(TAG, "Notifications disabled, visibleThread == threadId.");
         ThreadDatabase threads = DatabaseFactory.getThreadDatabase(context);
         threads.setRead(threadId);
         return;
       }
       else {
-        Log.w(TAG, "Notifications disabled, visibleThread != threadId.");
         return;
       }
     }
 
     if (visibleThread == threadId) {
-      Log.w(TAG, "Notifications enabled, visibleThread == threadId");
       ThreadDatabase threads = DatabaseFactory.getThreadDatabase(context);
       threads.setRead(threadId);
       sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
     } else {
-      Log.w(TAG, "Notifications enabled, visibleThread != threadId");
       updateNotification(context, masterSecret, true, 0);
-      Log.w(TAG, "updateNotification() has returned.");
     }
   }
 
@@ -294,7 +289,7 @@ public class MessageNotifier {
     builder.setContentText(context.getString(R.string.MessageNotifier_most_recent_from_s,
                                              notifications.get(0).getIndividualRecipientName()));
     builder.setContentIntent(PendingIntent.getActivity(context, 0, new Intent(context, ConversationListActivity.class), 0));
-    
+
     builder.setContentInfo(String.valueOf(notificationState.getMessageCount()));
     builder.setNumber(notificationState.getMessageCount());
     builder.setCategory(NotificationCompat.CATEGORY_MESSAGE);

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -131,14 +131,13 @@ public class MessageNotifier {
                                            .getRecipientsForThreadId(threadId);
 
     if (!TextSecurePreferences.isNotificationsEnabled(context) ||
-    (recipients != null && recipients.isMuted()))
+        (recipients != null && recipients.isMuted()))
     {
       if (visibleThread == threadId) {
         ThreadDatabase threads = DatabaseFactory.getThreadDatabase(context);
         threads.setRead(threadId);
         return;
-      }
-      else {
+      } else {
         return;
       }
     }


### PR DESCRIPTION
Changed the logic in updateNotification() method of MessageNotifier. I tested this in the emulator going through all the possible logical scenarios in the method; everything seems to work fine.

fixes #3562 