### PR TITLE
Integrate DynamicLanguage with DeviceListFragment

### DIFF
--- a/src/org/thoughtcrime/securesms/DeviceActivity.java
+++ b/src/org/thoughtcrime/securesms/DeviceActivity.java
@@ -55,6 +55,7 @@ public class DeviceActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setTitle(R.string.AndroidManifest_manage_linked_devices);
     this.deviceAddFragment  = new DeviceAddFragment();
     this.deviceListFragment = new DeviceListFragment();
     this.deviceLinkFragment = new DeviceLinkFragment();
@@ -62,7 +63,7 @@ public class DeviceActivity extends PassphraseRequiredActionBarActivity
     this.deviceListFragment.setAddDeviceButtonListener(this);
     this.deviceAddFragment.setScanListener(this);
 
-    initFragment(android.R.id.content, deviceListFragment, masterSecret);
+    initFragment(android.R.id.content, deviceListFragment, masterSecret, dynamicLanguage.getCurrentLocale());
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -30,6 +30,7 @@ import org.whispersystems.textsecure.api.messages.multidevice.DeviceInfo;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 
 import javax.inject.Inject;
 
@@ -43,10 +44,17 @@ public class DeviceListFragment extends ListFragment
   @Inject
   TextSecureAccountManager accountManager;
 
-  private View empty;
+  private Locale                 locale;
+  private View                   empty;
   private View                   progressContainer;
-  private FloatingActionButton addDeviceButton;
+  private FloatingActionButton   addDeviceButton;
   private Button.OnClickListener addDeviceButtonListener;
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+    this.locale = (Locale) getArguments().getSerializable(PassphraseRequiredActionBarActivity.LOCALE_EXTRA);
+  }
 
   @Override
   public void onAttach(Activity activity) {
@@ -94,7 +102,7 @@ public class DeviceListFragment extends ListFragment
       return;
     }
 
-    setListAdapter(new DeviceListAdapter(getActivity(), R.layout.device_list_item_view, data));
+    setListAdapter(new DeviceListAdapter(getActivity(), R.layout.device_list_item_view, data, locale));
 
     if (data.isEmpty()) {
       empty.setVisibility(View.VISIBLE);
@@ -171,11 +179,13 @@ public class DeviceListFragment extends ListFragment
 
   private static class DeviceListAdapter extends ArrayAdapter<DeviceInfo> {
 
-    private final int resource;
+    private final int    resource;
+    private final Locale locale;
 
-    public DeviceListAdapter(Context context, int resource, List<DeviceInfo> objects) {
+    public DeviceListAdapter(Context context, int resource, List<DeviceInfo> objects, Locale locale) {
       super(context, resource, objects);
       this.resource = resource;
+      this.locale = locale;
     }
 
     @Override
@@ -184,7 +194,7 @@ public class DeviceListFragment extends ListFragment
         convertView = ((Activity)getContext()).getLayoutInflater().inflate(resource, parent, false);
       }
 
-      ((DeviceListItem)convertView).set(getItem(position));
+      ((DeviceListItem)convertView).set(getItem(position), locale);
 
       return convertView;
     }

--- a/src/org/thoughtcrime/securesms/DeviceListItem.java
+++ b/src/org/thoughtcrime/securesms/DeviceListItem.java
@@ -34,18 +34,18 @@ public class DeviceListItem extends LinearLayout {
     this.lastActive = (TextView) findViewById(R.id.active);
   }
 
-  public void set(DeviceInfo deviceInfo) {
+  public void set(DeviceInfo deviceInfo, Locale locale) {
     if (TextUtils.isEmpty(deviceInfo.getName())) this.name.setText(R.string.DeviceListItem_unnamed_device);
     else                                         this.name.setText(deviceInfo.getName());
 
     this.created.setText(getContext().getString(R.string.DeviceListItem_linked_s,
                                                 DateUtils.getDayPrecisionTimeSpanString(getContext(),
-                                                                                        Locale.getDefault(),
+                                                                                        locale,
                                                                                         deviceInfo.getCreated())));
 
     this.lastActive.setText(getContext().getString(R.string.DeviceListItem_last_active_s,
                                                    DateUtils.getDayPrecisionTimeSpanString(getContext(),
-                                                                                           Locale.getDefault(),
+                                                                                           locale,
                                                                                            deviceInfo.getLastSeen())));
 
     this.deviceId = deviceInfo.getId();


### PR DESCRIPTION
Fixes #4752

Followed the pattern used by other subclasses of `PassphraseRequiredActionBarActivity`, such as `ConversationListActivity`.