### PR TITLE
Prevent auto-backup on Marshmallow by targeting an older version

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,6 +6,7 @@
       android:versionName="3.7.2">
 
     <uses-sdk tools:overrideLibrary="com.amulyakhare.textdrawable,com.astuetz.pagerslidingtabstrip,pl.tajchert.waitingdots,com.h6ah4i.android.multiselectlistpreferencecompat"/>
+    <uses-sdk andoid:targetSdkVersion="22" />
 
     <permission android:name="org.thoughtcrime.securesms.ACCESS_SECRETS"
                 android:label="Access to TextSecure Secrets"
@@ -92,8 +93,6 @@
     <application android:name=".ApplicationContext"
                  android:icon="@drawable/icon"
                  android:label="@string/app_name"
-                 tools:replace="android:allowBackup"
-                 android:allowBackup="false"
                  android:theme="@style/TextSecure.LightTheme">
 
     <meta-data android:name="com.google.android.gms.version"


### PR DESCRIPTION
https://developer.android.com/training/backup/autosyncapi.html states
that only apps targeting API level 23 or higher will participate in the
auto-backup. By targeting level 22 for now, we can re-enable ADB-based
backup/restore without risking to leak data to the backup cloud.

For the long run, a proper encrypted backup/restore remains the better
solution. Once that is available, we can consider disabling backups
again.

Signed-off-by: Jan Kiszka <jan.kiszka@web.de>