### PR TITLE
Runtime permissions and Marshmallow compat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.0'
         classpath files('libs/gradle-witness.jar')
     }
 }
@@ -42,7 +42,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-base:6.5.87'
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile 'org.w3c:smil:1.0.0'
-    compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
+    compile 'org.apache.httpcomponents:httpclient-android:4.3.5.1'
     compile 'com.github.chrisbanes.photoview:library:1.2.3'
     compile 'com.github.bumptech.glide:glide:3.6.1'
     compile 'com.makeramen:roundedimageview:2.1.0'
@@ -56,8 +56,8 @@ dependencies {
 
     compile 'pl.tajchert:waitingdots:0.1.0'
     compile 'com.soundcloud.android:android-crop:0.9.10@aar'
-    compile 'com.android.support:appcompat-v7:22.1.1'
-    compile 'com.android.support:recyclerview-v7:21.0.3'
+    compile 'com.android.support:appcompat-v7:23.0.0'
+    compile 'com.android.support:recyclerview-v7:23.0.0'
     compile 'com.melnykov:floatingactionbutton:1.1.0'
     compile 'com.google.zxing:android-integration:3.1.0'
     compile ('com.android.support:support-v4-preferencefragment:1.0.0@aar'){
@@ -106,7 +106,7 @@ dependencyVerification {
             'com.google.android.gms:play-services-base:832cb6b3130e871db6a412c4ab585656dbcc5e7948101f190186757785703f75',
             'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
             'org.w3c:smil:085dc40f2bb249651578bfa07499fd08b16ad0886dbe2c4078586a408da62f9b',
-            'org.apache.httpcomponents:httpclient-android:6f56466a9bd0d42934b90bfbfe9977a8b654c058bf44a12bdc2877c4e1f033f1',
+            'org.apache.httpcomponents:httpclient-android:6c269d2d32ac35834de1713685d4da8bed520b648d5b6a9b7e28aebddd2782ba',
             'com.github.chrisbanes.photoview:library:8b5344e206f125e7ba9d684008f36c4992d03853c57e5814125f88496126e3cc',
             'com.github.bumptech.glide:glide:4718ac4c57ebabe56e673dc3265950b9dbf940d1c43c0adc363e8b95c0abdf75',
             'com.makeramen:roundedimageview:1f5a1865796b308c6cdd114acc6e78408b110f0a62fc63553278fbeacd489cd1',
@@ -115,8 +115,8 @@ dependencyVerification {
             'com.afollestad:material-dialogs:c17205f0d300baa307599c428a5473a6659684c94a5f68ae3c2b84b5e4741172',
             'pl.tajchert:waitingdots:2835d49e0787dbcb606c5a60021ced66578503b1e9fddcd7a5ef0cd5f095ba2c',
             'com.soundcloud.android:android-crop:ffd4b973cf6e97f7d64118a0dc088df50e9066fd5634fe6911dd0c0c5d346177',
-            'com.android.support:appcompat-v7:9a2355537c2f01cf0b95523605c18606b8d824017e6e94a05c77b0cfc8f21c96',
-            'com.android.support:recyclerview-v7:e525ad3f33c84bb12b73d2dc975b55364a53f0f2d0697e043efba59ba73e22d2',
+            'com.android.support:appcompat-v7:77be380b5dea998ffba28fdf83224b8bdf9525667f00da81bf38ea33f5fbf480',
+            'com.android.support:recyclerview-v7:ad1fcf4fd95e375fcf8f2431b83196cb9b502ef5967822f661735f3e3fbc0143',
             'com.melnykov:floatingactionbutton:0679ad9f7d61eb7aeab91e8dc56358cdedd5b1c1b9c48464499ffa05c40d3985',
             'com.google.zxing:android-integration:89e56aadf1164bd71e57949163c53abf90af368b51669c0d4a47a163335f95c4',
             'com.android.support:support-v4-preferencefragment:5470f5872514a6226fa1fc6f4e000991f38805691c534cf0bd2778911fc773ad',
@@ -129,6 +129,7 @@ dependencyVerification {
             'org.whispersystems:libpastelog:550d33c565380d90f4c671e7b8ed5f3a6da55a9fda468373177106b2eb5220b2',
             'com.amulyakhare:com.amulyakhare.textdrawable:54c92b5fba38cfd316a07e5a30528068f45ce8515a6890f1297df4c401af5dcb',
             'org.whispersystems:textsecure-android:6fc3a127b4ab63533e571066a8c6686e82d071d804f4563eee66a3773dd094e0',
+            'com.android.support:support-annotations:95bb152032ca4043e0527cfca222de8d80aef6d6fa6e73b65d1d78ccffb2b93f',
             'com.nineoldandroids:library:68025a14e3e7673d6ad2f95e4b46d78d7d068343aa99256b686fe59de1b3163a',
             'javax.inject:javax.inject:91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',
             'com.madgag.spongycastle:core:8d6240b974b0aca4d3da9c7dd44d42339d8a374358aca5fc98e50a995764511f',
@@ -144,14 +145,14 @@ dependencyVerification {
             'com.fasterxml.jackson.core:jackson-annotations:0ca408c24202a7626ec8b861e99d85eca5e38b73311dd6dd12e3e9deecc3fe94',
             'com.fasterxml.jackson.core:jackson-core:cbf4604784b4de226262845447a1ad3bb38a6728cebe86562e2c5afada8be2c0',
             'org.whispersystems:curve25519-java:9ccef8f5aba05d9942336f023c589d6278b4f9135bdc34a7bade1f4e7ad65fa3',
-            'com.android.support:support-v4:1e2e4d35ac7fd30db5ce3bc177b92e4d5af86acef2ef93e9221599d733346f56',
-            'com.android.support:support-annotations:7bc07519aa613b186001160403bcfd68260fa82c61cc7e83adeedc9b862b94ae',
+            'com.android.support:support-v4:d9a6307bf5c1d67f9aea96977f4f77273d8731c69d1b24c400a8a5e1b0f39af3',
     ]
 }
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion '22.0.1'
+    compileSdkVersion 23
+    buildToolsVersion '23.0.0'
+    useLibrary 'org.apache.http.legacy'
 
     dexOptions {
         javaMaxHeapSize "4g"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="ConversationActivity_unblock_question">Unblock?</string>
     <string name="ConversationActivity_are_you_sure_you_want_to_unblock_this_contact">Are you sure you want to unblock this contact?</string>
     <string name="ConversationActivity_unblock">Unblock</string>
+    <string name="ConversationActivity_missing_send_permissions">TextSecure is missing the permissions necessary to send.</string>
+    <string name="ConversationActivity_missing_camera_permissions">TextSecure needs the camera permission to capture photos.</string>
 
     <!-- ConversationFragment -->
     <string name="ConversationFragment_message_details">Message details</string>
@@ -149,6 +151,11 @@
 
     <!-- ConversationListActivity -->
     <string name="ConversationListActivity_search">Search...</string>
+    <string name="ConversationListActivity_default_sms_permission_warning_title">SMS permissions</string>
+    <string name="ConversationListActivity_default_sms_permission_warning_message">
+        TextSecure is your default SMS provider, but doesn\'t have SMS permissions.\n\nBad things will happen, messages may get lost, and the TextSecure developers will be very disappointed in your life choices.
+    </string>
+    <string name="ConversationListActivity_default_sms_permission_error">I see how it is.</string>
 
     <!-- ConversationListFragment -->
     <string name="ConversationListFragment_delete_threads_question">Delete threads?</string>
@@ -197,6 +204,7 @@
     <string name="ExportFragment_error_unable_to_write_to_sd_card">Error, unable to write to SD card!</string>
     <string name="ExportFragment_error_while_writing_to_sd_card">Error while writing to SD card.</string>
     <string name="ExportFragment_success">Success!</string>
+    <string name="ExportFragment_missing_storage_permission">TextSecure doesn\'t have permission to write to storage.</string>
 
     <!-- GcmRefreshJob -->
     <string name="GcmRefreshJob_Permanent_TextSecure_communication_failure">Permanent TextSecure communication failure!</string>
@@ -255,6 +263,7 @@
     <string name="ImportFragment_restoring_encrypted_backup">Restoring encrypted backup...</string>
     <string name="ImportFragment_no_encrypted_backup_found">No encrypted backup found!</string>
     <string name="ImportFragment_restore_complete">Restore complete!</string>
+    <string name="ImportFragment_missing_storage_permission">TextSecure doesn\'t have permission to read from storage.</string>
 
     <!-- KeyScanningActivity -->
     <string name="KeyScanningActivity_no_scanned_key_found_exclamation">No scanned key found!</string>
@@ -306,6 +315,10 @@
     <string name="PassphrasePromptActivity_watermark_content_description">TextSecure icon</string>
     <string name="PassphrasePromptActivity_ok_button_content_description">Submit passphrase</string>
     <string name="PassphrasePromptActivity_invalid_passphrase_exclamation">Invalid passphrase!</string>
+
+
+    <!-- PermissionHandler -->
+    <string name="PermissionHandler_dialog_accept_button">I understand</string>
 
     <!-- PlayServicesProblemFragment -->
     <string name="PlayServicesProblemFragment_the_version_of_google_play_services_you_have_installed_is_not_functioning">The version of Google Play Services you have installed is not functioning correctly.  Please reinstall Google Play Services and try again.</string>
@@ -976,6 +989,7 @@
     <string name="MediaPreviewActivity_you">You</string>
     <string name="MediaPreviewActivity_cant_display">Failed to preview this image</string>
     <string name="MediaPreviewActivity_unssuported_media_type">Unsupported media type</string>
+    <string name="MediaPreviewActivity_missing_storage_permission">TextSecure doesn\'t have permission to access storage.</string>
 
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>

--- a/src/org/thoughtcrime/securesms/ImportExportActivity.java
+++ b/src/org/thoughtcrime/securesms/ImportExportActivity.java
@@ -12,13 +12,15 @@ import android.view.MenuItem;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.permissions.PermissionHandler;
 
 
 public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
 
-  private MasterSecret    masterSecret;
-  private TabPagerAdapter tabPagerAdapter;
-  private ViewPager       viewPager;
+  private MasterSecret      masterSecret;
+  private TabPagerAdapter   tabPagerAdapter;
+  private ViewPager         viewPager;
+  private PermissionHandler permissions;
 
   private DynamicTheme dynamicTheme = new DynamicTheme();
 
@@ -30,6 +32,7 @@ public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState, @NonNull MasterSecret masterSecret) {
     this.masterSecret = masterSecret;
+    this.permissions  = new PermissionHandler(this);
     setContentView(R.layout.import_export_activity);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
@@ -42,6 +45,12 @@ public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
   public void onResume() {
       dynamicTheme.onResume(this);
       super.onResume();
+  }
+
+  @Override public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                                   @NonNull int[] grantResults)
+  {
+    this.permissions.onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
   @Override
@@ -100,6 +109,8 @@ public class ImportExportActivity extends PassphraseRequiredActionBarActivity {
       this.exportFragment = new ExportFragment();
       this.importFragment.setMasterSecret(masterSecret);
       this.exportFragment.setMasterSecret(masterSecret);
+      this.importFragment.setPermissionHandler(permissions);
+      this.exportFragment.setPermissionHandler(permissions);
     }
 
     @Override

--- a/src/org/thoughtcrime/securesms/TransportOption.java
+++ b/src/org/thoughtcrime/securesms/TransportOption.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms;
 
 import android.support.annotation.DrawableRes;
+import android.support.annotation.NonNull;
 
 import org.thoughtcrime.securesms.util.CharacterCalculator;
 import org.thoughtcrime.securesms.util.CharacterCalculator.CharacterState;
@@ -18,13 +19,15 @@ public class TransportOption {
   private Type                type;
   private String              composeHint;
   private CharacterCalculator characterCalculator;
+  private String[]            requiredPermissions;
 
   public TransportOption(Type type,
                          @DrawableRes int drawable,
                          int backgroundColor,
-                         String text,
-                         String composeHint,
-                         CharacterCalculator characterCalculator)
+                         @NonNull String text,
+                         @NonNull String composeHint,
+                         @NonNull CharacterCalculator characterCalculator,
+                         @NonNull String[] requiredPermissions)
   {
     this.type                = type;
     this.drawable            = drawable;
@@ -32,6 +35,7 @@ public class TransportOption {
     this.text                = text;
     this.composeHint         = composeHint;
     this.characterCalculator = characterCalculator;
+    this.requiredPermissions = requiredPermissions;
   }
 
   public Type getType() {
@@ -64,5 +68,9 @@ public class TransportOption {
 
   public String getDescription() {
     return text;
+  }
+
+  public @NonNull String[] getRequiredPermissions() {
+    return requiredPermissions;
   }
 }

--- a/src/org/thoughtcrime/securesms/TransportOptions.java
+++ b/src/org/thoughtcrime/securesms/TransportOptions.java
@@ -1,7 +1,7 @@
 package org.thoughtcrime.securesms;
 
+import android.Manifest.permission;
 import android.content.Context;
-import android.content.res.TypedArray;
 
 import org.thoughtcrime.securesms.util.MmsCharacterCalculator;
 import org.thoughtcrime.securesms.util.PushCharacterCalculator;
@@ -89,24 +89,26 @@ public class TransportOptions {
                                       context.getResources().getColor(R.color.grey_600),
                                       context.getString(R.string.ConversationActivity_transport_insecure_mms),
                                       context.getString(R.string.conversation_activity__type_message_mms_insecure),
-                                      new MmsCharacterCalculator()));
+                                      new MmsCharacterCalculator(),
+                                      new String[]{permission.SEND_SMS}));
     } else {
       results.add(new TransportOption(Type.SMS, R.drawable.ic_send_sms_white_24dp,
                                       context.getResources().getColor(R.color.grey_600),
                                       context.getString(R.string.ConversationActivity_transport_insecure_sms),
                                       context.getString(R.string.conversation_activity__type_message_sms_insecure),
-                                      new SmsCharacterCalculator()));
+                                      new SmsCharacterCalculator(),
+                                      new String[]{permission.SEND_SMS}));
     }
 
     results.add(new TransportOption(Type.TEXTSECURE, R.drawable.ic_send_push_white_24dp,
                                     context.getResources().getColor(R.color.textsecure_primary),
                                     context.getString(R.string.ConversationActivity_transport_textsecure),
                                     context.getString(R.string.conversation_activity__type_message_push),
-                                    new PushCharacterCalculator()));
+                                    new PushCharacterCalculator(),
+                                    new String[]{}));
 
     return results;
   }
-
 
   private void setTransport(Type type) {
     this.selectedType = type;
@@ -131,6 +133,6 @@ public class TransportOptions {
   }
 
   public interface OnTransportChangedListener {
-    public void onChange(TransportOption newTransport);
+    void onChange(TransportOption newTransport);
   }
 }

--- a/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.jobs;
 
+import android.Manifest.permission;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -23,6 +24,7 @@ import org.thoughtcrime.securesms.transport.InsecureFallbackApprovalException;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 import org.thoughtcrime.securesms.util.NumberUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.jobqueue.JobParameters;
 
 import java.util.ArrayList;
@@ -84,6 +86,10 @@ public class SmsSendJob extends SendJob {
 
     if (message.isSecure() || message.isKeyExchange() || message.isEndSession()) {
       throw new UndeliverableMessageException("Trying to send a secure SMS?");
+    }
+
+    if (!Util.hasPermission(context, permission.SEND_SMS)) {
+      throw new UndeliverableMessageException("Trying to send SMS without permissions.");
     }
 
     ArrayList<String> messages                = SmsManager.getDefault().divideMessage(message.getBody().getBody());

--- a/src/org/thoughtcrime/securesms/permissions/DialogRationalePermissionRequest.java
+++ b/src/org/thoughtcrime/securesms/permissions/DialogRationalePermissionRequest.java
@@ -1,0 +1,48 @@
+package org.thoughtcrime.securesms.permissions;
+
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.DialogInterface.OnClickListener;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.support.v7.app.AlertDialog;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.permissions.PermissionHandler.PermissionRequest;
+import org.thoughtcrime.securesms.permissions.PermissionHandler.RationaleCallback;
+
+import java.util.List;
+
+public abstract class DialogRationalePermissionRequest extends PermissionRequest {
+  private            Context context;
+  @StringRes private int     rationaleTitle;
+  @StringRes private int     rationaleMessage;
+
+  public DialogRationalePermissionRequest(@NonNull Context context,
+                                          @StringRes int rationaleTitle,
+                                          @StringRes int rationaleMessage,
+                                          @NonNull String... permissions)
+  {
+    super(permissions);
+    this.context = context;
+    this.rationaleTitle = rationaleTitle;
+    this.rationaleMessage = rationaleMessage;
+  }
+
+  @Override public boolean onRationaleRequested(
+      @NonNull final List<String> permissionsNeedingRationale,
+      @NonNull final RationaleCallback callback)
+  {
+    final AlertDialog.Builder builder = new AlertDialog.Builder(context);
+    builder.setTitle(rationaleTitle)
+           .setMessage(rationaleMessage)
+           .setNeutralButton(R.string.PermissionHandler_dialog_accept_button, new OnClickListener() {
+             @Override public void onClick(DialogInterface dialog, int which) {
+               callback.onRationaleFinished();
+               dialog.dismiss();
+             }
+           })
+           .show();
+    return true;
+  }
+}

--- a/src/org/thoughtcrime/securesms/permissions/PermissionHandler.java
+++ b/src/org/thoughtcrime/securesms/permissions/PermissionHandler.java
@@ -1,0 +1,161 @@
+package org.thoughtcrime.securesms.permissions;
+
+import android.app.Activity;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+
+import org.thoughtcrime.securesms.permissions.PermissionHandler.PermissionRequest.PermissionResult;
+import org.thoughtcrime.securesms.util.Util;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+
+public class PermissionHandler {
+  private Activity                             activity;
+  private Map<Integer, PermissionRequestState> openRequests;
+  private int                                  requestCodeCounter;
+
+  public PermissionHandler(@NonNull Activity activity) {
+    this.activity     = activity;
+    this.openRequests = new HashMap<>();
+  }
+
+  public abstract static class PermissionRequest {
+    private String[] permissions;
+
+    public PermissionRequest(@NonNull String... permissions) {
+      this.permissions = permissions;
+    }
+
+    public abstract void onResult(Map<String, PermissionResult> results);
+
+    /**
+     * Called if Android decides the user might want to see an explanation of a permission.
+     *
+     * @param permissionsNeedingRationale the list of permissions we need to explain
+     * @param callback called when the rationale view is finished explaining
+     * @return true if the handler should wait for the callback to be called, false otherwise
+     */
+    public boolean onRationaleRequested(List<String> permissionsNeedingRationale, RationaleCallback callback) {
+      return false;
+    }
+
+    protected @NonNull static PermissionResult getSingleResult(@NonNull Map<String, PermissionResult> results) {
+      return results.values().iterator().next();
+    }
+
+    protected static boolean isFullyGranted(@NonNull Map<String, PermissionResult> results) {
+      for (PermissionResult result : results.values()) {
+        if (!result.isGranted()) return false;
+      }
+      return true;
+    }
+
+    public enum PermissionResult {
+      ALREADY_GRANTED, GRANTED, DENIED;
+
+      public boolean isGranted() {
+        return this == GRANTED || this == ALREADY_GRANTED;
+      }
+
+      public static PermissionResult fromAndroidResult(int result) {
+        return result == PackageManager.PERMISSION_GRANTED ? GRANTED : DENIED;
+      }
+    }
+  }
+
+  private static class PermissionRequestState {
+    public final PermissionRequest request;
+    public final List<String>      granted        = new LinkedList<>();
+    public final List<String>      needsRationale = new LinkedList<>();
+    public final List<String>      needsApproval  = new LinkedList<>();
+
+    public PermissionRequestState(PermissionRequest request) {
+      this.request = request;
+    }
+  }
+
+  public class RationaleCallback {
+    private final PermissionRequestState state;
+
+    RationaleCallback(PermissionRequestState state) {
+      this.state = state;
+    }
+
+    public void onRationaleFinished() {
+      requestPendingPermissions(state);
+    }
+  }
+
+  public void request(final PermissionRequest request) {
+    final PermissionRequestState state = new PermissionRequestState(request);
+    for (final String permission : request.permissions) {
+      if (Util.hasPermission(activity, permission)) {
+        state.granted.add(permission);
+      } else if (ActivityCompat.shouldShowRequestPermissionRationale(activity, permission)) {
+        state.needsRationale.add(permission);
+      } else {
+        state.needsApproval.add(permission);
+      }
+    }
+
+    if (state.needsApproval.isEmpty() &&
+        state.needsRationale.isEmpty())
+    {
+      request.onResult(asImmediateResults(state.granted));
+    } else {
+      handlePendingPermissionsAndRationales(state);
+    }
+  }
+
+  private void handlePendingPermissionsAndRationales(final PermissionRequestState state) {
+    if (state.needsRationale.isEmpty() ||
+        !state.request.onRationaleRequested(state.needsRationale, new RationaleCallback(state)))
+    {
+      requestPendingPermissions(state);
+    }
+  }
+
+  private void requestPendingPermissions(final PermissionRequestState state) {
+    final int          requestCode        = generateRequestCode();
+    final List<String> pendingPermissions = new LinkedList<>(state.needsApproval);
+    pendingPermissions.addAll(state.needsRationale);
+
+    ActivityCompat.requestPermissions(activity,
+                                      pendingPermissions.toArray(new String[pendingPermissions.size()]),
+                                      requestCode);
+    openRequests.put(requestCode, state);
+  }
+
+  private int generateRequestCode() {
+    return (requestCodeCounter = (requestCodeCounter + 1) % 256);
+  }
+
+  private static Map<String, PermissionResult> asImmediateResults(List<String> permissions) {
+    Map<String, PermissionResult> results = new HashMap<>();
+    for (String permission : permissions) {
+      results.put(permission, PermissionResult.ALREADY_GRANTED);
+    }
+    return results;
+  }
+
+  public void onRequestPermissionsResult(int requestCode,
+                                         @NonNull String[] permissions,
+                                         @NonNull int[] grantResults)
+  {
+    PermissionRequestState requestState = openRequests.get(requestCode);
+    if (requestState == null) return;
+
+    Map<String, PermissionResult> results = new HashMap<>(asImmediateResults(requestState.granted));
+    for (int i = 0; i < permissions.length; i++) {
+      results.put(permissions[i], PermissionResult.fromAndroidResult(grantResults[i]));
+    }
+
+    openRequests.remove(requestCode);
+    requestState.request.onResult(results);
+  }
+}

--- a/src/org/thoughtcrime/securesms/permissions/SimplePermissionRequest.java
+++ b/src/org/thoughtcrime/securesms/permissions/SimplePermissionRequest.java
@@ -1,0 +1,41 @@
+package org.thoughtcrime.securesms.permissions;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.StringRes;
+import android.widget.Toast;
+
+import org.thoughtcrime.securesms.permissions.PermissionHandler.PermissionRequest;
+
+import java.util.Map;
+
+public abstract class SimplePermissionRequest extends PermissionRequest {
+  private Context context;
+  private String  errorText;
+
+  public SimplePermissionRequest(@NonNull Context context,
+                                 @NonNull String errorText,
+                                 @NonNull String... permissions)
+  {
+    super(permissions);
+    this.context   = context;
+    this.errorText = errorText;
+  }
+
+  public SimplePermissionRequest(@NonNull Context context,
+                                 @StringRes int errorTextRes,
+                                 @NonNull String... permissions)
+  {
+    this(context, context.getString(errorTextRes), permissions);
+  }
+
+  @Override public void onResult(Map<String, PermissionResult> results) {
+    if (isFullyGranted(results)) {
+      onGranted();
+    } else {
+      Toast.makeText(context, errorText, Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  public abstract void onGranted();
+}

--- a/src/org/thoughtcrime/securesms/service/KeyCachingService.java
+++ b/src/org/thoughtcrime/securesms/service/KeyCachingService.java
@@ -30,6 +30,7 @@ import android.os.IBinder;
 import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationCompat.Builder;
 import android.util.Log;
 import android.widget.RemoteViews;
 
@@ -267,13 +268,12 @@ public class KeyCachingService extends Service {
   }
 
   private void foregroundServiceLegacy() {
-    Notification notification  = new Notification(R.drawable.icon_cached,
-                                                  getString(R.string.KeyCachingService_textsecure_passphrase_cached),
-                                                  System.currentTimeMillis());
-    notification.setLatestEventInfo(getApplicationContext(),
-                                    getString(R.string.KeyCachingService_passphrase_cached),
-                                    getString(R.string.KeyCachingService_textsecure_passphrase_cached),
-                                    buildLaunchIntent());
+    Notification notification = new Builder(this).setWhen(System.currentTimeMillis())
+        .setTicker(getString(R.string.KeyCachingService_textsecure_passphrase_cached))
+        .setContentIntent(buildLaunchIntent())
+        .setContentTitle(getString(R.string.KeyCachingService_passphrase_cached))
+        .setContentText(getString(R.string.KeyCachingService_textsecure_passphrase_cached))
+        .build();
     notification.tickerText = null;
 
     stopForeground(true);

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.util;
 
+import android.Manifest.permission;
 import android.accounts.Account;
 import android.accounts.AccountManager;
 import android.content.ContentResolver;
@@ -8,10 +9,8 @@ import android.content.OperationApplicationException;
 import android.os.RemoteException;
 import android.provider.ContactsContract;
 import android.util.Log;
-import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.contacts.ContactsDatabase;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.NotInDirectoryException;
 import org.thoughtcrime.securesms.database.TextSecureDirectory;
@@ -43,6 +42,11 @@ public class DirectoryHelper {
   public static void refreshDirectory(final Context context, final TextSecureAccountManager accountManager, final String localNumber)
       throws IOException
   {
+    if (!Util.hasPermission(context, permission.READ_CONTACTS)) {
+      Log.w(TAG, "READ_CONTACTS permission missing. Skipping directory refresh.");
+      return;
+    }
+
     TextSecureDirectory       directory              = TextSecureDirectory.getInstance(context);
     Optional<Account>         account                = getOrCreateAccount(context);
     Set<String>               eligibleContactNumbers = directory.getPushEligibleContactNumbers(localNumber);

--- a/src/org/thoughtcrime/securesms/util/Util.java
+++ b/src/org/thoughtcrime/securesms/util/Util.java
@@ -29,6 +29,7 @@ import android.os.Handler;
 import android.os.Looper;
 import android.provider.Telephony;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 import android.telephony.TelephonyManager;
 import android.text.Spannable;
 import android.text.SpannableString;
@@ -351,5 +352,9 @@ public class Util {
 
   public static float clamp(float value, float min, float max) {
     return Math.min(Math.max(value, min), max);
+  }
+
+  public static boolean hasPermission(Context context, String permission) {
+    return PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(context, permission);
   }
 }


### PR DESCRIPTION
I looked at a couple of libraries for the new runtime permissions, and didn't fall in love with any of them. Wrote a basic permission request handler to be a little nicer looking and abstract out all of Android's hard-on-the-eyes result code system.

Also had to make a few changes to workaround new deprecations in API 23 (NotificationCompat and Apache HTTP lib used by our MMS logic).

Tested in an emulator and the on physical devices for compatibility.