### PR TITLE
Android Wear notifications [WIP]

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -30,7 +30,6 @@ import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.AsyncTask;
-import android.os.Build;
 import android.os.Bundle;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
@@ -654,6 +653,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onClick(DialogInterface dialog, int which) {
         if (threadId > 0) {
           DatabaseFactory.getThreadDatabase(ConversationActivity.this).deleteConversation(threadId);
+          MessageNotifier.updateNotificationCancelRead(ConversationActivity.this, masterSecret, threadId); // TODO necessary?
         }
         composeText.getText().clear();
         threadId = -1;
@@ -1202,8 +1202,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     new AsyncTask<Long, Void, Void>() {
       @Override
       protected Void doInBackground(Long... params) {
-        DatabaseFactory.getThreadDatabase(ConversationActivity.this).setRead(params[0]);
-        MessageNotifier.updateNotification(ConversationActivity.this, masterSecret);
+        Long threadId = params[0];
+        DatabaseFactory.getThreadDatabase(ConversationActivity.this).setRead(threadId);
+        MessageNotifier.updateNotificationCancelRead(ConversationActivity.this, masterSecret, threadId);
         return null;
       }
     }.execute(threadId);

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -42,6 +42,8 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
+import java.util.Set;
+
 public class ConversationListActivity extends PassphraseRequiredActionBarActivity
     implements ConversationListFragment.ConversationSelectedListener
 {
@@ -201,8 +203,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     new AsyncTask<Void, Void, Void>() {
       @Override
       protected Void doInBackground(Void... params) {
+        Set<Long> unreadThreadIds = MessageNotifier.unreadThreadIds(ConversationListActivity.this, masterSecret);
+
         DatabaseFactory.getThreadDatabase(ConversationListActivity.this).setAllThreadsRead();
-        MessageNotifier.updateNotification(ConversationListActivity.this, masterSecret);
+        MessageNotifier.updateNotificationCancelRead(ConversationListActivity.this, masterSecret, unreadThreadIds);
         return null;
       }
     }.execute();

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -200,8 +200,10 @@ public class ConversationListFragment extends Fragment
 
             @Override
             protected Void doInBackground(Void... params) {
+              Set<Long> unreadThreadIds = MessageNotifier.unreadThreadIds(getActivity(), masterSecret);
+
               DatabaseFactory.getThreadDatabase(getActivity()).deleteConversations(selectedConversations);
-              MessageNotifier.updateNotification(getActivity(), masterSecret);
+              MessageNotifier.updateNotificationCancelRead(getActivity(), masterSecret, unreadThreadIds);
               return null;
             }
 

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -87,7 +87,7 @@ public class RegistrationActivity extends BaseActionBarActivity {
     this.createButton.setOnClickListener(new CreateButtonListener());
     this.skipButton.setOnClickListener(new CancelButtonListener());
 
-    if (getIntent().getBooleanExtra("cancel_button", false)) {
+    if (getIntent().getBooleanExtra("cancel_button", true)) { // FIXME
       this.skipButton.setVisibility(View.VISIBLE);
     } else {
       this.skipButton.setVisibility(View.INVISIBLE);

--- a/src/org/thoughtcrime/securesms/jobs/TrimThreadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/TrimThreadJob.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.notifications.MessageNotifier;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.jobqueue.Job;
 import org.whispersystems.jobqueue.JobParameters;
@@ -51,6 +52,7 @@ public class TrimThreadJob extends Job {
       return;
 
     DatabaseFactory.getThreadDatabase(context).trimThread(threadId, threadLengthLimit);
+    MessageNotifier.updateNotificationCancelRead(context, null, threadId); // TODO update notifications here?
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -1,7 +1,5 @@
 package org.thoughtcrime.securesms.notifications;
 
-import android.app.NotificationManager;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
@@ -10,6 +8,9 @@ import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
 
@@ -27,20 +28,20 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
     final long[] threadIds = intent.getLongArrayExtra(THREAD_IDS_EXTRA);
 
     if (threadIds != null) {
-      Log.w("TAG", "threadIds length: " + threadIds.length);
-
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-                                   .cancel(MessageNotifier.NOTIFICATION_ID);
+      Log.w(TAG, "threadIds length: " + threadIds.length);
 
       new AsyncTask<Void, Void, Void>() {
         @Override
         protected Void doInBackground(Void... params) {
+          Set<Long> threadIdsAsSet = new HashSet<Long>();
+
           for (long threadId : threadIds) {
             Log.w(TAG, "Marking as read: " + threadId);
             DatabaseFactory.getThreadDatabase(context).setRead(threadId);
+            threadIdsAsSet.add(threadId);
           }
 
-          MessageNotifier.updateNotification(context, masterSecret);
+          MessageNotifier.updateNotificationCancelRead(context, masterSecret, threadIdsAsSet);
           return null;
         }
       }.execute();

--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 public class MultipleRecipientNotificationBuilder extends AbstractNotificationBuilder {
 
+  public static final String NOTIFICATION_GROUP_KEY_MESSAGES = "group_key_messages";
+
   private final List<CharSequence> messageBodies = new LinkedList<>();
 
   public MultipleRecipientNotificationBuilder(Context context, NotificationPrivacyPreference privacy) {
@@ -31,6 +33,8 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(NOTIFICATION_GROUP_KEY_MESSAGES);
+    setGroupSummary(true);
   }
 
   public void setMessageCount(int messageCount, int threadCount) {

--- a/src/org/thoughtcrime/securesms/notifications/OrderedThreadNotifications.java
+++ b/src/org/thoughtcrime/securesms/notifications/OrderedThreadNotifications.java
@@ -1,0 +1,23 @@
+package org.thoughtcrime.securesms.notifications;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+public class OrderedThreadNotifications {
+
+    private final LinkedHashSet<Long> orderedThreads;
+    private final Map<Long, NotificationState> threadNotificationMapping;
+
+    public OrderedThreadNotifications(LinkedHashSet<Long> orderedThreads, Map<Long, NotificationState> threadNotificationMapping) {
+        this.orderedThreads = orderedThreads;
+        this.threadNotificationMapping = threadNotificationMapping;
+    }
+
+    public LinkedHashSet<Long> getOrderedThreads() {
+        return orderedThreads;
+    }
+
+    public NotificationState getNotificationState(Long threadId) {
+        return threadNotificationMapping.get(threadId);
+    }
+}

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -51,6 +51,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(MultipleRecipientNotificationBuilder.NOTIFICATION_GROUP_KEY_MESSAGES);
   }
 
   public void setSender(@NonNull Recipient recipient) {

--- a/src/org/thoughtcrime/securesms/notifications/WearReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/WearReplyReceiver.java
@@ -35,8 +35,6 @@ import org.thoughtcrime.securesms.sms.OutgoingTextMessage;
 
 import java.util.LinkedList;
 
-import ws.com.google.android.mms.pdu.PduBody;
-
 /**
  * Get the response text from the Wearable Device and sends an message as a reply
  */
@@ -75,7 +73,7 @@ public class WearReplyReceiver extends MasterSecretBroadcastReceiver {
           }
 
           DatabaseFactory.getThreadDatabase(context).setRead(threadId);
-          MessageNotifier.updateNotification(context, masterSecret);
+          MessageNotifier.updateNotificationCancelRead(context, masterSecret, threadId);
 
           return null;
         }

--- a/src/org/thoughtcrime/securesms/util/Trimmer.java
+++ b/src/org/thoughtcrime/securesms/util/Trimmer.java
@@ -8,6 +8,9 @@ import android.widget.Toast;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
+import org.thoughtcrime.securesms.notifications.MessageNotifier;
+
+import java.util.Set;
 
 public class Trimmer {
 
@@ -37,7 +40,10 @@ public class Trimmer {
 
     @Override
     protected Void doInBackground(Integer... params) {
+      Set<Long> unreadThreadIds = MessageNotifier.unreadThreadIds(context, null);
+
       DatabaseFactory.getThreadDatabase(context).trimAllThreads(params[0], this);
+      MessageNotifier.updateNotificationCancelRead(context, null, unreadThreadIds); // TODO update notifications here?
       return null;
     }
 


### PR DESCRIPTION
:warning: **This merge request is currently work in progress. Do not merge.**

@dr03lf and I are working on it.


# Changes
One stack group element per contact is displayed.
Messages appear in the order they were received (latest message bottom).

Notifications are ordered by the time of latest message arrival.
Contacts with the newest message appear on top.

**Currently alarms for messages are disabled.**

If an alarm (ringtone, vibration) is set on the summary notification,
every single thread message appears on the handheld.

If an alarm is set on the single thread notifications, the more
notifications arrive, the more alarms are kicked off.

# TODOs
* [ ] Enable alarms for incoming messages

This merge request implements feature https://github.com/WhisperSystems/Signal-Android/issues/2525.