### PR TITLE
Android Wear notifications

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1026,6 +1026,8 @@
     <string name="preferences_chats__message_trimming">Message trimming</string>
     <string name="preferences_advanced__use_system_emoji">Use system emoji</string>
     <string name="preferences_advanced__disable_signal_built_in_emoji_support">Disable Signal\'s built-in emoji support</string>
+    <string name="preferences_advanced__android_wear_notification_workaround">Android Wear notification workaround</string>
+    <string name="preferences_advanced__suppress_heads-up_notification_on_handheld">Suppress heads-up notification on handheld (affects Android 5.0, 5.1)</string>
 
     <!-- **************************************** -->
     <!-- menus -->

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -18,6 +18,12 @@
                         android:title="@string/preferences_advanced__use_system_emoji"
                         android:summary="@string/preferences_advanced__disable_signal_built_in_emoji_support" />
 
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+        android:defaultValue="false"
+        android:key="pref_bug_130689_notification_fix"
+        android:summary="@string/preferences_advanced__suppress_heads-up_notification_on_handheld"
+        android:title="@string/preferences_advanced__android_wear_notification_workaround"/>
+
     <Preference android:key="pref_choose_identity"
                 android:title="@string/preferences__choose_identity"
                 android:summary="@string/preferences__choose_your_contact_entry_from_the_contacts_list"/>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1211,8 +1211,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     new AsyncTask<Long, Void, Void>() {
       @Override
       protected Void doInBackground(Long... params) {
-        DatabaseFactory.getThreadDatabase(ConversationActivity.this).setRead(params[0]);
-        MessageNotifier.updateNotification(ConversationActivity.this, masterSecret);
+        Long threadId = params[0];
+        DatabaseFactory.getThreadDatabase(ConversationActivity.this).setRead(threadId);
+        MessageNotifier.updateNotificationCancelRead(ConversationActivity.this, masterSecret, threadId);
         return null;
       }
     }.execute(threadId);

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -43,6 +43,8 @@ import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 
+import java.util.Set;
+
 public class ConversationListActivity extends PassphraseRequiredActionBarActivity
     implements ConversationListFragment.ConversationSelectedListener
 {
@@ -200,8 +202,10 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
     new AsyncTask<Void, Void, Void>() {
       @Override
       protected Void doInBackground(Void... params) {
+        Set<Long> unreadThreadIds = MessageNotifier.unreadThreadIds(ConversationListActivity.this, masterSecret);
+
         DatabaseFactory.getThreadDatabase(ConversationListActivity.this).setAllThreadsRead();
-        MessageNotifier.updateNotification(ConversationListActivity.this, masterSecret);
+        MessageNotifier.updateNotificationCancelRead(ConversationListActivity.this, masterSecret, unreadThreadIds);
         return null;
       }
     }.execute();

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -273,8 +273,10 @@ public class ConversationListFragment extends Fragment
 
             @Override
             protected Void doInBackground(Void... params) {
+              Set<Long> unreadThreadIds = MessageNotifier.unreadThreadIds(getActivity(), masterSecret);
+
               DatabaseFactory.getThreadDatabase(getActivity()).deleteConversations(selectedConversations);
-              MessageNotifier.updateNotification(getActivity(), masterSecret);
+              MessageNotifier.updateNotificationCancelRead(getActivity(), masterSecret, unreadThreadIds);
               return null;
             }
 

--- a/src/org/thoughtcrime/securesms/jobs/TrimThreadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/TrimThreadJob.java
@@ -19,7 +19,10 @@ package org.thoughtcrime.securesms.jobs;
 import android.content.Context;
 import android.util.Log;
 
+import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.notifications.MessageNotifier;
+import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.jobqueue.Job;
 import org.whispersystems.jobqueue.JobParameters;
@@ -51,6 +54,9 @@ public class TrimThreadJob extends Job {
       return;
 
     DatabaseFactory.getThreadDatabase(context).trimThread(threadId, threadLengthLimit);
+
+    final MasterSecret masterSecret = KeyCachingService.getMasterSecret(context);
+    MessageNotifier.updateNotificationCancelRead(context, masterSecret, threadId);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -1,7 +1,5 @@
 package org.thoughtcrime.securesms.notifications;
 
-import android.app.NotificationManager;
-import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
@@ -10,6 +8,9 @@ import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
 
@@ -27,20 +28,20 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
     final long[] threadIds = intent.getLongArrayExtra(THREAD_IDS_EXTRA);
 
     if (threadIds != null) {
-      Log.w("TAG", "threadIds length: " + threadIds.length);
-
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-                                   .cancel(MessageNotifier.NOTIFICATION_ID);
+      Log.w(TAG, "threadIds length: " + threadIds.length);
 
       new AsyncTask<Void, Void, Void>() {
         @Override
         protected Void doInBackground(Void... params) {
+          Set<Long> threadIdsAsSet = new HashSet<Long>();
+
           for (long threadId : threadIds) {
             Log.w(TAG, "Marking as read: " + threadId);
             DatabaseFactory.getThreadDatabase(context).setRead(threadId);
+            threadIdsAsSet.add(threadId);
           }
 
-          MessageNotifier.updateNotification(context, masterSecret);
+          MessageNotifier.updateNotificationCancelRead(context, masterSecret, threadIdsAsSet);
           return null;
         }
       }.execute();

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -17,6 +17,7 @@
 package org.thoughtcrime.securesms.notifications;
 
 import android.app.AlarmManager;
+import android.app.Notification;
 import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
@@ -32,6 +33,8 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.app.NotificationManagerCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
@@ -55,10 +58,16 @@ import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.util.SpanUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+import org.whispersystems.libaxolotl.util.guava.Function;
+import org.whispersystems.libaxolotl.util.guava.Optional;
 import org.whispersystems.textsecure.api.messages.TextSecureEnvelope;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import me.leolin.shortcutbadger.ShortcutBadger;
@@ -95,9 +104,34 @@ public class MessageNotifier {
       intent.setData((Uri.parse("custom://" + System.currentTimeMillis())));
 
       FailedNotificationBuilder builder = new FailedNotificationBuilder(context, TextSecurePreferences.getNotificationPrivacy(context), intent);
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-        .notify((int)threadId, builder.build());
+      NotificationManagerCompat.from(context).notify((int)threadId, builder.build());
     }
+  }
+
+  /**
+   * See {@link #updateNotificationCancelRead(Context, MasterSecret, Set)}.
+   *
+   * @param context Current context
+   * @param masterSecret Master secret
+   * @param threadId Thread id to cancel notification for
+   */
+  public static void updateNotificationCancelRead(@NonNull Context context, @Nullable MasterSecret masterSecret, @NonNull Long threadId) {
+    updateNotificationCancelRead(context, masterSecret, new HashSet<Long>(Arrays.asList(threadId)));
+  }
+
+  /**
+   * Cancels the notifications for the given threadIds and calls {@link #updateNotification(Context, MasterSecret)}.
+   *
+   * @param context Current context
+   * @param masterSecret Master secret
+   * @param threadIds Thread ids to cancel notifications for
+   */
+  public static void updateNotificationCancelRead(@NonNull Context context, @Nullable MasterSecret masterSecret, @NonNull Set<Long> threadIds) {
+    for(Long threadId : threadIds) {
+      NotificationManagerCompat.from(context).cancel(threadId + "", NOTIFICATION_ID);
+    }
+
+    updateNotification(context, masterSecret);
   }
 
   public static void updateNotification(@NonNull Context context, @Nullable MasterSecret masterSecret) {
@@ -152,12 +186,19 @@ public class MessageNotifier {
     }
   }
 
-  private static void updateNotification(@NonNull  Context context,
-                                         @Nullable MasterSecret masterSecret,
-                                         boolean signal,
-                                         boolean includePushDatabase,
-                                         int     reminderCount)
-  {
+  public static Set<Long> unreadThreadIds(@NonNull  Context context,
+                                           @Nullable MasterSecret masterSecret) {
+    return currentNotificationState(context, masterSecret, false).transform(new Function<NotificationState, Set<Long>>() {
+      @Override
+      public Set<Long> apply(NotificationState input) {
+        return input.getThreads();
+      }
+    }).or(new HashSet<Long>());
+  }
+
+  private static Optional<NotificationState> currentNotificationState(@NonNull  Context context,
+                                                           @Nullable MasterSecret masterSecret,
+                                                           boolean includePushDatabase) {
     Cursor telcoCursor = null;
     Cursor pushCursor  = null;
 
@@ -166,13 +207,11 @@ public class MessageNotifier {
       pushCursor  = DatabaseFactory.getPushDatabase(context).getPending();
 
       if ((telcoCursor == null || telcoCursor.isAfterLast()) &&
-          (pushCursor == null || pushCursor.isAfterLast()))
-      {
-        ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+              (pushCursor == null || pushCursor.isAfterLast())) {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
         updateBadge(context, 0);
         clearReminder(context);
-        return;
+        return Optional.absent();
       }
 
       NotificationState notificationState = constructNotificationState(context, masterSecret, telcoCursor);
@@ -181,10 +220,36 @@ public class MessageNotifier {
         appendPushNotificationState(context, notificationState, pushCursor);
       }
 
-      if (notificationState.hasMultipleThreads()) {
-        sendMultipleThreadNotification(context, notificationState, signal);
+      return Optional.of(notificationState);
+    } finally {
+      if (telcoCursor != null) telcoCursor.close();
+      if (pushCursor != null)  pushCursor.close();
+    }
+  }
+
+  private static void updateNotification(@NonNull  Context context,
+                                         @Nullable MasterSecret masterSecret,
+                                         boolean signal,
+                                         boolean includePushDatabase,
+                                         int     reminderCount)
+  {
+    Optional<NotificationState> notificationStateOption = currentNotificationState(context, masterSecret, includePushDatabase);
+
+    if(!notificationStateOption.isPresent())
+      return;
+
+    boolean bug130689NotificationFixEnabled = TextSecurePreferences.isBug130689NotificationFixEnabled(context);
+    boolean hasWearSupport = hasWearSupport();
+    boolean hasNotificationSummaryAlarmBug = hasNotificationSummaryAlarmBug();
+    boolean displayWearableNotifications = hasWearSupport && (!hasNotificationSummaryAlarmBug || bug130689NotificationFixEnabled);
+    boolean displayBugFixNotification = hasWearSupport && hasNotificationSummaryAlarmBug && bug130689NotificationFixEnabled;
+
+    NotificationState notificationState = notificationStateOption.get();
+
+    if (notificationState.hasMultipleThreads()) {
+        sendMultipleThreadNotification(context, masterSecret, notificationState, signal, displayBugFixNotification, displayWearableNotifications);
       } else {
-        sendSingleThreadNotification(context, masterSecret, notificationState, signal);
+        sendSingleThreadNotification(context, masterSecret, notificationState, signal, displayWearableNotifications);
       }
 
       updateBadge(context, notificationState.getMessageCount());
@@ -192,23 +257,13 @@ public class MessageNotifier {
       if (signal) {
         scheduleReminder(context, reminderCount);
       }
-    } finally {
-      if (telcoCursor != null) telcoCursor.close();
-      if (pushCursor != null)  pushCursor.close();
-    }
+
   }
 
-  private static void sendSingleThreadNotification(@NonNull  Context context,
+  private static SingleRecipientNotificationBuilder singleThreadNotificationBuilder(@NonNull  Context context,
                                                    @Nullable MasterSecret masterSecret,
                                                    @NonNull  NotificationState notificationState,
-                                                   boolean signal)
-  {
-    if (notificationState.getNotifications().isEmpty()) {
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
-      return;
-    }
-
+                                                   boolean signal) {
     SingleRecipientNotificationBuilder builder       = new SingleRecipientNotificationBuilder(context, masterSecret, TextSecurePreferences.getNotificationPrivacy(context));
     List<NotificationItem>             notifications = notificationState.getNotifications();
     Recipients                         recipients    = notifications.get(0).getRecipients();
@@ -223,7 +278,7 @@ public class MessageNotifier {
     if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.addActions(masterSecret,
-                       notificationState.getMarkAsReadIntent(context),
+                       notificationState.getMarkAsReadIntent(context, (int) notifications.get(0).getThreadId()),
                        notificationState.getQuickReplyIntent(context, notifications.get(0).getRecipients()),
                        notificationState.getWearableReplyIntent(context, notifications.get(0).getRecipients()));
 
@@ -240,13 +295,56 @@ public class MessageNotifier {
                         notifications.get(0).getText());
     }
 
-    ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(NOTIFICATION_ID, builder.build());
+    return builder;
+  }
+
+  public static boolean hasWearSupport() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2;
+  }
+
+  private static void sendSingleThreadNotification(@NonNull Context context,
+                                                   @Nullable MasterSecret masterSecret,
+                                                   @NonNull NotificationState notificationState,
+                                                   boolean signal,
+                                                   boolean displayWearableNotifications)
+  {
+    if (notificationState.getNotifications().isEmpty()) {
+      NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
+
+      return;
+    }
+
+    Long threadId = notificationState.getNotifications().get(0).getThreadId();
+
+    SingleRecipientNotificationBuilder wearNotificationBuilder = singleThreadNotificationBuilder(context, masterSecret, notificationState, signal);
+
+    if(hasWearSupport()) {
+      NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID);
+
+      if(displayWearableNotifications) {
+        NotificationManagerCompat.from(context).notify(threadId + "", NOTIFICATION_ID, wearNotificationBuilder.build());
+      } else {
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, wearNotificationBuilder.build());
+      }
+
+
+      if(doesNotDisplayNonSummaryGroupNotifications()) {
+        SingleRecipientNotificationBuilder builder = singleThreadNotificationBuilder(context, masterSecret, notificationState, true);
+        builder.setGroupSummary(true);
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, builder.build());
+      }
+    } else {
+      NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, wearNotificationBuilder.build());
+    }
+
   }
 
   private static void sendMultipleThreadNotification(@NonNull  Context context,
+                                                     @Nullable MasterSecret masterSecret,
                                                      @NonNull  NotificationState notificationState,
-                                                     boolean signal)
+                                                     boolean signal,
+                                                     boolean displayBugfixNotification,
+                                                     boolean displayWearableNotifications)
   {
     MultipleRecipientNotificationBuilder builder       = new MultipleRecipientNotificationBuilder(context, TextSecurePreferences.getNotificationPrivacy(context));
     List<NotificationItem>               notifications = notificationState.getNotifications();
@@ -257,7 +355,7 @@ public class MessageNotifier {
     long timestamp = notifications.get(0).getTimestamp();
     if (timestamp != 0) builder.setWhen(timestamp);
 
-    builder.addActions(notificationState.getMarkAsReadIntent(context));
+    builder.addActions(notificationState.getMarkAllAsReadIntent(context));
 
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
 
@@ -269,10 +367,31 @@ public class MessageNotifier {
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getText());
+
+      if(displayBugfixNotification) {
+        builder.setPriority(NotificationCompat.PRIORITY_DEFAULT);
+      }
     }
 
-    ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(NOTIFICATION_ID, builder.build());
+    if(displayWearableNotifications) {
+      OrderedThreadNotifications notificationStates = notificationState.orderedThreadNotifications();
+
+      NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+
+      for (Long threadId : notificationStates.getOrderedThreads()) {
+
+        NotificationState state = notificationStates.getNotificationState(threadId);
+        SingleRecipientNotificationBuilder singleThreadNotificationBuilder = singleThreadNotificationBuilder(context, masterSecret, state, false);
+
+        notificationManager.notify(threadId + "", NOTIFICATION_ID, singleThreadNotificationBuilder.build());
+      }
+    } else {
+      builder.setGroup("");
+      builder.setGroupSummary(false);
+    }
+
+    NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, builder.build());
+
   }
 
   private static void sendInThreadNotification(Context context, Recipients recipients) {
@@ -424,6 +543,27 @@ public class MessageNotifier {
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, PendingIntent.FLAG_CANCEL_CURRENT);
     AlarmManager  alarmManager  = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
     alarmManager.cancel(pendingIntent);
+  }
+
+  /**
+   * On certain Android versions (5.0, 5.1) when adding an alarm (ringtone, vibration) to a summary notification, all other non-summary notifications in this group are displayed as well.
+   * <br><br>
+   * This bug was reported at https://code.google.com/p/android/issues/detail?id=130689
+   *
+   * @return <b>true</b> if the device is affected, <b>false</b> otherwise
+   */
+  private static boolean hasNotificationSummaryAlarmBug() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1;
+  }
+
+  /**
+   * On Android prior to 5.0, non-summary notifications in a group are not displayed on the handheld.
+   * <br><br>
+   * This bug was reported at https://code.google.com/p/android/issues/detail?id=159947
+   * @return <b>true</b> if the device is affected, <b>false</b> otherwise
+   */
+  private static boolean doesNotDisplayNonSummaryGroupNotifications() {
+    return Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
   }
 
   public static class ReminderReceiver extends BroadcastReceiver {

--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -19,6 +19,8 @@ import java.util.List;
 
 public class MultipleRecipientNotificationBuilder extends AbstractNotificationBuilder {
 
+  public static final String NOTIFICATION_GROUP_KEY_MESSAGES = "group_key_messages";
+
   private final List<CharSequence> messageBodies = new LinkedList<>();
 
   public MultipleRecipientNotificationBuilder(Context context, NotificationPrivacyPreference privacy) {
@@ -31,6 +33,8 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(NOTIFICATION_GROUP_KEY_MESSAGES);
+    setGroupSummary(true);
   }
 
   public void setMessageCount(int messageCount, int threadCount) {

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -12,9 +12,14 @@ import org.thoughtcrime.securesms.ConversationPopupActivity;
 import org.thoughtcrime.securesms.database.RecipientPreferenceDatabase.VibrateState;
 import org.thoughtcrime.securesms.recipients.Recipients;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
 import java.util.Set;
 
 public class NotificationState {
@@ -70,7 +75,31 @@ public class NotificationState {
     return notifications;
   }
 
-  public PendingIntent getMarkAsReadIntent(Context context) {
+  public OrderedThreadNotifications orderedThreadNotifications() {
+    LinkedHashSet<Long> orderedThreads = new LinkedHashSet<>();
+    Map<Long, NotificationState> threadNotificationMapping = new HashMap<>();
+
+    ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
+
+    while(iterator.hasPrevious()) {
+      NotificationItem item = iterator.previous();
+      Long threadId = item.getThreadId();
+
+      orderedThreads.remove(threadId);
+      orderedThreads.add(threadId);
+
+      if(!threadNotificationMapping.containsKey(threadId)) {
+        threadNotificationMapping.put(threadId, new NotificationState());
+      }
+
+      NotificationState notificationState = threadNotificationMapping.get(threadId);
+      notificationState.addNotification(item);
+    }
+
+    return new OrderedThreadNotifications(orderedThreads, threadNotificationMapping);
+  }
+
+  public PendingIntent getMarkAsReadIntent(Context context, Integer threadId) {
     long[] threadArray = new long[threads.size()];
     int    index       = 0;
 
@@ -89,7 +118,11 @@ public class NotificationState {
     Log.w("NotificationState", "Pending array off intent length: " +
         intent.getLongArrayExtra("thread_ids").length);
 
-    return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getBroadcast(context, threadId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+  }
+
+  public PendingIntent getMarkAllAsReadIntent(Context context) {
+    return getMarkAsReadIntent(context, 0);
   }
 
   public PendingIntent getWearableReplyIntent(Context context, Recipients recipients) {
@@ -114,4 +147,7 @@ public class NotificationState {
   }
 
 
+  public Set<Long> getThreads() {
+    return threads;
+  }
 }

--- a/src/org/thoughtcrime/securesms/notifications/OrderedThreadNotifications.java
+++ b/src/org/thoughtcrime/securesms/notifications/OrderedThreadNotifications.java
@@ -1,0 +1,23 @@
+package org.thoughtcrime.securesms.notifications;
+
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+public class OrderedThreadNotifications {
+
+    private final LinkedHashSet<Long> orderedThreads;
+    private final Map<Long, NotificationState> threadNotificationMapping;
+
+    public OrderedThreadNotifications(LinkedHashSet<Long> orderedThreads, Map<Long, NotificationState> threadNotificationMapping) {
+        this.orderedThreads = orderedThreads;
+        this.threadNotificationMapping = threadNotificationMapping;
+    }
+
+    public LinkedHashSet<Long> getOrderedThreads() {
+        return orderedThreads;
+    }
+
+    public NotificationState getNotificationState(Long threadId) {
+        return threadNotificationMapping.get(threadId);
+    }
+}

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -53,6 +53,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(MultipleRecipientNotificationBuilder.NOTIFICATION_GROUP_KEY_MESSAGES);
   }
 
   public void setThread(@NonNull Recipients recipients) {

--- a/src/org/thoughtcrime/securesms/notifications/WearReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/WearReplyReceiver.java
@@ -35,8 +35,6 @@ import org.thoughtcrime.securesms.sms.OutgoingTextMessage;
 
 import java.util.LinkedList;
 
-import ws.com.google.android.mms.pdu.PduBody;
-
 /**
  * Get the response text from the Wearable Device and sends an message as a reply
  */
@@ -75,7 +73,7 @@ public class WearReplyReceiver extends MasterSecretBroadcastReceiver {
           }
 
           DatabaseFactory.getThreadDatabase(context).setRead(threadId);
-          MessageNotifier.updateNotification(context, masterSecret);
+          MessageNotifier.updateNotificationCancelRead(context, masterSecret, threadId);
 
           return null;
         }

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -105,6 +105,8 @@ public class TextSecurePreferences {
     return getIntegerPreference(context, DIRECT_CAPTURE_CAMERA_ID, CameraInfo.CAMERA_FACING_FRONT);
   }
 
+  public  static final String BUG_130689_NOTIFICATION_FIX_PREF = "pref_bug_130689_notification_fix";
+
   public static void setMultiDevice(Context context, boolean value) {
     setBooleanPreference(context, MULTI_DEVICE_PROVISIONED_PREF, value);
   }
@@ -494,6 +496,10 @@ public class TextSecurePreferences {
 
   public static boolean isSystemEmojiPreferred(Context context) {
     return getBooleanPreference(context, SYSTEM_EMOJI_PREF, false);
+  }
+
+  public static boolean isBug130689NotificationFixEnabled(Context context) {
+    return getBooleanPreference(context, BUG_130689_NOTIFICATION_FIX_PREF, false);
   }
 
   public static @NonNull Set<String> getMobileMediaDownloadAllowed(Context context) {

--- a/src/org/thoughtcrime/securesms/util/Trimmer.java
+++ b/src/org/thoughtcrime/securesms/util/Trimmer.java
@@ -6,8 +6,13 @@ import android.os.AsyncTask;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
+import org.thoughtcrime.securesms.notifications.MessageNotifier;
+import org.thoughtcrime.securesms.service.KeyCachingService;
+
+import java.util.Set;
 
 public class Trimmer {
 
@@ -37,7 +42,12 @@ public class Trimmer {
 
     @Override
     protected Void doInBackground(Integer... params) {
+      Set<Long> unreadThreadIds = MessageNotifier.unreadThreadIds(context, null);
+
       DatabaseFactory.getThreadDatabase(context).trimAllThreads(params[0], this);
+
+      final MasterSecret masterSecret = KeyCachingService.getMasterSecret(context);
+      MessageNotifier.updateNotificationCancelRead(context, masterSecret, unreadThreadIds);
       return null;
     }
 


### PR DESCRIPTION
Successor of https://github.com/WhisperSystems/Signal-Android/pull/4472

One stack group element per contact is displayed.
Messages appear in the order they were received (latest message bottom).

Notifications are ordered by the time of latest message arrival.
Contacts with the newest message appear on top.

#### Bug on Android 5.0 and 5.1

If an alarm (ringtone, vibration) is set on the summary notification,
every single thread message appears on the handheld.
If an alarm is set on the single thread notifications, the more
notifications arrive, the more alarms are kicked off.

To work around the issue, the summary notification's priority is set to
'default' instead of 'high', which suppresses the heads-up notification.
This notification is shown in the Android notification bar nevertheless.

Users enabling this workaround will often read notifications on the
wearable and therefore not miss the heads-up notification.

On older / newer devices, this setting has no effect, the summary
notification is displayed as usual.

See https://code.google.com/p/android/issues/detail?id=130689

Developed with Sebastian Chlan <sebastian.chlan@gmail.com> - @dr03lf

// FREEBIE