### PR TITLE
remove travis ci file since travis is not used

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: android
-android:
-  components:
-    - platform-tools
-    - build-tools-19.1.0
-    - android-19
-    - extra-android-m2repository


### PR DESCRIPTION
Travis CI is not used per https://github.com/WhisperSystems/Signal-Android/pull/4381#issuecomment-153865376 so deleting extra file.