### PR TITLE
Hide devices preference pane. 

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -21,9 +21,9 @@
                 android:title="@string/preferences__chats"
                 android:icon="?pref_ic_chats"/>
 
-    <Preference android:key="preference_category_devices"
+    <!-- <Preference android:key="preference_category_devices"
                 android:title="@string/preferences__devices"
-                android:icon="?pref_ic_devices"/>
+                android:icon="?pref_ic_devices"/> --->
 
     <Preference android:key="preference_category_advanced"
                 android:title="@string/preferences__advanced"


### PR DESCRIPTION
Signal-Browser is not ready yet (uses the staging server) so to avoid user confusion remove the device provisioning menu.

// FREEBIE