### PR TITLE
Wording ambiguity: Archived conversation -> Conversation archived

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -180,7 +180,7 @@
     </activity-alias>
 
     <activity android:name=".ConversationListArchiveActivity"
-              android:label="@string/AndroidManifest_conversations_archive"
+              android:label="@string/AndroidManifest_archived_conversations"
               android:launchMode="singleTask"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize"
               android:parentActivityName=".ConversationListActivity">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -174,10 +174,10 @@
     </plurals>
     <string name="ConversationListFragment_deleting">Deleting</string>
     <string name="ConversationListFragment_deleting_selected_conversations">Deleting selected conversations...</string>
-    <string name="ConversationListFragment_archived_conversations">Archived conversations</string>
+    <string name="ConversationListFragment_conversations_archived">Conversations archived</string>
     <string name="ConversationListFragment_undo">UNDO</string>
     <string name="ConversationListFragment_moved_conversation_to_inbox">Moved conversation to inbox</string>
-    <string name="ConversationListFragment_archived_conversation">Archived conversation</string>
+    <string name="ConversationListFragment_conversation_archived">Conversation archived</string>
     <string name="ConversationListFragment_moved_conversations_to_inbox">Moved conversations to inbox</string>
 
     <!-- ConversationListItem -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -876,7 +876,7 @@
     <string name="AndroidManifest__message_details">Message details</string>
     <string name="AndroidManifest_manage_linked_devices">Manage linked devices</string>
     <string name="AndroidManifest__invite_friends">Invite friends</string>
-    <string name="AndroidManifest_conversations_archive">Conversations archive</string>
+    <string name="AndroidManifest_archived_conversations">Archived conversations</string>
 
     <!-- arrays.xml -->
     <string name="arrays__import_export">Import / export</string>

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -201,7 +201,7 @@ public class ConversationListFragment extends Fragment
     String snackBarTitle;
 
     if (archive) snackBarTitle = getString(R.string.ConversationListFragment_moved_conversations_to_inbox);
-    else         snackBarTitle = getString(R.string.ConversationListFragment_archived_conversations);
+    else         snackBarTitle = getString(R.string.ConversationListFragment_conversations_archived);
 
     new SnackbarAsyncTask<Void>(getView(), snackBarTitle,
                                 getString(R.string.ConversationListFragment_undo),
@@ -452,7 +452,7 @@ public class ConversationListFragment extends Fragment
         }.execute(threadId);
       } else {
         new SnackbarAsyncTask<Long>(getView(),
-                                    getString(R.string.ConversationListFragment_archived_conversation),
+                                    getString(R.string.ConversationListFragment_conversation_archived),
                                     getString(R.string.ConversationListFragment_undo),
                                     getResources().getColor(R.color.amber_500),
                                     Snackbar.LENGTH_LONG, false)


### PR DESCRIPTION
// FREEBIE

**Issue:**
There are 3 occurrences of 'Archived conversation[s]' in Signal - with 2 different meanings.

- *'Archived conversations'* means *'Conversations have been archived'* (i. e. archiving completed)
- *'Archived conversation'* means *'Conversation has been archived'* (i. e. archiving completed)

But:
- *'Archived conversations (%d)'* means 'Conversations ***which*** *have been archived'*

I've seen incorrect translations at Transifex because of this ambiguity.

**Solution:**
- Change the first two strings into *'Conversations archived'* and *'Conversation archived'* for differentiation.

I would think this is less ambiguous, but I'm not a native speaker. At the very least, it uses 2 different wordings for the 2 different meanings. So it's your judgment if this makes sense.