### PR TITLE
Update the README's Travis build status image with the new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Signal Android [![Build Status](https://travis-ci.org/WhisperSystems/TextSecure.svg?branch=master)](https://travis-ci.org/WhisperSystems/TextSecure)
+# Signal Android [![Build Status](https://travis-ci.org/WhisperSystems/Signal-Android.svg?branch=master)](https://travis-ci.org/WhisperSystems/Signal-Android)
 
 Signal is a messaging app for simple private communication with friends.
 


### PR DESCRIPTION
TextSecure -> Signal. The current one shows a broken image. This one shows an "Unknown" for the build status, which is better, although Travis doesn't actually seem to know about Signal-Android yet.