### PR TITLE
Update donation image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ whispersystems@lists.riseup.net
 https://lists.riseup.net/www/info/whispersystems
 
 ## Contributing Funds
-[![Donate](https://www.coinbase.com/assets/buttons/donation_large-5e1b50d6490970e32b80023f3070b1d77afc621b9e64ac996596a67a4671967b.png)](https://www.coinbase.com/checkouts/51dac699e660a4d773216b5ad94d6a0b)
+[![Donate](https://cloud.githubusercontent.com/assets/3121306/11278543/d46e03d0-8eeb-11e5-9691-0da1bf643192.png)](https://www.coinbase.com/checkouts/51dac699e660a4d773216b5ad94d6a0b)
 
 You can add funds to BitHub to directly help further development efforts.
 


### PR DESCRIPTION
Since the button-generator by coinbase seems to fail from time to time (like at the moment, where the donation image results in a 404) a better solution is to have a normal image as donation button.
Furthermore this one is more eye-catching I guess.

The image is a free promotional graphic and is taken from https://en.bitcoin.it/wiki/Promotional_graphics

fixes #4542
//FREEBIE