### PR TITLE
Delete Selected Message button strings "No"/"Yes" -> "Cancel"/"Delete"

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -260,7 +260,7 @@ public class ConversationFragment extends Fragment
     builder.setMessage(getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_this_will_permanently_delete_all_n_selected_messages, messagesCount, messagesCount));
     builder.setCancelable(true);
 
-    builder.setPositiveButton(R.string.yes, new DialogInterface.OnClickListener() {
+    builder.setPositiveButton(R.string.delete, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
         new ProgressDialogAsyncTask<MessageRecord, Void, Void>(getActivity(),
@@ -290,7 +290,7 @@ public class ConversationFragment extends Fragment
       }
     });
 
-    builder.setNegativeButton(R.string.no, null);
+    builder.setNegativeButton(android.R.string.cancel, null);
     builder.show();
   }
 


### PR DESCRIPTION
Fixes #4704
// FREEBIE

**Before**
![delete-selected-message-dialog-before](https://cloud.githubusercontent.com/assets/11031903/11360016/543f41a6-92c4-11e5-948e-86f6a0314ae3.png)

**After**
![delete-selected-message-dialog-after](https://cloud.githubusercontent.com/assets/11031903/11360019/59e7b8ae-92c4-11e5-9d99-057013076eb9.png)

See https://www.google.com/design/spec/components/dialogs.html#dialogs-alerts