### PR TITLE
Add the option to mute notifications for one year. Closes #4448.

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -158,6 +158,7 @@
       <item>@string/arrays__mute_for_two_hours</item>
       <item>@string/arrays__mute_for_one_day</item>
       <item>@string/arrays__mute_for_seven_days</item>
+      <item>@string/arrays__mute_for_one_year</item>
   </string-array>
 
   <string-array name="recipient_vibrate_entries">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -848,6 +848,7 @@
     <string name="arrays__mute_for_two_hours">Mute for 2 hours</string>
     <string name="arrays__mute_for_one_day">Mute for 1 day</string>
     <string name="arrays__mute_for_seven_days">Mute for 7 days</string>
+    <string name="arrays__mute_for_one_year">Mute for 1 year</string>
 
     <string name="arrays__settings_default">Settings default</string>
     <string name="arrays__enabled">Enabled</string>

--- a/src/org/thoughtcrime/securesms/MuteDialog.java
+++ b/src/org/thoughtcrime/securesms/MuteDialog.java
@@ -21,11 +21,12 @@ public class MuteDialog extends AlertDialogWrapper {
         final long muteUntil;
 
         switch (which) {
-          case 0:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1); break;
-          case 1:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2); break;
-          case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);  break;
-          case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);  break;
-          default: muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1); break;
+          case 0:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);  break;
+          case 1:  muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(2);  break;
+          case 2:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(1);   break;
+          case 3:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(7);   break;
+          case 4:  muteUntil = System.currentTimeMillis() + TimeUnit.DAYS.toMillis(365); break;
+          default: muteUntil = System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1);  break;
         }
 
         listener.onMuted(muteUntil);


### PR DESCRIPTION
Some people like to have groups always muted. Previously, it was only possible to mute them one week at a time, which can get cumbersome. This adds the option to mute them for one year to the list.