### PR TITLE
activated state of switches match textsecure color dark

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -96,7 +96,7 @@
         <item name="conversation_editor_background">#22000000</item>
         <item name="conversation_editor_text_color">#ff111111</item>
         <item name="conversation_transport_sms_indicator">@drawable/ic_send_sms_insecure</item>
-        <item name="conversation_transport_push_indicator">@drawable/ic_send_push</item>android
+        <item name="conversation_transport_push_indicator">@drawable/ic_send_push</item>
         <item name="conversation_transport_popup_background">@color/white</item>
         <item name="conversation_emoji_toggle">@drawable/ic_mood_grey600_24dp</item>
         <item name="conversation_keyboard_toggle">@drawable/ic_keyboard_grey600_24dp</item>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -96,7 +96,7 @@
         <item name="conversation_editor_background">#22000000</item>
         <item name="conversation_editor_text_color">#ff111111</item>
         <item name="conversation_transport_sms_indicator">@drawable/ic_send_sms_insecure</item>
-        <item name="conversation_transport_push_indicator">@drawable/ic_send_push</item>
+        <item name="conversation_transport_push_indicator">@drawable/ic_send_push</item>android
         <item name="conversation_transport_popup_background">@color/white</item>
         <item name="conversation_emoji_toggle">@drawable/ic_mood_grey600_24dp</item>
         <item name="conversation_keyboard_toggle">@drawable/ic_keyboard_grey600_24dp</item>
@@ -188,6 +188,7 @@
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
+        <item name="colorControlActivated">@color/textsecure_primary_dark"</item>
         <item name="android:windowBackground">@color/black</item>
         <item name="md_dark_theme">true</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_dark</item>


### PR DESCRIPTION
fixes #3881

I set colorControlActivated to @color/textsecure_primary_dark

should the same be done with the light theme - setting the activated state to the textsecure color?