### PR TITLE
Don't show images without data under "all images"

### DIFF
--- a/src/org/thoughtcrime/securesms/database/ImageDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ImageDatabase.java
@@ -26,7 +26,8 @@ public class ImageDatabase extends Database {
         + "WHERE " + AttachmentDatabase.MMS_ID + " IN (SELECT " + MmsSmsColumns.ID
         + " FROM " + MmsDatabase.TABLE_NAME
         + " WHERE " + MmsDatabase.THREAD_ID + " = ?) AND "
-        + AttachmentDatabase.CONTENT_TYPE + " LIKE 'image/%' "
+        + AttachmentDatabase.CONTENT_TYPE + " LIKE 'image/%' AND "
+        + AttachmentDatabase.DATA + " IS NOT NULL "
         + "ORDER BY " + AttachmentDatabase.TABLE_NAME + "." + AttachmentDatabase.ROW_ID + " DESC";
 
   public ImageDatabase(Context context, SQLiteOpenHelper databaseHelper) {


### PR DESCRIPTION
This affects images
- that have yet to be downloaded (using media download controls)
- that are currently being downloaded
- that failed to download

Before:
![screenshot from 2015-11-11 13-46-30](https://cloud.githubusercontent.com/assets/264472/11134197/422103d8-899b-11e5-8897-2aa5f697b478.png)

After:
![screenshot from 2015-11-12 23-57-39](https://cloud.githubusercontent.com/assets/264472/11134204/4afd9bce-899b-11e5-9eff-7621920874fa.png)