### PR TITLE
Linkify geo URIs

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -75,7 +75,6 @@
                     android:textColor="?conversation_item_received_text_primary_color"
                     android:textColorLink="?conversation_item_received_text_primary_color"
                     android:textSize="@dimen/conversation_item_body_text_size"
-                    android:autoLink="all"
                     android:linksClickable="true" />
 
             <LinearLayout android:id="@+id/mms_download_controls"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -77,7 +77,6 @@
 
             <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/conversation_item_body"
-                    android:autoLink="all"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:paddingLeft="4dp"

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -28,7 +28,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
-import android.text.util.Linkify;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -63,6 +62,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.LinkifyHelper;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 
@@ -250,7 +250,6 @@ public class ConversationItem extends LinearLayout
     mediaThumbnail.setFocusable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
     mediaThumbnail.setClickable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
     mediaThumbnail.setLongClickable(batchSelected.isEmpty());
-    bodyText.setAutoLinkMask(batchSelected.isEmpty() ? Linkify.ALL : 0);
   }
 
   private boolean isCaptionlessMms(MessageRecord messageRecord) {
@@ -278,6 +277,10 @@ public class ConversationItem extends LinearLayout
     } else {
       bodyText.setText(messageRecord.getDisplayBody());
       bodyText.setVisibility(View.VISIBLE);
+    }
+
+    if (batchSelected.isEmpty()) {
+      LinkifyHelper.addLinks(bodyText);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/util/LinkifyHelper.java
+++ b/src/org/thoughtcrime/securesms/util/LinkifyHelper.java
@@ -1,0 +1,15 @@
+package org.thoughtcrime.securesms.util;
+
+import android.text.util.Linkify;
+import android.widget.TextView;
+
+import java.util.regex.Pattern;
+
+public class LinkifyHelper {
+  private final static Pattern GEO_URL_PATTERN = Pattern.compile("geo:([\\-0-9.]+),([\\-0-9.]+)(?:,([\\-0-9.]+))?(?:\\?(.*))?", Pattern.CASE_INSENSITIVE);
+
+  public static void addLinks(TextView text) {
+    Linkify.addLinks(text, Linkify.ALL);
+    Linkify.addLinks(text, GEO_URL_PATTERN, null);
+  }
+}


### PR DESCRIPTION
Fixes #4206

The geo URI RegEx is from https://codecov.io/github/zxing/zxing/core/src/main/java/com/google/zxing/client/result/GeoResultParser.java

The idea of LinkifyHelper is borrowed from ChatSecure and could be extended to (their) other URI types: https://github.com/guardianproject/ChatSecureAndroid/blob/master/src/info/guardianproject/util/LinkifyHelper.java

Example geo URIs for testing can be found here: https://en.wikipedia.org/wiki/Geo_URI_scheme

The next step would be Signal to generate geo URIs using the location API.