### PR TITLE
Added german translation strings (Play store description). Used 'Text…

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -937,5 +937,18 @@ Die Überprüfung der SMS-Bestätigung hat zu lange gedauert.</string>
   <string name="device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link">Zum Verknüpfen den auf dem Gerät angezeigten QR-Code einscannen</string>
   <string name="device_link_fragment__link_device">Gerät verknüpfen</string>
   <string name="device_list_fragment__link_new_device">Neues Gerät verknüpfen</string>
+  <string name="PlaystoreDescription_para_0100">TextSecure - Privater Messenger</string>
+  <string name="PlaystoreDescription_para_0200">TextSecure ist eine Messaging App, die es dir erlaubt, mit deinen Freunden zu chatten, ohne deine Privatsphäre aufgeben zu müssen.</string>
+  <string name="PlaystoreDescription_para_0300">Mit TextSecure kannst du Sofortnachrichten verschicken ohne teure SMS Gebühren zu bezahlen, in Gruppenchats mit all deinen Freunden zugleich kommunizieren und Medien oder Anhänge teilen. Alles komplett privat. Die Server haben zu keinem Zeitpunkt Zugriff auf deine Kommunikation und speichern diese auch nicht.</string>
+  <string name="text_secure_normal__help">Hilfe</string>
+  <string name="SingleRecipientNotificationBuilder_signal"></string>
+  <string name="SingleRecipientNotificationBuilder_new_message">Neue Nachricht!</string>
+  <string name="PlaystoreDescription_para_1000">Weitere Informationen:</string>
+  <string name="PlaystoreDescription_para_0900"></string>
+  <string name="PlaystoreDescription_para_0800">Bitte melde Fehler, Probleme oder Änderungsvorschläge bei:</string>
+  <string name="PlaystoreDescription_para_0700">* Schnell. Das TextSecure Protokoll wurde mit dem Ziel entworfen, unter den widrigsten Bedingungen zu funktionieren. Mit TextSecure kommen deine Nachrichten sofort bei deinen Freunden an.</string>
+  <string name="PlaystoreDescription_para_0400">* Privat. TextSecure nutzt ein fortgeschrittenes Ende-zu-Ende Verschlüsselungsprotokoll, welches jede Nachricht zu jeder Zeit sicher verschlüsselt.</string>
+  <string name="PlaystoreDescription_para_0500">* Quelloffen. TextSecure ist freie, quelloffene Software, die es jedem ermöglicht, den Quelltext auf seine Sicherheit hin zu prüfen. TextSecure ist der einzige Messenger, der quelloffene, durch Experten geprüfte kryptografische Protokolle einsetzt, um deine Nachrichten zu beschützen.</string>
+  <string name="PlaystoreDescription_para_0600">* Gruppenchat. TextSecure erlaubt es dir, verschlüsselte Gruppen zu erstellen, sodass du private Unterhaltungen mit all deinen Freunden auf einmal haben kannst. Dabei sind nicht nur die Nachrichten verschlüsselt, selbst auf Metadaten wie Mitgliederliste, Gruppenname und -icon haben die TextSecure Server haben keinen Zugriff.</string>
   <!--EOF-->
 </resources>


### PR DESCRIPTION
…Secure' as appname, like the english default strings did