### PR TITLE
Change 'SD card' to 'storage' & cosmetic corrections (rebased 3.3.0)

### DIFF
--- a/res/layout/import_fragment.xml
+++ b/res/layout/import_fragment.xml
@@ -80,7 +80,7 @@
                 <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"
                           style="@style/Registration.Description"
-                          android:text="@string/import_fragment__import_encrypted_backup"/>
+                          android:text="@string/import_fragment__restore_encrypted_backup"/>
 
                 <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -140,7 +140,7 @@
         <item quantity="other">This will permanently delete all %1$d selected messages.</item>
     </plurals>
     <string name="ConversationFragment_save_to_sd_card">Save to storage?</string>
-    <string name="ConversationFragment_this_media_has_been_stored_in_an_encrypted_database_warning">Saving this media to storage will allow any other apps on your phone to access it.\n\nContinue?</string>
+    <string name="ConversationFragment_saving_this_media_to_storage_warning">Saving this media to storage will allow any other apps on your device to access it.\n\nContinue?</string>
     <string name="ConversationFragment_error_while_saving_attachment_to_sd_card">Error while saving attachment to storage!</string>
     <string name="ConversationFragment_success_exclamation">Success!</string>
     <string name="ConversationFragment_unable_to_write_to_sd_card_exclamation">Unable to write to storage!</string>
@@ -205,15 +205,13 @@
     <string name="ExperienceUpgradeActivity_textsecure_is_now_signal_long">TextSecure and RedPhone are now one app: Signal. Tap to explore.</string>
     <!-- ExportFragment -->
     <string name="ExportFragment_export">Export</string>
-    <string name="ExportFragment_export_plaintext_to_sd_card">Export plaintext to SD card?</string>
-    <string name="ExportFragment_warning_this_will_export_the_plaintext_contents">Warning, this will
-        export the plaintext contents of your Signal messages to the SD card.
-    </string>
+    <string name="ExportFragment_export_plaintext_to_storage">Export plaintext to storage?</string>
+    <string name="ExportFragment_warning_this_will_export_the_plaintext_contents">Warning, this will export the plaintext contents of your Signal messages to storage.</string>
     <string name="ExportFragment_cancel">Cancel</string>
     <string name="ExportFragment_exporting">Exporting</string>
-    <string name="ExportFragment_exporting_plaintext_to_sd_card">Exporting plaintext to SD card...</string>
-    <string name="ExportFragment_error_unable_to_write_to_sd_card">Error, unable to write to SD card!</string>
-    <string name="ExportFragment_error_while_writing_to_sd_card">Error while writing to SD card.</string>
+    <string name="ExportFragment_exporting_plaintext_to_storage">Exporting plaintext to storage...</string>
+    <string name="ExportFragment_error_unable_to_write_to_storage">Error, unable to write to storage.</string>
+    <string name="ExportFragment_error_while_writing_to_storage">Error while writing to storage.</string>
     <string name="ExportFragment_success">Success!</string>
 
     <!-- GcmRefreshJob -->
@@ -656,19 +654,13 @@
     <string name="database_upgrade_activity__updating_database">Updating database...</string>
 
     <string name="export_fragment__export_plaintext_backup">Export plaintext backup</string>
-    <string name="export_fragment__export_a_plaintext_backup_compatible_with">
-        Export a plaintext backup compatible with \'SMSBackup And Restore\' to the SD card.</string>
+    <string name="export_fragment__export_a_plaintext_backup_compatible_with">Export a plaintext backup compatible with \'SMS Backup &amp; Restore\' to storage</string>
     <string name="import_fragment__import_system_sms_database">Import system SMS database</string>
-    <string name="import_fragment__import_the_database_from_the_default_system">Import the database
-        from the default system messenger app.
-    </string>
-    <string name="import_fragment__import_encrypted_backup">Import encrypted backup</string>
-    <string name="import_fragment__restore_a_previously_exported_encrypted_signal_backup">
-        Restore a previously exported encrypted Signal backup.
-    </string>
+    <string name="import_fragment__import_the_database_from_the_default_system">Import the database from the default system messenger app</string>
+    <string name="import_fragment__restore_encrypted_backup">Restore encrypted backup</string>
+    <string name="import_fragment__restore_a_previously_exported_encrypted_signal_backup">Restore a previously exported encrypted Signal backup</string>
     <string name="import_fragment__import_plaintext_backup">Import plaintext backup</string>
-    <string name="import_fragment__import_a_plaintext_backup_file">
-        Import a plaintext backup file. Compatible with \'SMSBackup And Restore.\'</string>
+    <string name="import_fragment__import_a_plaintext_backup_file">Import a plaintext backup file. Compatible with \'SMS Backup &amp; Restore.\'</string>
 
     <!-- load_more_header -->
     <string name="load_more_header__see_full_conversation">See full conversation</string>

--- a/src/org/thoughtcrime/securesms/ExportFragment.java
+++ b/src/org/thoughtcrime/securesms/ExportFragment.java
@@ -75,7 +75,7 @@ public class ExportFragment extends Fragment {
   private void handleExportPlaintextBackup() {
     AlertDialogWrapper.Builder builder = new AlertDialogWrapper.Builder(getActivity());
     builder.setIconAttribute(R.attr.dialog_alert_icon);
-    builder.setTitle(getActivity().getString(R.string.ExportFragment_export_plaintext_to_sd_card));
+    builder.setTitle(getActivity().getString(R.string.ExportFragment_export_plaintext_to_storage));
     builder.setMessage(getActivity().getString(R.string.ExportFragment_warning_this_will_export_the_plaintext_contents));
     builder.setPositiveButton(getActivity().getString(R.string.ExportFragment_export), new Dialog.OnClickListener() {
       @Override
@@ -94,7 +94,7 @@ public class ExportFragment extends Fragment {
     protected void onPreExecute() {
       dialog = ProgressDialog.show(getActivity(), 
                                    getActivity().getString(R.string.ExportFragment_exporting), 
-                                   getActivity().getString(R.string.ExportFragment_exporting_plaintext_to_sd_card),
+                                   getActivity().getString(R.string.ExportFragment_exporting_plaintext_to_storage),
                                    true, false);
     }
 
@@ -125,12 +125,12 @@ public class ExportFragment extends Fragment {
       switch (result) {
         case NO_SD_CARD:
           Toast.makeText(context,
-                         context.getString(R.string.ExportFragment_error_unable_to_write_to_sd_card),
+                         context.getString(R.string.ExportFragment_error_unable_to_write_to_storage),
                          Toast.LENGTH_LONG).show();
           break;
         case IO_ERROR:
           Toast.makeText(context,
-                         context.getString(R.string.ExportFragment_error_while_writing_to_sd_card),
+                         context.getString(R.string.ExportFragment_error_while_writing_to_storage),
                          Toast.LENGTH_LONG).show();
           break;
         case SUCCESS:
@@ -164,12 +164,12 @@ public class ExportFragment extends Fragment {
 //      switch (result) {
 //        case NO_SD_CARD:
 //          Toast.makeText(context,
-//                         context.getString(R.string.ExportFragment_error_unable_to_write_to_sd_card),
+//                         context.getString(R.string.ExportFragment_error_unable_to_write_to_storage),
 //                         Toast.LENGTH_LONG).show();
 //          break;
 //        case IO_ERROR:
 //          Toast.makeText(context,
-//                         context.getString(R.string.ExportFragment_error_while_writing_to_sd_card),
+//                         context.getString(R.string.ExportFragment_error_while_writing_to_storage),
 //                         Toast.LENGTH_LONG).show();
 //          break;
 //        case SUCCESS:

--- a/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -153,7 +153,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     builder.setTitle(R.string.ConversationFragment_save_to_sd_card);
     builder.setIconAttribute(R.attr.dialog_alert_icon);
     builder.setCancelable(true);
-    builder.setMessage(R.string.ConversationFragment_this_media_has_been_stored_in_an_encrypted_database_warning);
+    builder.setMessage(R.string.ConversationFragment_saving_this_media_to_storage_warning);
     builder.setPositiveButton(R.string.yes, onAcceptListener);
     builder.setNegativeButton(R.string.no, null);
     builder.show();


### PR DESCRIPTION
Rebased against master (3.3.0)
Replaces #4317
Fixes #3920

Change **'SD card'** in strings to **'storage'** for clarity & consistency.

Furthermore, I've done a couple of minor cosmetic string corrections.
I've decided to include these here rather than in a separate PR as there is some overlap with the 'SD card' stuff, and I'd like to save the translators from translating these strings twice.

- Change app's name from 'SMSBackup And Restore' to its official name **'SMS Backup & Restore'**
- Change 'Import encrypted backup' into '**Restore** encrypted backup' as this is the only option that replaces the complete database rather than add to it (which all the 'import' options do). 'restore' is the wording used in the description string as well.
- Remove **redundant periods** at the end of single sentences of some related description strings (in line with Google's design guidelines and the rest of Signal's description strings)
- Remove some **redundant line feeds** in XML (confusing to translators at
Transifex)