### PR TITLE
Enable preview for image drafts

### DIFF
--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -138,7 +138,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
     mediaUri     = getIntent().getData();
     mediaType    = getIntent().getType();
-    date         = getIntent().getLongExtra(DATE_EXTRA, -1);
+    date         = getIntent().getLongExtra(DATE_EXTRA, System.currentTimeMillis());
 
     if (recipientId > -1) {
       recipient = RecipientFactory.getRecipientForId(this, recipientId, true);

--- a/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
+++ b/src/org/thoughtcrime/securesms/mms/AttachmentManager.java
@@ -32,13 +32,13 @@ import android.util.Log;
 import android.view.View;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.MediaPreviewActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.AudioView;
 import org.thoughtcrime.securesms.components.RemovableMediaView;
 import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.providers.PersistentBlobProvider;
-import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.concurrent.ListenableFuture.Listener;
@@ -76,6 +76,7 @@ public class AttachmentManager {
     this.attachmentListener = listener;
 
     removableMediaView.setRemoveClickListener(new RemoveButtonListener());
+    thumbnail.setOnClickListener(new ThumbnailClickListener());
   }
 
   public void clear() {
@@ -272,6 +273,23 @@ public class AttachmentManager {
    return slide == null                                                        ||
           constraints.isSatisfied(context, masterSecret, slide.asAttachment()) ||
           constraints.canResize(slide.asAttachment());
+  }
+
+  private void previewImageDraft(final @NonNull Slide slide) {
+    if (MediaPreviewActivity.isContentTypeSupported(slide.getContentType()) && slide.getThumbnailUri() != null) {
+      Intent intent = new Intent(context, MediaPreviewActivity.class);
+      intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+      intent.setDataAndType(slide.getUri(), slide.getContentType());
+
+      context.startActivity(intent);
+    }
+  }
+
+  private class ThumbnailClickListener implements View.OnClickListener {
+    @Override
+    public void onClick(View v) {
+      if (slide.isPresent()) previewImageDraft(slide.get());
+    }
   }
 
   private class RemoveButtonListener implements View.OnClickListener {


### PR DESCRIPTION
as seen in #3443
(Only collabs can reopen if they had closed a PR/ an issue. Also, that closed PR does not seem to update - so much git left to learn...)

Had to use `setOnClickListener()` because a ThumbnailClickListener [only get's dispatched if](https://github.com/WhisperSystems/Signal-Android/blob/946c43940b1e5ddb06db4bf7e86e09284cea95ff/src/org/thoughtcrime/securesms/components/ThumbnailView.java#L184)
`slide.getTransferState()          == AttachmentDatabase.TRANSFER_PROGRESS_DONE`, which won't ever happen for a draft. It that remains in state `TRANSFER_PROGRESS_STARTED`.

Quite happy with this solution :smiley: 