### PR TITLE
add recipients.removeListener in onDestroy()

### DIFF
--- a/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
+++ b/src/org/thoughtcrime/securesms/MessageDetailsActivity.java
@@ -72,6 +72,7 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
   public final static String RECIPIENTS_IDS_EXTRA = "recipients_ids";
 
   private MasterSecret     masterSecret;
+  private Recipients       recipients;
   private boolean          isPushGroup;
   private ConversationItem conversationItem;
   private ViewGroup        itemParent;
@@ -114,7 +115,7 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
   private void initializeActionBar() {
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
 
-    Recipients recipients = RecipientFactory.getRecipientsForIds(this, getIntent().getLongArrayExtra(RECIPIENTS_IDS_EXTRA), true);
+    recipients = RecipientFactory.getRecipientsForIds(this, getIntent().getLongArrayExtra(RECIPIENTS_IDS_EXTRA), true);
     recipients.addListener(this);
 
     setActionBarColor(recipients.getColor());
@@ -136,6 +137,12 @@ public class MessageDetailsActivity extends PassphraseRequiredActionBarActivity 
         setActionBarColor(recipients.getColor());
       }
     });
+  }
+
+  @Override
+  protected void onDestroy() {
+    super.onDestroy();
+    if (recipients != null) recipients.removeListener(this);
   }
 
   private void initializeResources() {


### PR DESCRIPTION
I added the listener in #3580 without adding `removeListener()`, but I guess this is necessary?