### PR TITLE
Add Hebrew to language list

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -13,6 +13,7 @@
       <item>Español</item>
       <item>Français</item>
       <item>Greek ελληνικά</item>
+      <item>Hebrew עברית</item>
       <item>Hrvatski</item>
       <item>Indonesia</item>
       <item>Italiano</item>
@@ -49,6 +50,7 @@
       <item>es</item>
       <item>fr</item>
       <item>el</item>
+      <item>he</item>
       <item>hr</item>
       <item>in</item>
       <item>it</item>


### PR DESCRIPTION
Now that Hebrew is 100% translated and pulled from transifex, let's enabled it in the language list.
Shalom.
