### PR TITLE
Add color to "Scan the QR code" in DeviceAddFragment

### DIFF
--- a/res/layout/device_add_fragment.xml
+++ b/res/layout/device_add_fragment.xml
@@ -43,7 +43,8 @@
 
             <TextView android:text="@string/device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link"
                       android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"/>
+                      android:layout_height="wrap_content"
+                      android:textColor="#ff6d6d6d"/>
 
 
         </LinearLayout>


### PR DESCRIPTION
Fixes #4771
// FREEBIE

Both the background color of the space below the `cameraview`, and the `ic_devices_white` tint are hardcoded rather than themed at this time.  The text, however, was left to the theme to color, which unfortunately made it invisible in dark theme:

![device-add-light-dark](https://cloud.githubusercontent.com/assets/11031903/11499394/2263e4d4-9869-11e5-9228-b08730d6d06a.png)

The text color on the light theme renders at `#6d6d6d`, though I couldn't find a matching color resource.  I used this color directly as a stopgap until the overall theming is finished on the devices screens (see #4611).  This allows the `DeviceAddFragment` to look the same, minus the toolbar background, on both light and dark themes in the interim.