### PR TITLE
Always play "sonar" on call initialization

### DIFF
--- a/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
@@ -116,6 +116,7 @@ public class OutgoingRinger implements MediaPlayer.OnCompletionListener, MediaPl
       mediaPlayer.stop();
     } catch( IllegalStateException e ) {
     }
+    currentSoundID = -1;
   }
 
   private void stop( int soundID ) {


### PR DESCRIPTION
If "sonar" was the last sound played on the last call, it wasn't being played on the next calling attempt due to [this line in OutgoingRinger](https://github.com/WhisperSystems/Signal-Android/blob/ca5da2cf2ad038c9ee7a505e5b4ef0e323159a4b/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java#L82).

Steps to reproduce:
- B has no internet connection
- A tries to call B, hears "sonar" ringer
- A hangs up, tries to call B again
- no "sonar" ringer :(