### PR TITLE
un-jank Google Photos sharing

### DIFF
--- a/res/layout/share_activity.xml
+++ b/res/layout/share_activity.xml
@@ -1,9 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:id="@+id/drawer_layout"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent">
+             xmlns:wheel="http://schemas.android.com/apk/res-auto"
+             android:orientation="vertical"
+             android:layout_width="match_parent"
+             android:layout_height="match_parent">
+
+    <FrameLayout android:id="@+id/drawer_layout"
+                 android:layout_width="match_parent"
+                 android:layout_height="match_parent"
+                 android:visibility="gone" />
+
+    <com.pnikosis.materialishprogress.ProgressWheel android:id="@+id/progress_wheel"
+                                                    android:layout_width="70dp"
+                                                    android:layout_height="70dp"
+                                                    android:layout_gravity="center"
+                                                    wheel:matProg_progressIndeterminate="true" />
 
 </FrameLayout>

--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -17,21 +17,29 @@
 
 package org.thoughtcrime.securesms;
 
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.view.ViewGroup;
 import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.ViewUtil;
 
-import java.net.URLDecoder;
+import java.io.IOException;
+import java.io.InputStream;
 
 import ws.com.google.android.mms.ContentType;
 
@@ -43,8 +51,16 @@ import ws.com.google.android.mms.ContentType;
 public class ShareActivity extends PassphraseRequiredActionBarActivity
     implements ShareFragment.ConversationSelectedListener
 {
+  private static final String TAG = ShareActivity.class.getSimpleName();
+
   private final DynamicTheme    dynamicTheme    = new DynamicTheme   ();
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
+
+  private MasterSecret masterSecret;
+  private ViewGroup    fragmentContainer;
+  private View         progressWheel;
+  private Uri          resolvedExtra;
+  private boolean      isPassingAlongMedia;
 
   @Override
   protected void onPreCreate() {
@@ -54,14 +70,21 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   protected void onCreate(Bundle icicle, @NonNull MasterSecret masterSecret) {
+    this.masterSecret = masterSecret;
     setContentView(R.layout.share_activity);
+
+    fragmentContainer = ViewUtil.findById(this, R.id.drawer_layout);
+    progressWheel     = ViewUtil.findById(this, R.id.progress_wheel);
+
     initFragment(R.id.drawer_layout, new ShareFragment(), masterSecret);
+    initializeMedia();
   }
 
   @Override
   protected void onNewIntent(Intent intent) {
-      super.onNewIntent(intent);
-      setIntent(intent);
+    super.onNewIntent(intent);
+    setIntent(intent);
+    initializeMedia();
   }
 
   @Override
@@ -75,7 +98,46 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void onPause() {
     super.onPause();
-    if (!isFinishing()) finish();
+    if (!isPassingAlongMedia && resolvedExtra != null) {
+      PersistentBlobProvider.getInstance(this).delete(resolvedExtra);
+    }
+    if (!isFinishing()) {
+      finish();
+    }
+  }
+
+  private void initializeMedia() {
+    final Context context = this;
+    isPassingAlongMedia = false;
+    fragmentContainer.setVisibility(View.GONE);
+    progressWheel.setVisibility(View.VISIBLE);
+    new AsyncTask<Uri, Void, Uri>() {
+      @Override
+      protected Uri doInBackground(Uri... uris) {
+        try {
+          if (uris.length != 1 || uris[0] == null) {
+            return null;
+          }
+
+          InputStream input = context.getContentResolver().openInputStream(uris[0]);
+          if (input == null) {
+            return null;
+          }
+
+          return PersistentBlobProvider.getInstance(context).create(masterSecret, input);
+        } catch (IOException ioe) {
+          Log.w(TAG, ioe);
+          return null;
+        }
+      }
+
+      @Override
+      protected void onPostExecute(Uri uri) {
+        resolvedExtra = uri;
+        ViewUtil.fadeIn(fragmentContainer, 300);
+        ViewUtil.fadeOut(progressWheel, 300);
+      }
+    }.execute(getIntent().<Uri>getParcelableExtra(Intent.EXTRA_STREAM));
   }
 
   @Override
@@ -100,6 +162,7 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
 
   private void handleNewConversation() {
     Intent intent = getBaseShareIntent(NewConversationActivity.class);
+    isPassingAlongMedia = true;
     startActivity(intent);
   }
 
@@ -114,38 +177,24 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, threadId);
     intent.putExtra(ConversationActivity.DISTRIBUTION_TYPE_EXTRA, distributionType);
 
+    isPassingAlongMedia = true;
     startActivity(intent);
   }
 
-  private Uri getStreamExtra() {
-    Uri streamUri = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
-    if (streamUri == null) {
-      return null;
-    }
-
-    if (streamUri.getAuthority().equals("com.google.android.apps.photos.contentprovider") &&
-        streamUri.toString().endsWith("/ACTUAL"))
-    {
-      String[] parts = streamUri.toString().split("/");
-      if (parts.length > 3) {
-        return Uri.parse(URLDecoder.decode(parts[parts.length - 2]));
-      }
-    }
-    return streamUri;
-  }
-
-  private Intent getBaseShareIntent(final Class<?> target) {
+  private Intent getBaseShareIntent(final @NonNull Class<?> target) {
     final Intent intent      = new Intent(this, target);
     final String textExtra   = getIntent().getStringExtra(Intent.EXTRA_TEXT);
-    final Uri    streamExtra = getStreamExtra();
+    final Uri    streamExtra = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
     final String type        = streamExtra != null ? getMimeType(streamExtra) : getIntent().getType();
 
-    if (ContentType.isImageType(type)) {
-      intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, streamExtra);
-    } else if (ContentType.isAudioType(type)) {
-      intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, streamExtra);
-    } else if (ContentType.isVideoType(type)) {
-      intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, streamExtra);
+    if (resolvedExtra != null) {
+      if (ContentType.isImageType(type)) {
+        intent.putExtra(ConversationActivity.DRAFT_IMAGE_EXTRA, resolvedExtra);
+      } else if (ContentType.isAudioType(type)) {
+        intent.putExtra(ConversationActivity.DRAFT_AUDIO_EXTRA, resolvedExtra);
+      } else if (ContentType.isVideoType(type)) {
+        intent.putExtra(ConversationActivity.DRAFT_VIDEO_EXTRA, resolvedExtra);
+      }
     }
     intent.putExtra(ConversationActivity.DRAFT_TEXT_EXTRA, textExtra);
 

--- a/src/org/thoughtcrime/securesms/mms/PartAuthority.java
+++ b/src/org/thoughtcrime/securesms/mms/PartAuthority.java
@@ -9,7 +9,7 @@ import android.support.annotation.NonNull;
 import org.thoughtcrime.securesms.attachments.AttachmentId;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.providers.CaptureProvider;
+import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.providers.PartProvider;
 import org.thoughtcrime.securesms.providers.SingleUseBlobProvider;
 
@@ -25,7 +25,7 @@ public class PartAuthority {
 
   private static final int PART_ROW       = 1;
   private static final int THUMB_ROW      = 2;
-  private static final int CAPTURE_ROW    = 3;
+  private static final int PERSISTENT_ROW = 3;
   private static final int SINGLE_USE_ROW = 4;
 
   private static final UriMatcher uriMatcher;
@@ -34,7 +34,7 @@ public class PartAuthority {
     uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
     uriMatcher.addURI("org.thoughtcrime.securesms", "part/*/#", PART_ROW);
     uriMatcher.addURI("org.thoughtcrime.securesms", "thumb/*/#", THUMB_ROW);
-    uriMatcher.addURI(CaptureProvider.AUTHORITY, CaptureProvider.EXPECTED_PATH, CAPTURE_ROW);
+    uriMatcher.addURI(PersistentBlobProvider.AUTHORITY, PersistentBlobProvider.EXPECTED_PATH, PERSISTENT_ROW);
     uriMatcher.addURI(SingleUseBlobProvider.AUTHORITY, SingleUseBlobProvider.PATH, SINGLE_USE_ROW);
   }
 
@@ -50,8 +50,8 @@ public class PartAuthority {
       case THUMB_ROW:
         partUri = new PartUriParser(uri);
         return DatabaseFactory.getAttachmentDatabase(context).getThumbnailStream(masterSecret, partUri.getPartId());
-      case CAPTURE_ROW:
-        return CaptureProvider.getInstance(context).getStream(masterSecret, ContentUris.parseId(uri));
+      case PERSISTENT_ROW:
+        return PersistentBlobProvider.getInstance(context).getStream(masterSecret, ContentUris.parseId(uri));
       case SINGLE_USE_ROW:
         return SingleUseBlobProvider.getInstance().getStream(ContentUris.parseId(uri));
       default:

--- a/src/org/thoughtcrime/securesms/providers/SingleUseBlobProvider.java
+++ b/src/org/thoughtcrime/securesms/providers/SingleUseBlobProvider.java
@@ -27,7 +27,7 @@ import java.util.Map;
 
 public class SingleUseBlobProvider {
 
-  private static final String TAG = CaptureProvider.class.getSimpleName();
+  private static final String TAG = SingleUseBlobProvider.class.getSimpleName();
 
   public  static final String AUTHORITY   = "org.thoughtcrime.securesms";
   public  static final String PATH        = "memory/*/#";


### PR DESCRIPTION
(as well as sharing from many other apps, most likely)

We had incorrect assumptions about how temporary URI permissions worked when passed in via share intents.

This change copies over the file in ShareActivity to hold on to until the user dismisses it. Also includes some AttachmentManager refactoring and simplifications.