### PR TITLE
Add gitter.im link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Signal Android 
 
+[![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/WhisperSystems/Signal-Android?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+
 Signal is a messaging app for simple private communication with friends.
 
 Signal uses your phone's data connection (WiFi/3G/4G) to communicate securely, optionally supports plain SMS/MMS to function as a unified messenger, and can also encrypt the stored messages on your phone.


### PR DESCRIPTION
As we have a gitter.im room set up and added to the README for [Signal-iOS](https://github.com/WhisperSystems/Signal-iOS), and we have an unused but activated room for this repository, thought it would be a nice idea to add this link to direct people over to this room for development related chat? (anything not mailinglist worthy).