### PR TITLE
Remove funky halloween easter egg

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -442,7 +442,9 @@ public class ConversationItem extends LinearLayout
 
   @Override
   public void onModified(Recipients recipient) {
-    onModified(recipient.getPrimaryRecipient());
+    if (!recipient.isGroupRecipient()) {
+      onModified(recipient.getPrimaryRecipient());
+    }
   }
 
   private class AttachmentDownloadClickListener implements SlideClickListener {


### PR DESCRIPTION
Fixes #4420

// FREEBIE

Not entirely sure if this is a good way to fix this - feels a bit more like a workaround - but I think there's no context in which updating the conversation bubbles & avatars with group recipient info makes sense, so at least this shouldn't break anything.