### PR TITLE
Tap the local key to Share it

### DIFF
--- a/src/org/thoughtcrime/securesms/ViewIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/ViewIdentityActivity.java
@@ -34,7 +34,7 @@ public class ViewIdentityActivity extends KeyScanningActivity {
   public static final String IDENTITY_KEY = "identity_key";
   public static final String TITLE        = "title";
 
-  private TextView    identityFingerprint;
+  protected TextView  identityFingerprint;
   private IdentityKey identityKey;
 
   @Override

--- a/src/org/thoughtcrime/securesms/ViewLocalIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/ViewLocalIdentityActivity.java
@@ -17,11 +17,14 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.View;
+import android.widget.TextView;
 
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil;
 import org.thoughtcrime.securesms.crypto.IdentityKeyParcelable;
@@ -40,7 +43,20 @@ public class ViewLocalIdentityActivity extends ViewIdentityActivity {
                          new IdentityKeyParcelable(IdentityKeyUtil.getIdentityKey(this)));
     getIntent().putExtra(ViewIdentityActivity.TITLE,
                          getString(R.string.ViewIdentityActivity_my_identity_fingerprint));
+
     super.onCreate(icicle, masterSecret);
+
+    /* Make the key on the screen do something when tapped. Since it's our key, the
+    obvious choice is to share it with someone or something. */
+    identityFingerprint.setOnClickListener(new View.OnClickListener() {
+      public void onClick(View v) {
+        Intent sendIntent = new Intent();
+        sendIntent.setAction(Intent.ACTION_SEND);
+        sendIntent.putExtra(Intent.EXTRA_TEXT, ((TextView) v).getText());
+        sendIntent.setType("text/plain");
+        startActivity(sendIntent);
+      }
+    });
   }
 
   @Override


### PR DESCRIPTION
This touches on #1911 and #826 .  When you're staring at your own
fingerprint, what should tapping on it do?

Nothing? That's dumb. In Android, We expect to be able to copy data
between apps, and a fingerprint is exactly the kind of thing a user
would want to share with someone.

So, tapping your local fingerprint now prompts you to send your
fingerprint to any app you have that accepts plain/text. If you already
have a communication channel you trust, this simplifies your universe,
and this makes it dead easy to publish it on Twitter et c.