### PR TITLE
Tap to focus/adjust metering in direct capture

### DIFF
--- a/res/animator/quick_camera_focus_circle_expand.xml
+++ b/res/animator/quick_camera_focus_circle_expand.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animator xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          tools:targetApi="11"
+          android:valueType="floatType"
+          android:valueFrom="10dp"
+          android:valueTo="50dp"
+          android:duration="200"
+          android:interpolator="@android:interpolator/accelerate_decelerate"/>

--- a/res/animator/quick_camera_focus_circle_fade_out.xml
+++ b/res/animator/quick_camera_focus_circle_fade_out.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<animator xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
+          tools:targetApi="11"
+          android:valueType="intType"
+          android:valueFrom="255"
+          android:valueTo="0"
+          android:duration="200"
+          android:startOffset="200"
+          android:interpolator="@android:interpolator/linear"/>


### PR DESCRIPTION
Feature: Tap to focus/adjust exposure in the direct capture view with expanding circle animation to indicate focus area. 
Doesn't do anything < ICS, Android 4.0
As with all camera stuff, probably needs to be tested on a whole bunch of devices.
Re: Issue #3575 
![tap_to_focus](https://cloud.githubusercontent.com/assets/1096636/8842066/8f6ce8cc-30c3-11e5-97f9-cc7f0d03d04e.gif) ![tap_to_focus2](https://cloud.githubusercontent.com/assets/1096636/8842068/9633ee44-30c3-11e5-8800-b4dc44daeb16.gif)

//FREEBIE