### PR TITLE
Update attachment content type when updating attachment data

### DIFF
--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -36,6 +36,7 @@ import org.thoughtcrime.securesms.crypto.DecryptingPartInputStream;
 import org.thoughtcrime.securesms.crypto.EncryptingPartOutputStream;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.crypto.MasterSecretUnion;
+import org.thoughtcrime.securesms.mms.MediaStream;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.MediaUtil.ThumbnailData;
@@ -289,7 +290,7 @@ public class AttachmentDatabase extends Database {
 
   public @NonNull Attachment updateAttachmentData(@NonNull MasterSecret masterSecret,
                                                   @NonNull Attachment attachment,
-                                                  @NonNull InputStream inputStream)
+                                                  @NonNull MediaStream mediaStream)
       throws MmsException
   {
     SQLiteDatabase     database           = databaseHelper.getWritableDatabase();
@@ -300,19 +301,21 @@ public class AttachmentDatabase extends Database {
       throw new MmsException("No attachment data found!");
     }
 
-    long dataSize = setAttachmentData(masterSecret, dataFile, inputStream);
+    long dataSize = setAttachmentData(masterSecret, dataFile, mediaStream.getStream());
 
     ContentValues contentValues = new ContentValues();
     contentValues.put(SIZE, dataSize);
+    contentValues.put(CONTENT_TYPE, mediaStream.getMimeType());
 
     database.update(TABLE_NAME, contentValues, PART_ID_WHERE, databaseAttachment.getAttachmentId().toStrings());
 
     return new DatabaseAttachment(databaseAttachment.getAttachmentId(),
                                   databaseAttachment.getMmsId(),
                                   databaseAttachment.hasData(),
-                                  databaseAttachment.getContentType(),
+                                  mediaStream.getMimeType(),
                                   databaseAttachment.getTransferState(),
-                                  dataSize, databaseAttachment.getLocation(),
+                                  dataSize,
+                                  databaseAttachment.getLocation(),
                                   databaseAttachment.getKey(),
                                   databaseAttachment.getRelay());
   }

--- a/src/org/thoughtcrime/securesms/jobs/SendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SendJob.java
@@ -10,7 +10,9 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
 import org.thoughtcrime.securesms.mms.MediaConstraints;
+import org.thoughtcrime.securesms.mms.MediaStream;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
+import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.Util;
 import org.whispersystems.jobqueue.JobParameters;
 
@@ -19,6 +21,7 @@ import java.io.InputStream;
 import java.util.LinkedList;
 import java.util.List;
 
+import ws.com.google.android.mms.ContentType;
 import ws.com.google.android.mms.MmsException;
 
 public abstract class SendJob extends MasterSecretJob {
@@ -63,7 +66,7 @@ public abstract class SendJob extends MasterSecretJob {
         if (constraints.isSatisfied(context, masterSecret, attachment)) {
           results.add(attachment);
         } else if (constraints.canResize(attachment)) {
-          InputStream resized = constraints.getResizedMedia(context, masterSecret, attachment);
+          MediaStream resized = constraints.getResizedMedia(context, masterSecret, attachment);
           results.add(attachmentDatabase.updateAttachmentData(masterSecret, attachment, resized));
         } else {
           throw new UndeliverableMessageException("Size constraints could not be met!");

--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -18,6 +18,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.concurrent.ExecutionException;
 
+import ws.com.google.android.mms.ContentType;
+
 public abstract class MediaConstraints {
   private static final String TAG = MediaConstraints.class.getSimpleName();
 
@@ -58,7 +60,7 @@ public abstract class MediaConstraints {
     return attachment != null && MediaUtil.isImage(attachment) && !MediaUtil.isGif(attachment);
   }
 
-  public InputStream getResizedMedia(@NonNull Context context,
+  public MediaStream getResizedMedia(@NonNull Context context,
                                      @NonNull MasterSecret masterSecret,
                                      @NonNull Attachment attachment)
       throws IOException
@@ -69,7 +71,8 @@ public abstract class MediaConstraints {
 
     try {
       // XXX - This is loading everything into memory! We want the send path to be stream-like.
-      return new ByteArrayInputStream(BitmapUtil.createScaledBytes(context, new DecryptableUri(masterSecret, attachment.getDataUri()), this));
+      return new MediaStream(new ByteArrayInputStream(BitmapUtil.createScaledBytes(context, new DecryptableUri(masterSecret, attachment.getDataUri()), this)),
+                             ContentType.IMAGE_JPEG);
     } catch (ExecutionException ee) {
       throw new IOException(ee);
     }

--- a/src/org/thoughtcrime/securesms/mms/MediaStream.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaStream.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2015 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.mms;
+
+import java.io.InputStream;
+
+public class MediaStream {
+  private final InputStream stream;
+  private final String      mimeType;
+
+  public MediaStream(InputStream stream, String mimeType) {
+    this.stream   = stream;
+    this.mimeType = mimeType;
+  }
+
+  public InputStream getStream() {
+    return stream;
+  }
+
+  public String getMimeType() {
+    return mimeType;
+  }
+}


### PR DESCRIPTION
Fixes #4687 

See #4687 for details.  The check in `SendJob.java` line 69 is a preventive measure in case of future changes to the resizing functionality.