### PR TITLE
fail faster in FileNotFoundException case

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
@@ -25,6 +25,7 @@ import org.whispersystems.textsecure.api.push.TextSecureAddress;
 import org.whispersystems.textsecure.api.push.exceptions.UnregisteredUserException;
 import org.whispersystems.textsecure.api.util.InvalidNumberException;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
@@ -127,6 +128,8 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
     } catch (InvalidNumberException | UnregisteredUserException e) {
       Log.w(TAG, e);
       throw new InsecureFallbackApprovalException(e);
+    } catch (FileNotFoundException e) {
+      throw new UndeliverableMessageException("media missing");
     } catch (IOException e) {
       Log.w(TAG, e);
       throw new RetryLaterException(e);


### PR DESCRIPTION
I actually couldn't reproduce #3053 in 3.3.1, but either way it does make more sense to fail immediately without retry if we receive a FileNotFoundException, so adding this in for extra sanity.