### PR TITLE
Fixed issue #3536.

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1206,6 +1206,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     if (refreshFragment) {
       fragment.reload(recipients, threadId);
+      MessageNotifier.setVisibleThread(threadId);
     }
 
     fragment.scrollToBottom();


### PR DESCRIPTION
Updates the visibleThread in MessageNotifier when sending a new message in a new thread.

Update:
It also solves another bug related to #3536. When receiving a message after sending the first one in a new thread, a push notification was created (shouldn't create push since the thread is open).