### PR TITLE
Wording: send -> type (conversation's input text field)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -626,9 +626,9 @@
     <string name="conversation_title_view__conversation_muted">Conversation muted</string>
 
     <!-- conversation_activity -->
-    <string name="conversation_activity__type_message_push">Send Signal message</string>
-    <string name="conversation_activity__type_message_sms_insecure">Send unsecured SMS</string>
-    <string name="conversation_activity__type_message_mms_insecure">Send unsecured MMS</string>
+    <string name="conversation_activity__type_signal_message">Type Signal message</string>
+    <string name="conversation_activity__type_unsecured_sms">Type unsecured SMS</string>
+    <string name="conversation_activity__type_unsecured_mms">Type unsecured MMS</string>
     <string name="conversation_activity__send">Send</string>
     <string name="conversation_activity__remove">Remove</string>
     <string name="conversation_activity__window_description">Conversation with %1$s</string>

--- a/src/org/thoughtcrime/securesms/TransportOptions.java
+++ b/src/org/thoughtcrime/securesms/TransportOptions.java
@@ -92,20 +92,20 @@ public class TransportOptions {
       results.add(new TransportOption(Type.SMS, R.drawable.ic_send_sms_white_24dp,
                                       context.getResources().getColor(R.color.grey_600),
                                       context.getString(R.string.ConversationActivity_transport_insecure_mms),
-                                      context.getString(R.string.conversation_activity__type_message_mms_insecure),
+                                      context.getString(R.string.conversation_activity__type_unsecured_mms),
                                       new MmsCharacterCalculator()));
     } else {
       results.add(new TransportOption(Type.SMS, R.drawable.ic_send_sms_white_24dp,
                                       context.getResources().getColor(R.color.grey_600),
                                       context.getString(R.string.ConversationActivity_transport_insecure_sms),
-                                      context.getString(R.string.conversation_activity__type_message_sms_insecure),
+                                      context.getString(R.string.conversation_activity__type_unsecured_sms),
                                       new SmsCharacterCalculator()));
     }
 
     results.add(new TransportOption(Type.TEXTSECURE, R.drawable.ic_send_push_white_24dp,
                                     context.getResources().getColor(R.color.textsecure_primary),
                                     context.getString(R.string.ConversationActivity_transport_signal),
-                                    context.getString(R.string.conversation_activity__type_message_push),
+                                    context.getString(R.string.conversation_activity__type_signal_message),
                                     new PushCharacterCalculator()));
 
     return results;


### PR DESCRIPTION
// FREEBIE

- Replace '*send*' with '*type*' in the conversation's input text field

**Reason:** The current wording doesn't make much sense to me, as tapping on the text field containing one of these strings leads to *typing* rather than *sending* the message.

**Alternative:** An alternative to '*type*' would be '*write*'. If that is prefered, I'll be happy to change it accordingly.