### PR TITLE
Make long pressing the attach button open the transport popup

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -48,6 +48,8 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnFocusChangeListener;
 import android.view.View.OnKeyListener;
+import android.view.View.OnLongClickListener;
+import android.view.ViewStub;
 import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.ImageButton;
@@ -886,6 +888,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     composeText.setOnEditorActionListener(sendButtonListener);
     attachButton.setOnClickListener(new AttachButtonListener());
+    attachButton.setOnLongClickListener(new AttachButtonLongClickListener());
     sendButton.setOnClickListener(sendButtonListener);
     sendButton.setEnabled(true);
     sendButton.addOnTransportChangedListener(new OnTransportChangedListener() {
@@ -1391,6 +1394,13 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     @Override
     public void onClick(View v) {
       handleAddAttachment();
+    }
+  }
+
+  private class AttachButtonLongClickListener implements View.OnLongClickListener {
+    @Override
+    public boolean onLongClick(View v) {
+      return sendButton.showPopupIfNeeded();
     }
   }
 

--- a/src/org/thoughtcrime/securesms/components/SendButton.java
+++ b/src/org/thoughtcrime/securesms/components/SendButton.java
@@ -93,6 +93,13 @@ public class SendButton extends ImageButton
 
   @Override
   public boolean onLongClick(View v) {
+    return showPopupIfNeeded();
+  }
+
+  /**
+   * @return true iff the popup was opened
+   */
+  public boolean showPopupIfNeeded(){
     if (transportOptions.getEnabledTransports().size() > 1) {
       getTransportOptionsPopup().display(transportOptions.getEnabledTransports());
       return true;


### PR DESCRIPTION
It can be quite frustrating (and confusing) that you can only change transport with long pressing after adding an attachment / writing text. This adds a listener to the attach button to allow for long pressing that too.