### PR TITLE
Update regular expression pattern for sms verification

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -38,7 +38,7 @@ public class SmsListener extends BroadcastReceiver {
   private static final String SMS_RECEIVED_ACTION  = Telephony.Sms.Intents.SMS_RECEIVED_ACTION;
   private static final String SMS_DELIVERED_ACTION = Telephony.Sms.Intents.SMS_DELIVER_ACTION;
 
-  private static final Pattern CHALLENGE_PATTERN = Pattern.compile(".*Your TextSecure verification code: ([0-9]{3,4})-([0-9]{3,4}).*");
+  private static final Pattern CHALLENGE_PATTERN = Pattern.compile(".*\\s*Your TextSecure verification code: ([0-9]{3,4})-([0-9]{3,4}).*");
 
   private boolean isExemption(SmsMessage message, String messageBody) {
 

--- a/test/androidTest/java/org/thoughtcrime/securesms/service/SmsListenerTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/service/SmsListenerTest.java
@@ -38,13 +38,14 @@ import static org.mockito.Mockito.when;
 public class SmsListenerTest extends TextSecureTestCase {
 
   private static final String CHALLENGE_SMS_3_3         = "Your TextSecure verification code: 337-337";
+  private static final String CHALLENGE_SMS_3_3_PREPEND = "XXX\nYour TextSecure verification code: 1337-1337";
   private static final String CHALLENGE_SMS_3_4         = "Your TextSecure verification code: 337-1337";
   private static final String CHALLENGE_SMS_4_3         = "Your TextSecure verification code: 1337-337";
   private static final String CHALLENGE_SMS_4_4         = "Your TextSecure verification code: 1337-1337";
   private static final String CHALLENGE_SMS_4_4_PREPEND = "XXXYour TextSecure verification code: 1337-1337";
   private static final String CHALLENGE_SMS_4_4_APPEND  = "Your TextSecure verification code: 1337-1337XXX";
   private static final String[] CHALLENGE_SMS = {
-      CHALLENGE_SMS_3_3, CHALLENGE_SMS_3_4,         CHALLENGE_SMS_4_3,
+      CHALLENGE_SMS_3_3, CHALLENGE_SMS_3_3_PREPEND, CHALLENGE_SMS_3_4, CHALLENGE_SMS_4_3,
       CHALLENGE_SMS_4_4, CHALLENGE_SMS_4_4_PREPEND, CHALLENGE_SMS_4_4_APPEND
   };
 
@@ -53,7 +54,7 @@ public class SmsListenerTest extends TextSecureTestCase {
   private static final String CHALLENGE_4_3 = "1337337";
   private static final String CHALLENGE_4_4 = "13371337";
   private static final String[] CHALLENGES = {
-      CHALLENGE_3_3, CHALLENGE_3_4, CHALLENGE_4_3,
+      CHALLENGE_3_3, CHALLENGE_3_3, CHALLENGE_3_4, CHALLENGE_4_3,
       CHALLENGE_4_4, CHALLENGE_4_4, CHALLENGE_4_4,
   };
 


### PR DESCRIPTION
In South Korea, SMS message include an extra text in front of body message in first line.

The extra text provide information that where message comes from.

So SMS verification cannot be passed in South Korea while registering.

It will cause failure of registration so that they can only choose ARS.