### PR TITLE
Fixing the issue #2791 (Export backups to a sub-folder)

### DIFF
--- a/AbstractBackup.java
+++ b/AbstractBackup.java
@@ -1,0 +1,38 @@
+package org.thoughtcrime.securesms.database;
+
+import android.os.Environment;
+
+import java.io.File;
+
+public abstract class AbstractBackup {
+
+  protected static void verifyCanRead() throws NoExternalStorageException {
+    if (!Environment.getExternalStorageDirectory().canRead() ||
+        !(getDirectoryPath().exists() || getOldFilePath().exists()))
+      throw new NoExternalStorageException();
+  }
+
+  protected static void verifyCanWrite() throws NoExternalStorageException {
+    if (!Environment.getExternalStorageDirectory().canWrite())
+      throw new NoExternalStorageException();
+  }
+
+  protected static File getDirectoryPath() {
+    File sdDirectory = Environment.getExternalStorageDirectory();
+    File backupDirectory = new File(sdDirectory.getAbsolutePath() + File.separator + "Signal", "Backup");
+    return backupDirectory;
+  }
+
+  protected static File getOldFilePath() {
+    File sdDirectory = Environment.getExternalStorageDirectory();
+    File FilePath = new File(sdDirectory.getAbsolutePath(), "TextSecurePlaintextBackup.xml");
+    return FilePath;
+  }
+
+  protected static File getFilePath(String file) {
+    return new File(getDirectoryPath(), file);
+  }
+
+  ;
+
+}

--- a/EncryptedBackupExporter.java
+++ b/EncryptedBackupExporter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2011 Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.database;
+
+import android.content.Context;
+import android.os.Environment;
+import android.util.Log;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.channels.FileChannel;
+
+public class EncryptedBackupExporter extends AbstractBackup {
+
+  private static void checkAndCreateFolder() {
+    File backupDirectory = getDirectoryPath();
+    if (!backupDirectory.exists()) {
+      backupDirectory.mkdirs();
+    }
+  }
+
+  public static void exportToSd(Context context) throws NoExternalStorageException, IOException {
+    verifyCanWrite();
+    checkAndCreateFolder();
+    exportDirectory(context, "");
+  }
+
+  public static void importFromSd(Context context) throws NoExternalStorageException, IOException {
+    verifyCanRead();
+    importDirectory(context, "");
+  }
+
+  private static String getExportDirectoryPath() {
+    File sdDirectory  = Environment.getExternalStorageDirectory();
+    return sdDirectory.getAbsolutePath() + File.separator + "TextSecureExport";
+  }
+
+  private static void migrateFile(File from, File to) {
+    try {
+      if (from.exists()) {
+        FileChannel source      = new FileInputStream(from).getChannel();
+        FileChannel destination = new FileOutputStream(to).getChannel();
+
+        destination.transferFrom(source, 0, source.size());
+        source.close();
+        destination.close();
+      }
+    } catch (IOException ioe) {
+      Log.w("EncryptedBackupExporter", ioe);
+    }
+  }
+
+  private static void exportDirectory(Context context, String directoryName) throws IOException {
+    File directory       = new File(context.getFilesDir().getParent() + File.separatorChar + directoryName);
+    File exportDirectory = new File(getExportDirectoryPath() + File.separatorChar + directoryName);
+
+    if (directory.exists()) {
+      exportDirectory.mkdirs();
+
+      File[] contents = directory.listFiles();
+
+      for (int i=0;i<contents.length;i++) {
+        File localFile = contents[i];
+
+        if (localFile.isFile()) {
+          File exportedFile = new File(exportDirectory.getAbsolutePath() + File.separator + localFile.getName());
+          migrateFile(localFile, exportedFile);
+        } else {
+          exportDirectory(context, directoryName + File.separator + localFile.getName());
+        }
+      }
+    } else {
+      Log.w("EncryptedBackupExporter", "Could not find directory: " + directory.getAbsolutePath());
+    }
+  }
+
+  private static void importDirectory(Context context, String directoryName) throws IOException {
+    File directory       = new File(getExportDirectoryPath() + File.separator + directoryName);
+    File importDirectory = new File(context.getFilesDir().getParent() + File.separator + directoryName);
+
+    if (directory.exists() && directory.isDirectory()) {
+      importDirectory.mkdirs();
+
+      File[] contents = directory.listFiles();
+
+      for (File exportedFile : contents) {
+        if (exportedFile.isFile()) {
+          File localFile = new File(importDirectory.getAbsolutePath() + File.separator + exportedFile.getName());
+          migrateFile(exportedFile, localFile);
+        } else if (exportedFile.isDirectory()) {
+          importDirectory(context, directoryName + File.separator + exportedFile.getName());
+        }
+      }
+    }
+  }
+}

--- a/PlaintextBackupExporter.java
+++ b/PlaintextBackupExporter.java
@@ -1,0 +1,67 @@
+package org.thoughtcrime.securesms.database;
+
+
+import android.content.Context;
+import android.os.Environment;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
+
+import java.io.File;
+import java.io.IOException;
+
+public class PlaintextBackupExporter extends AbstractBackup {
+
+  public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
+      throws NoExternalStorageException, IOException
+  {
+    Log.w("PlaintextBackupExporter", "Exporting plaintext...");
+    verifyCanWrite();
+    checkAndCreateFolder();
+    exportPlaintext(context, masterSecret);
+  }
+
+  private static void checkAndCreateFolder() {
+    File backupDirectory = getDirectoryPath();
+    if (!backupDirectory.exists()) {
+      backupDirectory.mkdirs();
+    }
+  }
+
+  private static void exportPlaintext(Context context, MasterSecret masterSecret)
+      throws IOException
+  {
+    String filePath         = getFilePath("SignalPlaintextBackup.xml").getAbsolutePath();
+    int    count            = DatabaseFactory.getSmsDatabase(context).getMessageCount();
+    XmlBackup.Writer writer = new XmlBackup.Writer(filePath, count);
+
+
+    SmsMessageRecord record;
+    EncryptingSmsDatabase.Reader reader = null;
+    int skip                            = 0;
+    int ROW_LIMIT                       = 500;
+
+    do {
+      if (reader != null)
+        reader.close();
+
+      reader = DatabaseFactory.getEncryptingSmsDatabase(context).getMessages(masterSecret, skip, ROW_LIMIT);
+
+      while ((record = reader.getNext()) != null) {
+        XmlBackup.XmlBackupItem item =
+            new XmlBackup.XmlBackupItem(0, record.getIndividualRecipient().getNumber(),
+                                        record.getDateReceived(),
+                                        MmsSmsColumns.Types.translateToSystemBaseType(record.getType()),
+                                        null, record.getDisplayBody().toString(), null,
+                                        1, record.getDeliveryStatus());
+
+        writer.writeItem(item);
+      }
+
+      skip += ROW_LIMIT;
+    } while (reader.getCount() > 0);
+
+    writer.close();
+  }
+}

--- a/PlaintextBackupImporter.java
+++ b/PlaintextBackupImporter.java
@@ -1,0 +1,130 @@
+package org.thoughtcrime.securesms.database;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import android.os.Environment;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.crypto.MasterCipher;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.recipients.RecipientFactory;
+import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
+import org.thoughtcrime.securesms.recipients.Recipients;
+import org.xmlpull.v1.XmlPullParserException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+
+public class PlaintextBackupImporter extends AbstractBackup {
+
+  public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
+      throws NoExternalStorageException, IOException
+  {
+    Log.w("PlaintextBackupImporter", "Importing plaintext...");
+    verifyCanRead();
+    importPlaintext(context, masterSecret);
+  }
+
+  private static File findPlaintextBackupFile() {
+    File backup = getFilePath("SignalPlaintextBackup.xml");
+    if (backup.exists()){
+      return backup;
+    }
+    return getOldFilePath();
+  }
+
+  private static void importPlaintext(Context context, MasterSecret masterSecret)
+      throws IOException
+  {
+    Log.w("PlaintextBackupImporter", "importPlaintext()");
+    String         filePath    = findPlaintextBackupFile().getAbsolutePath();
+    SmsDatabase    db          = DatabaseFactory.getSmsDatabase(context);
+    SQLiteDatabase transaction = db.beginTransaction();
+
+    try {
+      ThreadDatabase threads         = DatabaseFactory.getThreadDatabase(context);
+      XmlBackup      backup          = new XmlBackup(filePath);
+      MasterCipher   masterCipher    = new MasterCipher(masterSecret);
+      Set<Long>      modifiedThreads = new HashSet<Long>();
+      XmlBackup.XmlBackupItem item;
+
+      while ((item = backup.getNext()) != null) {
+        Recipients      recipients = RecipientFactory.getRecipientsFromString(context, item.getAddress(), false);
+        long            threadId   = threads.getThreadIdFor(recipients);
+        SQLiteStatement statement  = db.createInsertStatement(transaction);
+
+        if (item.getAddress() == null || item.getAddress().equals("null"))
+          continue;
+
+        if (!isAppropriateTypeForImport(item.getType()))
+          continue;
+
+        addStringToStatement(statement, 1, item.getAddress());
+        addNullToStatement(statement, 2);
+        addLongToStatement(statement, 3, item.getDate());
+        addLongToStatement(statement, 4, item.getDate());
+        addLongToStatement(statement, 5, item.getProtocol());
+        addLongToStatement(statement, 6, item.getRead());
+        addLongToStatement(statement, 7, item.getStatus());
+        addTranslatedTypeToStatement(statement, 8, item.getType());
+        addNullToStatement(statement, 9);
+        addStringToStatement(statement, 10, item.getSubject());
+        addEncryptedStingToStatement(masterCipher, statement, 11, item.getBody());
+        addStringToStatement(statement, 12, item.getServiceCenter());
+        addLongToStatement(statement, 13, threadId);
+        modifiedThreads.add(threadId);
+        statement.execute();
+      }
+
+      for (long threadId : modifiedThreads) {
+        threads.update(threadId);
+      }
+
+      Log.w("PlaintextBackupImporter", "Exited loop");
+    } catch (XmlPullParserException e) {
+      Log.w("PlaintextBackupImporter", e);
+      throw new IOException("XML Parsing error!");
+    } finally {
+      db.endTransaction(transaction);
+    }
+  }
+
+  private static void addEncryptedStingToStatement(MasterCipher masterCipher, SQLiteStatement statement, int index, String value) {
+    if (value == null || value.equals("null")) {
+      statement.bindNull(index);
+    } else {
+      statement.bindString(index, masterCipher.encryptBody(value));
+    }
+  }
+
+  private static void addTranslatedTypeToStatement(SQLiteStatement statement, int index, int type) {
+    statement.bindLong(index, SmsDatabase.Types.translateFromSystemBaseType(type) | SmsDatabase.Types.ENCRYPTION_SYMMETRIC_BIT);
+  }
+
+  private static void addStringToStatement(SQLiteStatement statement, int index, String value) {
+    if (value == null || value.equals("null")) statement.bindNull(index);
+    else                                       statement.bindString(index, value);
+  }
+
+  private static void addNullToStatement(SQLiteStatement statement, int index) {
+    statement.bindNull(index);
+  }
+
+  private static void addLongToStatement(SQLiteStatement statement, int index, long value) {
+    statement.bindLong(index, value);
+  }
+
+  private static boolean isAppropriateTypeForImport(long theirType) {
+    long ourType = SmsDatabase.Types.translateFromSystemBaseType(theirType);
+
+    return ourType == MmsSmsColumns.Types.BASE_INBOX_TYPE ||
+           ourType == MmsSmsColumns.Types.BASE_SENT_TYPE ||
+           ourType == MmsSmsColumns.Types.BASE_SENT_FAILED_TYPE;
+  }
+
+
+}


### PR DESCRIPTION
This pr puts the plain text backup under the folder Signal/Backup/. On the import side, verify if old backup file exist (to oldest clients). Also, I've changed the EncryptedBackupExporter, to point to the new backup path.

I didn't have tested the EncryptedBackupExporter because this is not working.