### PR TITLE
Add date indicator above messages

### DIFF
--- a/res/drawable/conversation_item_date_separator_background.xml
+++ b/res/drawable/conversation_item_date_separator_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gray20"/>
+    <corners android:radius="4dp"/>
+</shape>

--- a/res/drawable/conversation_item_date_separator_background_dark.xml
+++ b/res/drawable/conversation_item_date_separator_background_dark.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/gray70"/>
+    <corners android:radius="4dp"/>
+</shape>

--- a/res/layout/conversation_item_date_separator.xml
+++ b/res/layout/conversation_item_date_separator.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools">
+
+    <TextView android:id="@+id/conversation_item_date_separator"
+              android:layout_width="wrap_content"
+              android:layout_height="wrap_content"
+              android:layout_centerHorizontal="true"
+              android:layout_marginTop="6dp"
+              android:background="?attr/conversation_item_date_separator_background"
+              android:fontFamily="sans-serif-light"
+              android:padding="6sp"
+              android:textAppearance="?android:attr/textAppearanceSmall"
+              android:textColor="?attr/conversation_item_date_separator_text_color"
+              android:textSize="@dimen/conversation_item_date_text_size"
+              tools:text="31 January 2013"/>
+
+</RelativeLayout>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -62,6 +62,8 @@
     <attr name="conversation_item_received_text_secondary_color" format="reference|color"/>
     <attr name="conversation_item_sent_text_indicator_tab_color" format="reference|color"/>
     <attr name="conversation_item_sent_indicator_text_background" format="reference" />
+    <attr name="conversation_item_date_separator_text_color" format="reference|color"/>
+    <attr name="conversation_item_date_separator_background" format="reference"/>
 
     <attr name="dialog_info_icon" format="reference" />
     <attr name="dialog_alert_icon" format="reference" />

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -130,6 +130,8 @@
         <item name="conversation_item_sent_text_indicator_tab_color">#99000000</item>
         <item name="conversation_item_received_text_primary_color">@color/white</item>
         <item name="conversation_item_received_text_secondary_color">#BFffffff</item>
+        <item name="conversation_item_date_separator_text_color">#99000000</item>
+        <item name="conversation_item_date_separator_background">@drawable/conversation_item_date_separator_background</item>
 
         <item name="quick_camera_icon">@drawable/quick_camera_light</item>
 
@@ -210,6 +212,8 @@
         <item name="conversation_item_received_text_primary_color">@color/white</item>
         <item name="conversation_item_received_text_secondary_color">#BFffffff</item>
         <item name="conversation_item_sent_indicator_text_background">@drawable/conversation_item_sent_indicator_text_shape_dark</item>
+        <item name="conversation_item_date_separator_text_color">#ffffffff</item>
+        <item name="conversation_item_date_separator_background">@drawable/conversation_item_date_separator_background_dark</item>
 
         <item name="dialog_info_icon">@drawable/ic_info_outline_dark</item>
         <item name="dialog_alert_icon">@drawable/ic_warning_dark</item>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -134,8 +134,10 @@ public class ConversationFragment extends Fragment
 
   private void initializeListAdapter() {
     if (this.recipients != null && this.threadId != -1) {
-      list.setAdapter(new ConversationAdapter(getActivity(), masterSecret, locale, selectionClickListener, null,
-                                              (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient()));
+      ConversationAdapter adapter = new ConversationAdapter(getActivity(), masterSecret, locale, selectionClickListener, null,
+                                                            (!this.recipients.isSingleRecipient()) || this.recipients.isGroupRecipient());
+      list.setAdapter(adapter);
+      list.addItemDecoration(new DateSeparatorItemDecoration(adapter, list, locale));
       getLoaderManager().restartLoader(0, null, this);
     }
   }

--- a/src/org/thoughtcrime/securesms/DateSeparatorItemDecoration.java
+++ b/src/org/thoughtcrime/securesms/DateSeparatorItemDecoration.java
@@ -1,0 +1,185 @@
+package org.thoughtcrime.securesms;
+
+import android.graphics.Canvas;
+import android.graphics.Rect;
+import android.support.v4.util.LongSparseArray;
+import android.support.v4.util.SparseArrayCompat;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import org.thoughtcrime.securesms.util.DateUtils;
+
+import java.util.Locale;
+
+public class DateSeparatorItemDecoration extends RecyclerView.ItemDecoration {
+
+  private final ConversationAdapter adapter;
+  private final LayoutInflater      inflater;
+  private final Locale              locale;
+
+  private final SparseArrayCompat<SeparatorViewHolder> separators         = new SparseArrayCompat<>();
+  private final LongSparseArray<SeparatorViewHolder>   recycledSeparators = new LongSparseArray<>();
+
+  private Boolean isReverseLayout = null;
+
+  public DateSeparatorItemDecoration(ConversationAdapter adapter, RecyclerView parent, Locale locale) {
+    this.adapter = adapter;
+    inflater = LayoutInflater.from(adapter.getContext());
+    this.locale = locale;
+
+    parent.setRecyclerListener(new RecyclerView.RecyclerListener() {
+      @Override
+      public void onViewRecycled(RecyclerView.ViewHolder holder) {
+        int                 hashCode   = holder.itemView.hashCode();
+        SeparatorViewHolder viewHolder = separators.get(hashCode);
+        separators.delete(hashCode);
+        if (viewHolder != null) recycledSeparators.put(viewHolder.datestamp, viewHolder);
+      }
+    });
+  }
+
+  @Override
+  public void getItemOffsets(Rect outRect, View view, RecyclerView parent, RecyclerView.State state) {
+    super.getItemOffsets(outRect, view, parent, state);
+
+    int position = parent.getChildPosition(view);
+    if (needsSeparator(parent, position)) {
+      View separator = getSeparator(parent, view, position);
+      Rect separatorMargins = getMargins(separator);
+      outRect.top = separator.getHeight() + separatorMargins.top + separatorMargins.bottom;
+    }
+  }
+
+  @Override
+  public void onDraw(Canvas c, RecyclerView parent, RecyclerView.State state) {
+    if (parent.getChildCount() <= 0 || adapter.getItemCount() <= 0) {
+      return;
+    }
+
+    for (int i = 0; i < parent.getChildCount(); i++) {
+      View itemView = parent.getChildAt(i);
+      int position = parent.getChildPosition(itemView);
+      if (position == RecyclerView.NO_POSITION) {
+        continue;
+      }
+
+      if (needsSeparator(parent, position)) {
+        View separator = getSeparator(parent, itemView, position);
+        Rect margins = getMargins(separator);
+        int translationX = itemView.getLeft() + margins.left;
+        int translationY = itemView.getTop() - separator.getHeight() - margins.bottom;
+        Rect offset = new Rect(translationX, translationY, translationX + separator.getWidth(),
+                              translationY + separator.getHeight());
+
+        c.save();
+
+        if (parent.getLayoutManager().getClipToPadding()) {
+          Rect clipRect = new Rect(parent.getPaddingLeft(),
+                                  parent.getPaddingTop(),
+                                  parent.getWidth() - parent.getPaddingRight() - margins.right,
+                                  parent.getHeight() - parent.getPaddingBottom());
+          c.clipRect(clipRect);
+        }
+
+        c.translate(offset.left, offset.top);
+
+        separator.draw(c);
+        c.restore();
+      }
+    }
+  }
+
+  private boolean needsSeparator(RecyclerView parent, int position) {
+    int prevPos           = position + (getReverseLayout(parent) ? 1 : -1);
+    int firstItemPosition = getReverseLayout(parent) ? adapter.getItemCount() - 1 : 0;
+    return position == firstItemPosition || adapter.getDatestamp(position) != adapter.getDatestamp(prevPos);
+  }
+
+  private View getSeparator(RecyclerView parent, View childView, int position) {
+    SeparatorViewHolder separator = separators.get(childView.hashCode());
+
+    if (separator == null) {
+      long datestamp = adapter.getDatestamp(position);
+      separator = recycledSeparators.get(datestamp);
+      if (separator == null) {
+        if (recycledSeparators.size() > 0) {
+          separator = recycledSeparators.valueAt(0);
+          recycledSeparators.removeAt(0);
+        } else {
+          separator = new SeparatorViewHolder(inflater.inflate(R.layout.conversation_item_date_separator, parent, false));
+        }
+
+        separator.setDatestamp(datestamp);
+
+        View separatorView = separator.itemView;
+        if (separatorView.getLayoutParams() == null) {
+          separatorView.setLayoutParams(new ViewGroup.LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT));
+        }
+
+        int widthSpec = View.MeasureSpec.makeMeasureSpec(parent.getWidth(), View.MeasureSpec.EXACTLY);
+        int heightSpec = View.MeasureSpec.makeMeasureSpec(parent.getHeight(), View.MeasureSpec.UNSPECIFIED);
+        int childWidth = ViewGroup.getChildMeasureSpec(widthSpec,
+                                                      parent.getPaddingLeft() + parent.getPaddingRight(),
+                                                      separatorView.getLayoutParams().width);
+        int childHeight = ViewGroup.getChildMeasureSpec(heightSpec,
+                                                       parent.getPaddingTop() + parent.getPaddingBottom(),
+                                                       separatorView.getLayoutParams().height);
+        separatorView.measure(childWidth, childHeight);
+        separatorView.layout(0, 0, separatorView.getMeasuredWidth(), separatorView.getMeasuredHeight());
+      } else {
+        recycledSeparators.remove(datestamp);
+      }
+
+      separators.put(childView.hashCode(), separator);
+    }
+
+    return separator.itemView;
+  }
+
+  private boolean getReverseLayout(RecyclerView recyclerView) {
+    if (isReverseLayout == null) {
+      RecyclerView.LayoutManager lm = recyclerView.getLayoutManager();
+      if (lm instanceof LinearLayoutManager) {
+        isReverseLayout = ((LinearLayoutManager) lm).getReverseLayout();
+      } else {
+        throw new IllegalStateException("The LayoutManager " + lm + " is not " + LinearLayoutManager.class.getSimpleName());
+      }
+    }
+    return isReverseLayout;
+  }
+
+  private Rect getMargins(View view) {
+    ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
+
+    if (layoutParams instanceof ViewGroup.MarginLayoutParams) {
+      ViewGroup.MarginLayoutParams marginLayoutParams = (ViewGroup.MarginLayoutParams) layoutParams;
+      return new Rect(marginLayoutParams.leftMargin,
+                     marginLayoutParams.topMargin,
+                     marginLayoutParams.rightMargin,
+                     marginLayoutParams.bottomMargin);
+    } else {
+      return new Rect();
+    }
+  }
+
+
+  private class SeparatorViewHolder extends RecyclerView.ViewHolder {
+    final TextView text;
+    long datestamp;
+
+    public SeparatorViewHolder(View itemView) {
+      super(itemView);
+      text = (TextView) itemView.findViewById(R.id.conversation_item_date_separator);
+    }
+
+    public void setDatestamp(long datestamp) {
+      this.datestamp = datestamp;
+      text.setText(DateUtils.getDateSeparatorString(locale, datestamp));
+    }
+  }
+
+}

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -31,6 +31,8 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.GroupUtil;
 
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 
 /**
@@ -57,6 +59,7 @@ public abstract class MessageRecord extends DisplayRecord {
   private final int                       receiptCount;
   private final List<IdentityKeyMismatch> mismatches;
   private final List<NetworkFailure>      networkFailures;
+  private final long                      datestamp;
 
   MessageRecord(Context context, long id, Body body, Recipients recipients,
                 Recipient individualRecipient, int recipientDeviceId,
@@ -73,6 +76,15 @@ public abstract class MessageRecord extends DisplayRecord {
     this.receiptCount        = receiptCount;
     this.mismatches          = mismatches;
     this.networkFailures     = networkFailures;
+
+    Calendar cal = GregorianCalendar.getInstance();
+    if (isPush()) cal.setTimeInMillis(dateSent);
+    else          cal.setTimeInMillis(dateReceived);
+    cal.set(Calendar.HOUR_OF_DAY, 0);
+    cal.set(Calendar.MINUTE, 0);
+    cal.set(Calendar.SECOND, 0);
+    cal.set(Calendar.MILLISECOND, 0);
+    this.datestamp = cal.getTimeInMillis();
   }
 
   public abstract boolean isMms();
@@ -221,6 +233,10 @@ public abstract class MessageRecord extends DisplayRecord {
 
   public int hashCode() {
     return (int)getId();
+  }
+
+  public long getDatestamp() {
+    return datestamp;
   }
 
 }

--- a/src/org/thoughtcrime/securesms/util/DateUtils.java
+++ b/src/org/thoughtcrime/securesms/util/DateUtils.java
@@ -24,13 +24,28 @@ import java.util.Locale;
 
 import org.thoughtcrime.securesms.R;
 
+import java.util.Calendar;
 import java.util.Date;
+import java.util.GregorianCalendar;
 import java.util.concurrent.TimeUnit;
 
 /**
  * Utility methods to help display dates in a nice, easily readable way.
  */
 public class DateUtils extends android.text.format.DateUtils {
+
+  private static final long JANUARY_FIRST_MILLIS;
+
+  static {
+    Calendar c = GregorianCalendar.getInstance();
+    c.set(Calendar.MONTH, Calendar.JANUARY);
+    c.set(Calendar.DAY_OF_MONTH, 1);
+    c.set(Calendar.HOUR_OF_DAY, 0);
+    c.set(Calendar.MINUTE, 0);
+    c.set(Calendar.SECOND, 0);
+    c.set(Calendar.MILLISECOND, 0);
+    JANUARY_FIRST_MILLIS = c.getTimeInMillis();
+  }
 
   private static boolean isWithin(final long millis, final long span, final TimeUnit unit) {
     return System.currentTimeMillis() - millis <= unit.toMillis(span);
@@ -92,6 +107,14 @@ public class DateUtils extends android.text.format.DateUtils {
     }
 
     return new SimpleDateFormat(dateFormatPattern, locale);
+  }
+
+  public static String getDateSeparatorString(final Locale l, final long timestamp) {
+    String format;
+    if (timestamp < JANUARY_FIRST_MILLIS) format = "MMM d, yyyy";
+    else                                  format = "MMM d";
+
+    return getFormattedDateTime(timestamp, format, l);
   }
 
 }


### PR DESCRIPTION
This adds the date between two messages when the first message was sent/received at minimum one day before the second message.

The date is translated with respect to the language set in TS but also suffers from #3102.
The year is only displayed when the message was sent/received in a year smaller than the current year.

Screenshots with light and dark theme:
![date-sep-light](https://cloud.githubusercontent.com/assets/9959940/9197255/1897ade8-4033-11e5-9e3e-2fe8e5147f43.png)
![date-sep-dark](https://cloud.githubusercontent.com/assets/9959940/9197254/18734bba-4033-11e5-963c-66961f7b4e92.png)