### PR TITLE
catch camera RuntimeExceptions

### DIFF
--- a/src/org/thoughtcrime/securesms/components/camera/CameraView.java
+++ b/src/org/thoughtcrime/securesms/components/camera/CameraView.java
@@ -273,13 +273,21 @@ public class CameraView extends FrameLayout {
 
   private void startPreview() {
     if (camera.isPresent()) {
-      camera.get().startPreview();
+      try {
+        camera.get().startPreview();
+      } catch (RuntimeException re) {
+        Log.w(TAG, re);
+      }
     }
   }
 
   private void stopPreview() {
     if (camera.isPresent()) {
-      camera.get().stopPreview();
+      try {
+        camera.get().stopPreview();
+      } catch (RuntimeException re) {
+        Log.w(TAG, re);
+      }
     }
   }
 


### PR DESCRIPTION
Doesn't fix the root cause of #4415, but stops it from crashing. We should be catching these anyway.