### PR TITLE
fix quick attachment open animation

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1332,6 +1332,10 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } else {
       getSupportActionBar().show();
     }
+
+    if (drawerState == DrawerState.COLLAPSED) {
+      container.hideAttachedInput(true);
+    }
   }
 
   @Override


### PR DESCRIPTION
the open animation wasn't working if you used a drag gesture to close the qiuck attachment drawer, then clicked the camera toggle.