### PR TITLE
Make sure the compose text field always has focus

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -925,6 +925,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     composeText.setOnClickListener(composeKeyPressedListener);
     composeText.setOnFocusChangeListener(composeKeyPressedListener);
 
+    composeText.requestFocus();
+
     if (QuickAttachmentDrawer.isDeviceSupported(this)) {
       quickAttachmentDrawer.setListener(this);
       quickAttachmentToggle.setOnClickListener(new QuickAttachmentToggleListener());


### PR DESCRIPTION
Fixes #4527

// FREEBIE

Side note: This adds a blinking cursor in the text field, even when entering the conversation the normal way. I hope this is acceptable.