### PR TITLE
Fix NewConversationActivity toolbar/overflow dynamic theming

### DIFF
--- a/res/layout/contact_selection_activity.xml
+++ b/res/layout/contact_selection_activity.xml
@@ -11,7 +11,7 @@
             android:layout_width="match_parent"
             android:minHeight="?attr/actionBarSize"
             android:background="?attr/colorPrimary"
-            android:theme="@style/TextSecure.LightActionBar" />
+            android:theme="?attr/actionBarStyle" />
 
         <fragment android:id="@+id/contact_selection_list_fragment"
                   android:layout_width="match_parent"

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -31,7 +31,6 @@
         <item name="android:icon">@drawable/actionbar_icon_holo_dark</item>
         <item name="icon">@drawable/actionbar_icon_holo_dark</item>
         <item name="background">@color/gray95</item>
-        <item name="android:background">@color/gray95</item>
         <item name="logo">@drawable/actionbar_icon_holo_dark</item>
         <item name="android:popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="popupTheme">@style/ThemeOverlay.AppCompat.Dark</item>


### PR DESCRIPTION
Fixes #4624 

**Before**
![new-convo-overflow-menu-dark-before-anno](https://cloud.githubusercontent.com/assets/11031903/11297040/0e731f16-8fb9-11e5-851c-2f4e9adf7de4.png)

**After**
![new-convo-overflow-menu-dark-fixed-anno](https://cloud.githubusercontent.com/assets/11031903/11296961/9a4faa0a-8fb8-11e5-8a49-390845763148.png)

Since the last major style update, `NewConversationActivity`'s dark theme background colors (toolbar #212121) have differed from `ConversationListActivity` (toolbar #111111), whereas the light theme colors are the same.  This PR preserves this difference in the dark theme, assuming it is by design.