### PR TITLE
Clarify how to link devices.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -672,9 +672,8 @@
     <string name="device_link_fragment__link_device">Link device</string>
 
     <!-- device_list_fragment -->
-    <string name="device_list_fragment__no_devices_linked">No devices linked...</string>
+    <string name="device_list_fragment__no_devices_linked">No devices linked...\n \nYou can download our Chrome extension to add a device!</string>
     <string name="device_list_fragment__link_new_device">Link new device</string>
-
 
     <!-- experience_upgrade_activity -->
     <string name="experience_upgrade_activity__continue">continue</string>


### PR DESCRIPTION
Fixes #4649

The Chrome extension is not up yet so please do not merge yet. I"m not sure of the best way to link users towards a Chrome extension (they don't want to open the page on their Android smartphone).

// FREEBIE