### PR TITLE
Fixing the issue #2791 (Export backups to a sub-folder)

### DIFF
--- a/src/org/thoughtcrime/securesms/database/AbstractBackup.java
+++ b/src/org/thoughtcrime/securesms/database/AbstractBackup.java
@@ -1,0 +1,38 @@
+package org.thoughtcrime.securesms.database;
+
+import android.os.Environment;
+
+import java.io.File;
+
+public abstract class AbstractBackup {
+
+  protected static void verifyCanRead() throws NoExternalStorageException {
+    if (!Environment.getExternalStorageDirectory().canRead() ||
+        !(getDirectoryPath().exists() || getOldFilePath().exists()))
+      throw new NoExternalStorageException();
+  }
+
+  protected static void verifyCanWrite() throws NoExternalStorageException {
+    if (!Environment.getExternalStorageDirectory().canWrite())
+      throw new NoExternalStorageException();
+  }
+
+  protected static File getDirectoryPath() {
+    File sdDirectory = Environment.getExternalStorageDirectory();
+    File backupDirectory = new File(sdDirectory.getAbsolutePath() + File.separator + "Signal", "Backup");
+    return backupDirectory;
+  }
+
+  protected static File getOldFilePath() {
+    File sdDirectory = Environment.getExternalStorageDirectory();
+    File FilePath = new File(sdDirectory.getAbsolutePath(), "TextSecurePlaintextBackup.xml");
+    return FilePath;
+  }
+
+  protected static File getFilePath(String file) {
+    return new File(getDirectoryPath(), file);
+  }
+
+  ;
+
+}

--- a/src/org/thoughtcrime/securesms/database/EncryptedBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/EncryptedBackupExporter.java
@@ -26,38 +26,29 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.channels.FileChannel;
 
-public class EncryptedBackupExporter {
+public class EncryptedBackupExporter extends AbstractBackup {
+
+  private static void checkAndCreateFolder() {
+    File backupDirectory = getDirectoryPath();
+    if (!backupDirectory.exists()) {
+      backupDirectory.mkdirs();
+    }
+  }
 
   public static void exportToSd(Context context) throws NoExternalStorageException, IOException {
-    verifyExternalStorageForExport();
+    verifyCanWrite();
+    checkAndCreateFolder();
     exportDirectory(context, "");
   }
 
   public static void importFromSd(Context context) throws NoExternalStorageException, IOException {
-    verifyExternalStorageForImport();
+    verifyCanRead();
     importDirectory(context, "");
   }
 
   private static String getExportDirectoryPath() {
     File sdDirectory  = Environment.getExternalStorageDirectory();
     return sdDirectory.getAbsolutePath() + File.separator + "TextSecureExport";
-  }
-
-  private static void verifyExternalStorageForExport() throws NoExternalStorageException {
-    if (!Environment.getExternalStorageDirectory().canWrite())
-      throw new NoExternalStorageException();
-
-    String exportDirectoryPath = getExportDirectoryPath();
-    File exportDirectory       = new File(exportDirectoryPath);
-
-    if (!exportDirectory.exists())
-      exportDirectory.mkdir();
-  }
-
-  private static void verifyExternalStorageForImport() throws NoExternalStorageException {
-    if (!Environment.getExternalStorageDirectory().canRead() ||
-        !(new File(getExportDirectoryPath()).exists()))
-        throw new NoExternalStorageException();
   }
 
   private static void migrateFile(File from, File to) {

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -3,6 +3,7 @@ package org.thoughtcrime.securesms.database;
 
 import android.content.Context;
 import android.os.Environment;
+import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
@@ -10,30 +11,30 @@ import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
 import java.io.File;
 import java.io.IOException;
 
-public class PlaintextBackupExporter {
+public class PlaintextBackupExporter extends AbstractBackup {
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
-    verifyExternalStorageForPlaintextExport();
+    Log.w("PlaintextBackupExporter", "Exporting plaintext...");
+    verifyCanWrite();
+    checkAndCreateFolder();
     exportPlaintext(context, masterSecret);
   }
 
-  private static void verifyExternalStorageForPlaintextExport() throws NoExternalStorageException {
-    if (!Environment.getExternalStorageDirectory().canWrite())
-      throw new NoExternalStorageException();
-  }
-
-  private static String getPlaintextExportDirectoryPath() {
-    File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+  private static void checkAndCreateFolder() {
+    File backupDirectory = getDirectoryPath();
+    if (!backupDirectory.exists()) {
+      backupDirectory.mkdirs();
+    }
   }
 
   private static void exportPlaintext(Context context, MasterSecret masterSecret)
       throws IOException
   {
-    int count               = DatabaseFactory.getSmsDatabase(context).getMessageCount();
-    XmlBackup.Writer writer = new XmlBackup.Writer(getPlaintextExportDirectoryPath(), count);
+    String filePath         = getFilePath("SignalPlaintextBackup.xml").getAbsolutePath();
+    int    count            = DatabaseFactory.getSmsDatabase(context).getMessageCount();
+    XmlBackup.Writer writer = new XmlBackup.Writer(filePath, count);
 
 
     SmsMessageRecord record;

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -19,37 +19,35 @@ import java.util.HashSet;
 import java.util.Set;
 
 
-public class PlaintextBackupImporter {
+public class PlaintextBackupImporter extends AbstractBackup {
 
   public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
     Log.w("PlaintextBackupImporter", "Importing plaintext...");
-    verifyExternalStorageForPlaintextImport();
+    verifyCanRead();
     importPlaintext(context, masterSecret);
   }
 
-  private static void verifyExternalStorageForPlaintextImport() throws NoExternalStorageException {
-    if (!Environment.getExternalStorageDirectory().canRead() ||
-        !(new File(getPlaintextExportDirectoryPath()).exists()))
-      throw new NoExternalStorageException();
-  }
-
-  private static String getPlaintextExportDirectoryPath() {
-    File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+  private static File findPlaintextBackupFile() {
+    File backup = getFilePath("SignalPlaintextBackup.xml");
+    if (backup.exists()){
+      return backup;
+    }
+    return getOldFilePath();
   }
 
   private static void importPlaintext(Context context, MasterSecret masterSecret)
       throws IOException
   {
     Log.w("PlaintextBackupImporter", "importPlaintext()");
+    String         filePath    = findPlaintextBackupFile().getAbsolutePath();
     SmsDatabase    db          = DatabaseFactory.getSmsDatabase(context);
     SQLiteDatabase transaction = db.beginTransaction();
 
     try {
       ThreadDatabase threads         = DatabaseFactory.getThreadDatabase(context);
-      XmlBackup      backup          = new XmlBackup(getPlaintextExportDirectoryPath());
+      XmlBackup      backup          = new XmlBackup(filePath);
       MasterCipher   masterCipher    = new MasterCipher(masterSecret);
       Set<Long>      modifiedThreads = new HashSet<Long>();
       XmlBackup.XmlBackupItem item;


### PR DESCRIPTION
This pr puts the plain text backup under the folder Signal/Backup/. On the import side, verify if old backup file exist (to oldest clients). Also, I've changed the EncryptedBackupExporter, to point to the new backup path.

I didn't have tested the EncryptedBackupExporter because this is not working.