### PR TITLE
Change "Forget from memory" to simply "Forget"

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -916,7 +916,7 @@
     <string name="preferences__timeout_passphrase">Timeout passphrase</string>
     <string name="preferences__pref_timeout_interval_dialogtitle">Select passphrase timeout</string>
     <string name="preferences__pref_timeout_interval_title">Timeout interval</string>
-    <string name="preferences__the_amount_of_time_to_wait_before_forgetting_passphrase">The amount of time to wait before forgetting passphrase from memory</string>
+    <string name="preferences__the_amount_of_time_to_wait_before_forgetting_passphrase">The amount of time to wait before forgetting the passphrase</string>
     <string name="preferences__notifications">Notifications</string>
     <string name="preferences__enable_message_notifications">Enable message notifications</string>
     <string name="preferences__led_color">LED color</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -912,7 +912,7 @@
     <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__screen_security_summary">Screen security %s</string>
     <string name="preferences__disable_screen_security_to_allow_screen_shots">Block screenshots in the recents list and inside the app</string>
-    <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase from memory after some interval</string>
+    <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase after some interval</string>
     <string name="preferences__timeout_passphrase">Timeout passphrase</string>
     <string name="preferences__pref_timeout_interval_dialogtitle">Select passphrase timeout</string>
     <string name="preferences__pref_timeout_interval_title">Timeout interval</string>


### PR DESCRIPTION
Forgetting is usually from memory, so this makes
the message less redundant and easier to understand and to translate.