### PR TITLE
Replace 'my' with 'your'

### DIFF
--- a/res/menu/text_secure_normal.xml
+++ b/res/menu/text_secure_normal.xml
@@ -18,7 +18,7 @@
           android:id="@+id/menu_import_export"
           android:icon="@android:drawable/ic_menu_upload" />
 
-    <item android:title="@string/arrays__my_identity_key"
+    <item android:title="@string/arrays__your_identity_key"
           android:id="@+id/menu_my_identity"
           android:icon="@android:drawable/ic_menu_view" />
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -456,7 +456,7 @@
     <string name="VerifyIdentityActivity_recipient_has_no_identity_key">Recipient has no identity key.</string>
     <string name="VerifyIdentityActivity_recipient_has_no_identity_key_exclamation">Recipient has no identity key!</string>
     <string name="VerifyIdentityActivity_scan_their_key_to_compare">Scan their key to compare</string>
-    <string name="VerifyIdentityActivity_get_my_key_scanned">Get my key scanned</string>
+    <string name="VerifyIdentityActivity_get_your_key_scanned">Get your key scanned</string>
     <string name="VerifyIdentityActivity_warning_the_scanned_key_does_not_match_please_check_the_fingerprint_text_carefully">WARNING, the scanned key DOES NOT match! Please check the fingerprint text carefully.</string>
     <string name="VerifyIdentityActivity_not_verified_exclamation">NOT Verified!</string>
     <string name="VerifyIdentityActivity_their_key_is_correct_it_is_also_necessary_to_verify_your_key_with_them_as_well">Their key is correct. It is also necessary to verify your key with them as well.</string>
@@ -471,7 +471,7 @@
     <string name="ViewIdentityActivity_not_verified_exclamation">NOT verified!</string>
     <string name="ViewIdentityActivity_the_scanned_key_matches_exclamation">The scanned key matches!</string>
     <string name="ViewIdentityActivity_verified_exclamation">Verified!</string>
-    <string name="ViewIdentityActivity_my_identity_fingerprint">My identity fingerprint</string>
+    <string name="ViewIdentityActivity_your_identity_fingerprint">Your identity fingerprint</string>
 
     <!-- KeyExchangeInitiator -->
     <string name="KeyExchangeInitiator_initiate_despite_existing_request_question">Initiate despite existing request?</string>
@@ -807,7 +807,7 @@
 
     <!-- arrays.xml -->
     <string name="arrays__import_export">Import / export</string>
-    <string name="arrays__my_identity_key">My identity key</string>
+    <string name="arrays__your_identity_key">Your identity key</string>
     <string name="arrays__use_default">Use default</string>
     <string name="arrays__use_custom">Use custom</string>
 
@@ -850,7 +850,7 @@
     <string name="preferences__choose_identity">Choose identity</string>
     <string name="preferences__choose_your_contact_entry_from_the_contacts_list">Choose your contact entry from the contacts list.</string>
     <string name="preferences__change_passphrase">Change passphrase</string>
-    <string name="preferences__change_my_passphrase">Change my passphrase</string>
+    <string name="preferences__change_your_passphrase">Change your passphrase</string>
     <string name="preferences__enable_passphrase">Enable passphrase</string>
     <string name="preferences__passphrase_summary">Passphrase %s</string>
     <string name="preferences__enable_lock_screen_for_messages">Enable lock screen for messages</string>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -9,7 +9,7 @@
 
     <Preference android:key="pref_change_passphrase"
                 android:title="@string/preferences__change_passphrase"
-                android:summary="@string/preferences__change_my_passphrase"
+                android:summary="@string/preferences__change_your_passphrase"
                 android:dependency="pref_enable_passphrase_temporary"/>
 
     <CheckBoxPreference android:defaultValue="false"

--- a/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -117,7 +117,7 @@ public class VerifyIdentityActivity extends KeyScanningActivity {
 
   @Override
   protected String getDisplayString() {
-    return getString(R.string.VerifyIdentityActivity_get_my_key_scanned);
+    return getString(R.string.VerifyIdentityActivity_get_your_key_scanned);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ViewLocalIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/ViewLocalIdentityActivity.java
@@ -39,7 +39,7 @@ public class ViewLocalIdentityActivity extends ViewIdentityActivity {
     getIntent().putExtra(ViewIdentityActivity.IDENTITY_KEY,
                          new IdentityKeyParcelable(IdentityKeyUtil.getIdentityKey(this)));
     getIntent().putExtra(ViewIdentityActivity.TITLE,
-                         getString(R.string.ViewIdentityActivity_my_identity_fingerprint));
+                         getString(R.string.ViewIdentityActivity_your_identity_fingerprint));
     super.onCreate(icicle, masterSecret);
   }
 

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/ConversationListActivityActions.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/ConversationListActivityActions.java
@@ -58,7 +58,7 @@ public class ConversationListActivityActions {
 
   public static void clickMyIdentity(Context context) throws Exception {
     openActionBarOverflowOrOptionsMenu(context);
-    onView(withText(R.string.arrays__my_identity_key)).perform(click());
+    onView(withText(R.string.arrays__your_identity_key)).perform(click());
   }
 
   public static void clickSettings(Context context) throws Exception {

--- a/test/androidTestEspresso/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
+++ b/test/androidTestEspresso/java/org/thoughtcrime/securesms/ConversationListActivityTest.java
@@ -60,7 +60,7 @@ public class ConversationListActivityTest extends TextSecureEspressoTestCase<Con
     onView(withText(R.string.text_secure_normal__menu_new_group)).check(matches(isDisplayed()));
     onView(withText(R.string.text_secure_normal__mark_all_as_read)).check(matches(isDisplayed()));
     onView(withText(R.string.arrays__import_export)).check(matches(isDisplayed()));
-    onView(withText(R.string.arrays__my_identity_key)).check(matches(isDisplayed()));
+    onView(withText(R.string.arrays__your_identity_key)).check(matches(isDisplayed()));
     onView(withText(R.string.text_secure_normal__menu_settings)).check(matches(isDisplayed()));
 
     if (!TextSecurePreferences.isPasswordDisabled(getContext())) {


### PR DESCRIPTION
 // FREEBIE

**Description:**
Bringing strings in line with Google's Design Guidelines by replacing 'my' with 'your'.

**Quote:**
*Speak directly to users as “you,” not “me.” Don’t put words in the users’ mouths, with phrases that use “I” or “my.”*

**See**
https://www.google.com/design/spec/style/writing.html#writing-language