### PR TITLE
Fix crash when adding a contact from a conversation

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -153,7 +153,7 @@ public class ConversationFragment extends Fragment
   }
 
   public void reloadList() {
-    getLoaderManager().restartLoader(0, null, this);
+    getLoaderManager().restartLoader(0, Bundle.EMPTY, this);
   }
 
   private void initializeResources() {


### PR DESCRIPTION
(First contribution, so let's start small.)

This line from #4259 seems to have introduced a NPE crash when adding a contact from a conversation. A null Bundle ends up being passed to this function:
```Java
  @Override
  public Loader<Cursor> onCreateLoader(int id, Bundle args) {
    return new ConversationLoader(getActivity(), threadId, args.getLong("limit", PARTIAL_CONVERSATION_LIMIT));
  }
```

Fix tested on a Nexus 7 (2012) running stock Android 5.1.1, on top of e79ee7803fea85ec999e0f6dc803fc1227096cd0.