### PR TITLE
Support for group nicknames

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1019,6 +1019,9 @@
     <string name="preferences__enable_if_your_device_supports_sms_mms_delivery_over_wifi">Enable if your device uses SMS/MMS delivery over WiFi (only enable when \'WiFi Calling\' is enabled on your device)</string>
     <string name="preferences_app_protection__blocked_contacts">Blocked contacts</string>
     <string name="preferences_notifications__display_in_notifications">Display in notifications</string>
+    <string name="preferences_chats__nickname">Nickname</string>
+    <string name="preferences_chats__set_nickname">Set a nickname to be shown to other group members</string>
+    <string name="preferences_chats__current_nickname">Your nickname in groups: %s</string>
     <string name="preferences_chats__when_using_mobile_data">When using mobile data</string>
     <string name="preferences_chats__when_using_wifi">When using Wi-Fi</string>
     <string name="preferences_chats__when_roaming">When roaming</string>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+    <EditTextPreference
+        android:key="pref_nickname"
+        android:inputType="textPersonName"
+        android:maxLength="30"
+        android:title="@string/preferences_chats__nickname"
+        android:summary="@string/preferences_chats__set_nickname"/>
+
     <PreferenceCategory android:key="media_download" android:title="@string/preferences_chats__media_auto_download">
         <com.h6ah4i.android.compat.preference.MultiSelectListPreferenceCompat
                 android:title="@string/preferences_chats__when_using_mobile_data"

--- a/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
+++ b/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
@@ -71,7 +71,8 @@ public class DatabaseFactory {
   private static final int INTRODUCED_ARCHIVE_VERSION                      = 24;
   private static final int INTRODUCED_CONVERSATION_LIST_STATUS_VERSION     = 25;
   private static final int MIGRATED_CONVERSATION_LIST_STATUS_VERSION       = 26;
-  private static final int DATABASE_VERSION                                = 26;
+  private static final int INTRODUCED_NICKNAME                             = 27;
+  private static final int DATABASE_VERSION                                = 27;
 
   private static final String DATABASE_NAME    = "messages.db";
   private static final Object lock             = new Object();
@@ -811,6 +812,10 @@ public class DatabaseFactory {
                        new String[]{status + "", receiptCount + "", threadId + ""});
           }
         }
+      }
+
+      if (oldVersion < INTRODUCED_NICKNAME) {
+        db.execSQL("ALTER TABLE recipient_preferences ADD COLUMN nickname TEXT DEFAULT NULL");
       }
 
       db.setTransactionSuccessful();

--- a/src/org/thoughtcrime/securesms/database/RecipientPreferenceDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/RecipientPreferenceDatabase.java
@@ -166,10 +166,32 @@ public class RecipientPreferenceDatabase extends Database {
     if (nickname != null && nickname.length() > MAX_NICKNAME_LENGTH) {
       nickname = nickname.substring(0, MAX_NICKNAME_LENGTH);
     }
+    String oldNickname = getNickname(recipients);
+    if (nickname == oldNickname || nickname.equals(oldNickname)) {
+      return;
+    }
     ContentValues values = new ContentValues(1);
     values.put(NICKNAME, nickname);
     updateOrInsert(recipients, values);
     RecipientFactory.clearCache();
+  }
+
+  private String getNickname(Recipients recipients) {
+    SQLiteDatabase database = databaseHelper.getReadableDatabase();
+    Cursor         cursor   = null;
+
+    try {
+      cursor = database.query(TABLE_NAME, new String[] {NICKNAME}, RECIPIENT_IDS + " = ?",
+                              new String[] {Util.join(recipients.getIds(), " ")},
+                              null, null, null);
+
+      if (cursor != null && cursor.moveToNext()) {
+        return cursor.getString(cursor.getColumnIndexOrThrow(NICKNAME));
+      }
+      return null;
+    } finally {
+      if (cursor != null) cursor.close();
+    }
   }
 
   private void updateOrInsert(Recipients recipients, ContentValues contentValues) {

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -324,6 +324,13 @@ public class PushDecryptJob extends ContextJob {
     EncryptingSmsDatabase database = DatabaseFactory.getEncryptingSmsDatabase(context);
     String                body     = message.getBody().isPresent() ? message.getBody().get() : "";
 
+    if (message.getNickname().isPresent() && envelope.getSource() != null) {
+      Recipients recipients = RecipientFactory.getRecipientsFromString(context, envelope.getSource(), true);
+      String     nickname   = message.getNickname().get();
+
+      DatabaseFactory.getRecipientPreferenceDatabase(context).setNickname(recipients, nickname);
+    }
+
     Pair<Long, Long> messageAndThreadId;
 
     if (smsMessageId.isPresent() && !message.getGroupInfo().isPresent()) {

--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -18,6 +18,7 @@ import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
 import org.thoughtcrime.securesms.util.GroupUtil;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.jobqueue.requirements.NetworkRequirement;
 import org.whispersystems.textsecure.api.TextSecureMessageSender;
@@ -146,7 +147,7 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
       messageSender.sendMessage(addresses, groupDataMessage);
     } else {
       TextSecureGroup       group        = new TextSecureGroup(groupId);
-      TextSecureDataMessage groupMessage = new TextSecureDataMessage(message.getSentTimeMillis(), group, attachments, message.getBody());
+      TextSecureDataMessage groupMessage = new TextSecureDataMessage(message.getSentTimeMillis(), group, TextSecurePreferences.getNickname(context), attachments, message.getBody(), false);
 
       messageSender.sendMessage(addresses, groupMessage);
     }

--- a/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
@@ -152,7 +152,11 @@ public class RecipientProvider {
     }
 
     if (STATIC_DETAILS.containsKey(number)) return STATIC_DETAILS.get(number);
-    else                                    return new RecipientDetails(null, number, null, ContactPhotoFactory.getDefaultContactPhoto(null), color);
+    else {
+      String nickname = preferences.isPresent() ? preferences.get().getNickname() : null;
+
+      return new RecipientDetails(nickname != null ? number + " (~" + nickname + ")" : null, number, null, ContactPhotoFactory.getDefaultContactPhoto(null), color);
+    }
   }
 
   private @NonNull RecipientDetails getGroupRecipientDetails(Context context, String groupId) {

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -57,6 +57,7 @@ public class TextSecurePreferences {
   public  static final String PASSPHRASE_TIMEOUT_INTERVAL_PREF = "pref_timeout_interval";
   private static final String PASSPHRASE_TIMEOUT_PREF          = "pref_timeout_passphrase";
   public  static final String SCREEN_SECURITY_PREF             = "pref_screen_security";
+  public  static final String USER_NICKNAME_PREF               = "pref_nickname";
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
   private static final String ENTER_PRESENT_PREF               = "pref_enter_key";
   private static final String SMS_DELIVERY_REPORT_PREF         = "pref_delivery_report_sms";
@@ -234,6 +235,14 @@ public class TextSecurePreferences {
 
   public static boolean isEnterImeKeyEnabled(Context context) {
     return getBooleanPreference(context, ENTER_PRESENT_PREF, false);
+  }
+
+  public static String getNickname(Context context) {
+    return getStringPreference(context, USER_NICKNAME_PREF, null);
+  }
+
+  public static void setNickname(Context context, String nickname) {
+    setStringPreference(context, USER_NICKNAME_PREF, nickname);
   }
 
   public static boolean isEnterSendsEnabled(Context context) {


### PR DESCRIPTION
Caution: This PR updates the database!

This PR adds support for nicknames in groups. The user can set a custom nickname in the chat preferences. This nickname will be included in all group messages. The recipients will show the nickname if they don't have the sender in their contact list.
Nicknames from other people are stored in the RecipientPreferenceDatabase.

Example:
![group_nickname](https://cloud.githubusercontent.com/assets/2340865/11769752/d26fb9f0-a1ee-11e5-9a98-5be86ff56481.png)

Needs WhisperSystems/libtextsecure-java#19

Fixes #4852