### PR TITLE
"image/jpg" -> "image/jpeg" on MIME type checks and saving attachments

### DIFF
--- a/src/org/thoughtcrime/securesms/ShareActivity.java
+++ b/src/org/thoughtcrime/securesms/ShareActivity.java
@@ -29,7 +29,6 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
-import android.webkit.MimeTypeMap;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.mms.PartAuthority;
@@ -37,6 +36,7 @@ import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 import java.io.IOException;
@@ -167,7 +167,8 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
     final Intent intent      = new Intent(this, target);
     final String textExtra   = getIntent().getStringExtra(Intent.EXTRA_TEXT);
     final Uri    streamExtra = getIntent().getParcelableExtra(Intent.EXTRA_STREAM);
-    final String type        = streamExtra != null ? getMimeType(streamExtra) : getIntent().getType();
+    final String type        = streamExtra != null ? getMimeType(streamExtra)
+                                                   : MediaUtil.getCorrectedMimeType(getIntent().getType());
     intent.putExtra(ConversationActivity.TEXT_EXTRA, textExtra);
     if (resolvedExtra != null) intent.setDataAndType(resolvedExtra, type);
 
@@ -175,14 +176,9 @@ public class ShareActivity extends PassphraseRequiredActionBarActivity
   }
 
   private String getMimeType(Uri uri) {
-    String type = getContentResolver().getType(uri);
-
-    if (type == null) {
-      String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
-      type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
-    }
-
-    return type == null ? getIntent().getType() : type;
+    final String type = MediaUtil.getMimeType(getApplicationContext(), uri);
+    return type == null ? MediaUtil.getCorrectedMimeType(getIntent().getType())
+                        : type;
   }
 
   private class ResolveMediaTask extends AsyncTask<Uri, Void, Uri> {

--- a/src/org/thoughtcrime/securesms/util/MediaUtil.java
+++ b/src/org/thoughtcrime/securesms/util/MediaUtil.java
@@ -76,7 +76,20 @@ public class MediaUtil {
       final String extension = MimeTypeMap.getFileExtensionFromUrl(uri.toString());
       type = MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension);
     }
-    return type;
+    return getCorrectedMimeType(type);
+  }
+
+  public static @Nullable String getCorrectedMimeType(@Nullable String mimeType) {
+    if (mimeType == null) return null;
+
+    switch(mimeType) {
+    case "image/jpg":
+      return MimeTypeMap.getSingleton().hasMimeType(ContentType.IMAGE_JPEG)
+             ? ContentType.IMAGE_JPEG
+             : mimeType;
+    default:
+      return mimeType;
+    }
   }
 
   public static long getMediaSize(Context context, MasterSecret masterSecret, Uri uri) throws IOException {

--- a/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
+++ b/src/org/thoughtcrime/securesms/util/SaveAttachmentTask.java
@@ -57,7 +57,8 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
         return FAILURE;
       }
 
-      File        mediaFile   = constructOutputFile(attachment.contentType, attachment.date);
+      String      contentType = MediaUtil.getCorrectedMimeType(attachment.contentType);
+      File        mediaFile   = constructOutputFile(contentType, attachment.date);
       InputStream inputStream = PartAuthority.getAttachmentStream(context, masterSecret, attachment.uri);
 
       if (inputStream == null) {
@@ -68,7 +69,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
       Util.copy(inputStream, outputStream);
 
       MediaScannerConnection.scanFile(context, new String[]{mediaFile.getAbsolutePath()},
-                                      new String[]{attachment.contentType}, null);
+                                      new String[]{contentType}, null);
 
       return SUCCESS;
     } catch (IOException ioe) {
@@ -120,8 +121,7 @@ public class SaveAttachmentTask extends ProgressDialogAsyncTask<SaveAttachmentTa
     SimpleDateFormat  dateFormatter = new SimpleDateFormat("yyyy-MM-dd-HHmmss");
     String            base          = "signal-" + dateFormatter.format(timestamp);
 
-    if (extension == null)
-      extension = "attach";
+    if (extension == null) extension = "attach";
 
     int i = 0;
     File file = new File(outputDirectory, base + "." + extension);


### PR DESCRIPTION
Fixes #4602 

Also facilitates quick fixes for similar issues resulting from OEM changes to [`MimeUtils.java`](https://android.googlesource.com/platform/libcore/+/android-6.0.0_r5/luni/src/main/java/libcore/net/MimeUtils.java).