### PR TITLE
remove unused library causing crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,6 @@ dependencies {
     compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
     compile 'org.whispersystems:textsecure-android:1.8.1'
     compile 'com.h6ah4i.android.compat:mulsellistprefcompat:1.0.0'
-    compile 'me.relex:circleindicator:1.0.0@aar'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1'
@@ -127,7 +126,6 @@ dependencyVerification {
             'com.amulyakhare:com.amulyakhare.textdrawable:54c92b5fba38cfd316a07e5a30528068f45ce8515a6890f1297df4c401af5dcb',
             'org.whispersystems:textsecure-android:66ef91b93a08f0a290ef14c5e66af21113cd4b2c814c231855011ba4763f41cc',
             'com.h6ah4i.android.compat:mulsellistprefcompat:47167c5cb796de1a854788e9ff318358e36c8fb88123baaa6e38fb78511dfabe',
-            'me.relex:circleindicator:996766d3dad51401331515e742948f2a10982d17c626edd976a246b9bf046aac',
             'com.nineoldandroids:library:68025a14e3e7673d6ad2f95e4b46d78d7d068343aa99256b686fe59de1b3163a',
             'javax.inject:javax.inject:91c77044a50c481636c32d916fd89c9118a72195390452c81065080f957de7ff',
             'com.madgag.spongycastle:core:8d6240b974b0aca4d3da9c7dd44d42339d8a374358aca5fc98e50a995764511f',

--- a/res/layout/experience_upgrade_activity.xml
+++ b/res/layout/experience_upgrade_activity.xml
@@ -19,15 +19,6 @@
             android:layout_alignParentBottom="true"
             android:layout_centerHorizontal="true" />
 
-    <me.relex.circleindicator.CircleIndicator
-        android:id="@+id/indicator"
-        android:layout_gravity="bottom|center_horizontal"
-        android:layout_width="fill_parent"
-        android:layout_marginBottom="25dp"
-        android:clickable="false"
-        android:focusable="false"
-        android:layout_height="40dp" />
-
     <com.melnykov.fab.FloatingActionButton
         android:id="@+id/fab"
         android:layout_width="wrap_content"

--- a/src/org/thoughtcrime/securesms/ExperienceUpgradeActivity.java
+++ b/src/org/thoughtcrime/securesms/ExperienceUpgradeActivity.java
@@ -31,8 +31,6 @@ import org.whispersystems.libaxolotl.util.guava.Optional;
 import java.util.Collections;
 import java.util.List;
 
-import me.relex.circleindicator.CircleIndicator;
-
 public class ExperienceUpgradeActivity extends BaseActionBarActivity {
   private static final String TAG             = ExperienceUpgradeActivity.class.getSimpleName();
   private static final int    NOTIFICATION_ID = 1339;
@@ -112,18 +110,10 @@ public class ExperienceUpgradeActivity extends BaseActionBarActivity {
     }
 
     setContentView(R.layout.experience_upgrade_activity);
-    final ViewPager            pager     = ViewUtil.findById(this, R.id.pager);
-    final CircleIndicator      indicator = ViewUtil.findById(this, R.id.indicator);
-    final FloatingActionButton fab       = ViewUtil.findById(this, R.id.fab);
+    final ViewPager            pager = ViewUtil.findById(this, R.id.pager);
+    final FloatingActionButton fab   = ViewUtil.findById(this, R.id.fab);
 
     pager.setAdapter(new IntroPagerAdapter(getSupportFragmentManager(), upgrade.get().getPages()));
-
-    if (upgrade.get().getPages().size() > 1) {
-      indicator.setViewPager(pager);
-      indicator.setOnPageChangeListener(new OnPageChangeListener(upgrade.get()));
-    } else {
-      indicator.setVisibility(View.GONE);
-    }
 
     fab.setOnClickListener(new OnClickListener() {
       @Override


### PR DESCRIPTION
the CircleIndicator library I included for multi-page experience upgrades apparently has a bug in it. Since we're not using it right now, I decided to just remove it since that's safest.

closes #4393
