### PR TITLE
Rename TextSecurePlaintextBackup.xml to SignalPlaintextBackup.xml

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -26,7 +26,7 @@ public class PlaintextBackupExporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+    return sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml";
   }
 
   private static void exportPlaintext(Context context, MasterSecret masterSecret)

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -38,11 +38,12 @@ public class PlaintextBackupImporter {
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
 
-    File SignalBackup = new File(sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml");
-    if(SignalBackup.exists())
-      return sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml";
-    else
-      return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+    File signalBackup = new File(sdDirectory.getAbsolutePath() + File.separator, "SignalPlaintextBackup.xml");
+    if(signalBackup.exists()) {
+        return sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml";
+    } else {
+        return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+    }
   }
 
   private static void importPlaintext(Context context, MasterSecret masterSecret)

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -37,12 +37,12 @@ public class PlaintextBackupImporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
+    File signalBackup = new File(sdDirectory.getAbsolutePath(), "SignalPlaintextBackup.xml");
 
-    File signalBackup = new File(sdDirectory.getAbsolutePath() + File.separator, "SignalPlaintextBackup.xml");
-    if(signalBackup.exists()) {
-        return sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml";
+    if (signalBackup.exists()) {
+      return sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml";
     } else {
-        return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+      return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
     }
   }
 

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -37,7 +37,12 @@ public class PlaintextBackupImporter {
 
   private static String getPlaintextExportDirectoryPath() {
     File sdDirectory = Environment.getExternalStorageDirectory();
-    return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
+
+    File SignalBackup = new File(sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml");
+    if(SignalBackup.exists())
+      return sdDirectory.getAbsolutePath() + File.separator + "SignalPlaintextBackup.xml";
+    else
+      return sdDirectory.getAbsolutePath() + File.separator + "TextSecurePlaintextBackup.xml";
   }
 
   private static void importPlaintext(Context context, MasterSecret masterSecret)


### PR DESCRIPTION
Fixes #4849

All newly created plaintext backups will be saved under name 'SignalPlaintextBackup.xml', yet the Importer will still check for the 'TextSecurePlaintextBackup.xml' file as well (backward compatibility).