### PR TITLE
Add location sharing to the attachment menu

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -102,6 +102,12 @@
     <meta-data android:name="org.thoughtcrime.securesms.mms.TextSecureGlideModule"
                android:value="GlideModule" />
 
+
+
+    <meta-data
+        android:name="com.google.android.geo.API_KEY"
+        android:value="@string/google_location_key" />
+
     <activity android:name="org.thoughtcrime.redphone.RedPhone"
               android:screenOrientation="portrait"
               android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|fontScale"

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,8 @@ repositories {
 dependencies {
     compile 'me.leolin:ShortcutBadger:1.1.0-WS1'
     compile 'se.emilsjolander:stickylistheaders:2.7.0'
-    compile 'com.google.android.gms:play-services-base:6.5.87'
+    compile 'com.google.android.gms:play-services-gcm:8.1.0' // https://developers.google.com/android/guides/setup
+    compile 'com.google.android.gms:play-services-location:8.1.0'
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile 'org.w3c:smil:1.0.0'
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
@@ -107,7 +108,8 @@ dependencyVerification {
     verify = [
             'me.leolin:ShortcutBadger:3142d017234bfa0cdd69ccded7cc5ea63f13b97574803c8c616c9bbeaad33ad9',
             'se.emilsjolander:stickylistheaders:a08ca948aa6b220f09d82f16bbbac395f6b78897e9eeac6a9f0b0ba755928eeb',
-            'com.google.android.gms:play-services-base:832cb6b3130e871db6a412c4ab585656dbcc5e7948101f190186757785703f75',
+            'com.google.android.gms:play-services-gcm:757ecd2c837ac81c98f4cc7dc783e7454c6d0506f6cc66b10417126b675248c9',
+            'com.google.android.gms:play-services-location:8226f778aa86bd15b9143f62425262cc53d64021990f62eb1aaec108d4e25f35',
             'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
             'org.w3c:smil:085dc40f2bb249651578bfa07499fd08b16ad0886dbe2c4078586a408da62f9b',
             'org.apache.httpcomponents:httpclient-android:6f56466a9bd0d42934b90bfbfe9977a8b654c058bf44a12bdc2877c4e1f033f1',
@@ -150,7 +152,7 @@ dependencyVerification {
             'com.fasterxml.jackson.core:jackson-core:cbf4604784b4de226262845447a1ad3bb38a6728cebe86562e2c5afada8be2c0',
             'org.whispersystems:curve25519-java:9ccef8f5aba05d9942336f023c589d6278b4f9135bdc34a7bade1f4e7ad65fa3',
             'com.android.support:support-v4:c62f0d025dafa86f423f48df9185b0d89496adbc5f6a9be5a7c394d84cf91423',
-            'com.android.support:support-annotations:104f353b53d5dd8d64b2f77eece4b37f6b961de9732eb6b706395e91033ec70a',
+            'com.android.support:support-annotations:104f353b53d5dd8d64b2f77eece4b37f6b961de9732eb6b706395e91033ec70a'
     ]
 }
 
@@ -173,6 +175,8 @@ android {
         buildConfigField "String", "REDPHONE_RELAY_HOST", "\"relay.whispersystems.org\""
         buildConfigField "String", "REDPHONE_PREFIX_NAME", "\".whispersystems.org\""
         buildConfigField "boolean", "DEV_BUILD", "false"
+
+        multiDexEnabled true
     }
 
     compileOptions {

--- a/res/layout/attachment_type_selector.xml
+++ b/res/layout/attachment_type_selector.xml
@@ -137,13 +137,30 @@
 
         </LinearLayout>
 
+
         <LinearLayout android:layout_width="match_parent"
                       android:layout_height="wrap_content"
-                      android:layout_weight="1"
                       android:gravity="center"
-                      android:orientation="vertical">
+                      android:orientation="vertical"
+                      android:layout_weight="1">
+
+            <org.thoughtcrime.securesms.components.CircleColorImageView
+                android:id="@+id/location_button"
+                android:layout_width="60dp"
+                android:layout_height="60dp"
+                android:src="@drawable/ic_headset_white_36dp"
+                android:scaleType="center"
+                android:elevation="4dp"
+                app:circleColor="@color/orange_400"/>
+
+            <TextView android:layout_marginTop="10dp"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="@style/AttachmentTypeLabel"
+                android:text="@string/attachment_type_selector__location"/>
 
         </LinearLayout>
+
 
 
         <LinearLayout android:layout_width="match_parent"

--- a/res/layout/conversation_activity.xml
+++ b/res/layout/conversation_activity.xml
@@ -37,6 +37,7 @@
                      android:background="?android:windowBackground"
                      android:visibility="gone">
 
+
             <org.thoughtcrime.securesms.components.RemovableMediaView
                     android:id="@+id/removable_media_view"
                     android:layout_width="wrap_content"
@@ -61,6 +62,8 @@
                         android:paddingTop="15dp"
                         android:paddingBottom="15dp"
                         app:tintColor="@color/grey_500"/>
+
+
 
             </org.thoughtcrime.securesms.components.RemovableMediaView>
 

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -37,6 +37,7 @@
     <attr name="conversation_attach_video" format="reference"/>
     <attr name="conversation_attach_sound" format="reference"/>
     <attr name="conversation_attach_contact_info" format="reference"/>
+    <attr name="conversation_attach_location" format="reference"/>
     <attr name="conversation_attach" format="reference"/>
 
     <attr name="emoji_tab_strip_background" format="color" />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="AttachmentTypeSelectorAdapter_video">Video</string>
     <string name="AttachmentTypeSelectorAdapter_audio">Audio</string>
     <string name="AttachmentTypeSelectorAdapter_contact">Contact info</string>
+    <string name="AttachmentTypeSelectorAdapter_location">Location</string>
 
     <!-- BlockedContactsActivity -->
     <string name="BlockedContactsActivity_blocked_contacts">Blocked contacts</string>
@@ -573,6 +574,8 @@
     <string name="attachment_type_selector__video">Video</string>
     <string name="attachment_type_selector__contact">Contact</string>
     <string name="attachment_type_selector__camera">Camera</string>
+    <string name="attachment_type_selector__location">Location</string>
+
 
     <!-- change_passphrase_activity -->
     <string name="change_passphrase_activity__old_passphrase">OLD PASSPHRASE:</string>
@@ -1112,6 +1115,11 @@
 
     <!-- transport_selection_list_item -->
     <string name="transport_selection_list_item__transport_icon">Transport icon</string>
+
+
+    <!-- LocationChooserActivity -->
+    <string name="title_activity_location_chooser">Map</string>
+
 
 
     <!-- EOF -->

--- a/src/debug/res/values/google_location_api.xml
+++ b/src/debug/res/values/google_location_api.xml
@@ -1,0 +1,16 @@
+<resources>
+    <!--
+    TODO: Before you run your application, you need a Google Maps API key.
+
+    To get one, follow this link, follow the directions and press "Create" at the end:
+
+    https://console.developers.google.com/flows/enableapi?apiid=location_android_backend&keyType=CLIENT_SIDE_ANDROID&r=E9:44:42:D6:F7:49:82:8A:5E:4E:0C:0F:92:CE:F7:B2:79:46:C3:99%3Borg.thoughtcrime.securesms
+
+    You can also add your credentials to an existing key, using this line:
+    E9:44:42:D6:F7:49:82:8A:5E:4E:0C:0F:92:CE:F7:B2:79:46:C3:99;org.thoughtcrime.securesms
+
+    Once you have your key (it starts with "AIza"), replace the "google_location_key"
+    string in this file.
+    -->
+    <string name="google_location_key" translatable="false" templateMergeStrategy="preserve">AIzaSyCPHUGQWGWBuiLnI_MX_E5-AKaLHyBGT5M</string>
+</resources>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -54,6 +54,9 @@ import android.widget.Toast;
 
 import com.afollestad.materialdialogs.AlertDialogWrapper;
 import com.commonsware.cwac.camera.CameraHost.FailureReason;
+import com.google.android.gms.location.places.Place;
+import com.google.android.gms.location.places.ui.PlacePicker;
+import com.google.android.gms.maps.model.LatLng;
 import com.google.protobuf.ByteString;
 
 import org.thoughtcrime.redphone.RedPhone;
@@ -168,6 +171,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private static final int PICK_CONTACT_INFO = 4;
   private static final int GROUP_EDIT        = 5;
   private static final int TAKE_PHOTO        = 6;
+  private static final int GET_LOCATION      = 7;
 
   private   MasterSecret          masterSecret;
   protected ComposeText           composeText;
@@ -334,6 +338,16 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       if (attachmentManager.getCaptureUri() != null) {
         setMedia(attachmentManager.getCaptureUri(), MediaType.IMAGE);
       }
+      break;
+    case GET_LOCATION:
+        Place place = PlacePicker.getPlace(data, this);
+        LatLng coords = place.getLatLng();
+        String placeDescription = String.format("http://maps.google.com/?q=loc:%s,%s", coords.latitude, coords.longitude);
+        String placeName = place.getName().toString();
+        if(!placeName.equals("")){
+            placeDescription += " " + placeName;
+        }
+        composeText.setText(placeDescription);
       break;
     }
   }
@@ -1012,6 +1026,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       AttachmentManager.selectContactInfo(this, PICK_CONTACT_INFO); break;
     case AttachmentTypeSelectorAdapter.TAKE_PHOTO:
       attachmentManager.capturePhoto(this, recipients, TAKE_PHOTO); break;
+    case AttachmentTypeSelectorAdapter.ADD_LOCATION:
+      attachmentManager.captureLocation(this, GET_LOCATION);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
+++ b/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
@@ -33,6 +33,7 @@ public class AttachmentTypeSelector extends PopupWindow {
   public static final int ADD_SOUND         = 3;
   public static final int ADD_CONTACT_INFO  = 4;
   public static final int TAKE_PHOTO        = 5;
+  public static final int ADD_LOCATION      = 6;
 
   private static final int ANIMATION_DURATION = 300;
 
@@ -43,6 +44,7 @@ public class AttachmentTypeSelector extends PopupWindow {
   private final @NonNull ImageView   videoButton;
   private final @NonNull ImageView   contactButton;
   private final @NonNull ImageView   cameraButton;
+  private final @NonNull ImageView   locationButton;
   private final @NonNull ImageView   closeButton;
 
   private @Nullable View                      currentAnchor;
@@ -54,19 +56,21 @@ public class AttachmentTypeSelector extends PopupWindow {
     LayoutInflater inflater = (LayoutInflater) context.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
     LinearLayout   layout   = (LinearLayout) inflater.inflate(R.layout.attachment_type_selector, null, true);
 
-    this.listener      = listener;
-    this.imageButton   = ViewUtil.findById(layout, R.id.gallery_button);
-    this.audioButton   = ViewUtil.findById(layout, R.id.audio_button);
-    this.videoButton   = ViewUtil.findById(layout, R.id.video_button);
-    this.contactButton = ViewUtil.findById(layout, R.id.contact_button);
-    this.cameraButton  = ViewUtil.findById(layout, R.id.camera_button);
-    this.closeButton   = ViewUtil.findById(layout, R.id.close_button);
+    this.listener        = listener;
+    this.imageButton     = ViewUtil.findById(layout, R.id.gallery_button);
+    this.audioButton     = ViewUtil.findById(layout, R.id.audio_button);
+    this.videoButton     = ViewUtil.findById(layout, R.id.video_button);
+    this.contactButton   = ViewUtil.findById(layout, R.id.contact_button);
+    this.cameraButton    = ViewUtil.findById(layout, R.id.camera_button);
+    this.locationButton  = ViewUtil.findById(layout, R.id.location_button);
+    this.closeButton     = ViewUtil.findById(layout, R.id.close_button);
 
     this.imageButton.setOnClickListener(new PropagatingClickListener(ADD_IMAGE));
     this.audioButton.setOnClickListener(new PropagatingClickListener(ADD_SOUND));
     this.videoButton.setOnClickListener(new PropagatingClickListener(ADD_VIDEO));
     this.contactButton.setOnClickListener(new PropagatingClickListener(ADD_CONTACT_INFO));
     this.cameraButton.setOnClickListener(new PropagatingClickListener(TAKE_PHOTO));
+    this.locationButton.setOnClickListener(new PropagatingClickListener(ADD_LOCATION));
     this.closeButton.setOnClickListener(new CloseClickListener());
 
     setContentView(layout);

--- a/src/org/thoughtcrime/securesms/crypto/AsymmetricMasterCipher.java
+++ b/src/org/thoughtcrime/securesms/crypto/AsymmetricMasterCipher.java
@@ -34,7 +34,7 @@ import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
 /**
- * This class is used to asymmetricly encrypt local data.  This is used in the case
+ * This class is used to asymmetrically encrypt local data.  This is used in the case
  * where TextSecure receives an SMS, but the user's local encryption passphrase is
  * not cached (either because of a timeout, or because it hasn't yet been entered).
  * 

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -33,6 +33,8 @@ import android.view.animation.AlphaAnimation;
 import android.view.animation.Animation;
 import android.widget.Toast;
 
+import com.google.android.gms.location.places.ui.PlacePicker;
+
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.AudioView;
 import org.thoughtcrime.securesms.components.RemovableMediaView;
@@ -55,6 +57,7 @@ public class AttachmentManager {
   private final @NonNull RemovableMediaView removableMediaView;
   private final @NonNull ThumbnailView      thumbnail;
   private final @NonNull AudioView          audioView;
+
   private final @NonNull AttachmentListener attachmentListener;
 
   private @NonNull  Optional<Slide> slide = Optional.absent();
@@ -76,10 +79,12 @@ public class AttachmentManager {
     animation.setDuration(200);
     animation.setAnimationListener(new Animation.AnimationListener() {
       @Override
-      public void onAnimationStart(Animation animation) {}
+      public void onAnimationStart(Animation animation) {
+      }
 
       @Override
-      public void onAnimationRepeat(Animation animation) {}
+      public void onAnimationRepeat(Animation animation) {
+      }
 
       @Override
       public void onAnimationEnd(Animation animation) {
@@ -207,6 +212,18 @@ public class AttachmentManager {
 
   public @Nullable Uri getCaptureUri() {
     return captureUri;
+  }
+
+  public void captureLocation(Activity activity, int requestCode){
+    Log.w(TAG, "Capture location button was clicked");
+    // https://developers.google.com/places/android-api/placepicker
+    try {
+      PlacePicker.IntentBuilder builder = new PlacePicker.IntentBuilder();
+      activity.startActivityForResult(builder.build(activity), requestCode);
+    }catch(Exception e){
+      e.printStackTrace();
+    }
+
   }
 
   public void capturePhoto(Activity activity, Recipients recipients, int requestCode) {

--- a/src/org/thoughtcrime/securesms/mms/AttachmentTypeSelectorAdapter.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentTypeSelectorAdapter.java
@@ -38,6 +38,7 @@ public class AttachmentTypeSelectorAdapter extends ArrayAdapter<AttachmentTypeSe
   public static final int ADD_SOUND         = 3;
   public static final int ADD_CONTACT_INFO  = 4;
   public static final int TAKE_PHOTO        = 5;
+  public static final int ADD_LOCATION      = 6;
 
   private final Context context;
 
@@ -77,6 +78,7 @@ public class AttachmentTypeSelectorAdapter extends ArrayAdapter<AttachmentTypeSe
     addItem(data, context.getString(R.string.AttachmentTypeSelectorAdapter_video),   ResUtil.getDrawableRes(context, R.attr.conversation_attach_video),        ADD_VIDEO);
     addItem(data, context.getString(R.string.AttachmentTypeSelectorAdapter_audio),   ResUtil.getDrawableRes(context, R.attr.conversation_attach_sound),        ADD_SOUND);
     addItem(data, context.getString(R.string.AttachmentTypeSelectorAdapter_contact), ResUtil.getDrawableRes(context, R.attr.conversation_attach_contact_info), ADD_CONTACT_INFO);
+    addItem(data, context.getString(R.string.AttachmentTypeSelectorAdapter_location), ResUtil.getDrawableRes(context, R.attr.conversation_attach_location),     ADD_LOCATION);
 
     return data;
   }


### PR DESCRIPTION
This should close https://github.com/WhisperSystems/Signal-Android/issues/638.

This pull request still needs a few things:
 -  [ ] A white icon for GPS 
 -  [ ] Color choice for the background
 -  [ ] Production API key setup for Google's Location API

Some other points of discussion:
Since this is effectively leaking GPS coords to Google, we may want to add a warning stating so.
Maybe there can be an additional setting where no Google maps/etc are relied on and it just pulls the GPS coords directly from the location provider.