### PR TITLE
Improve generated contact photos with emoji names

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/avatars/GeneratedContactPhoto.java
+++ b/src/org/thoughtcrime/securesms/contacts/avatars/GeneratedContactPhoto.java
@@ -33,6 +33,16 @@ public class GeneratedContactPhoto implements ContactPhoto {
                        .height(targetSize)
                        .textColor(inverted ? color : Color.WHITE)
                        .endConfig()
-                       .buildRound(String.valueOf(name.charAt(0)), inverted ? Color.WHITE : color);
+                       .buildRound(getCharacter(name), inverted ? Color.WHITE : color);
+  }
+
+  private String getCharacter(String name) {
+    String cleanedName = name.replaceAll("[^\\p{L}\\p{Nd}]+", "");
+
+    if (cleanedName.isEmpty()) {
+      return "#";
+    } else {
+      return String.valueOf(cleanedName.charAt(0));
+    }
   }
 }


### PR DESCRIPTION
*This is a re-submission of pull #3617 as this code should be more readable.*

----

### Issue
This commit fixes Issue #3604.

Contact names which begin with emoji characters cause their generated photo to consist of the "question-mark-in-a-box" UTF-8 character.

This commit fixes the issue by using a new function to strip out any non-language (not just English) characters from their contact name, and instead use the first character of the returned string as their contact photo initial.

----

#### Basic Documentation
##### `String getCharacter(String name)`

`(String) name` is the name of the contact that requires their photo to be generated.

This function will return the first character of their name that should be suitable for use in the generated contact photo. Any whitespace, emojis, or non-language characters should be removed from their name and leave only characters suitable for display in their contact photo.
