### PR TITLE
Device management AlertDialog set not cancelable

### DIFF
--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -145,7 +145,25 @@ public class DeviceListFragment extends ListFragment
         getLoaderManager().initLoader(0, null, DeviceListFragment.this);
       }
     });
-    builder.show();
+
+    builder.setNegativeButton(android.R.string.cancel,
+            new DialogInterface.OnClickListener() {
+      @Override
+      public void onClick(DialogInterface dialog, int which) {
+        DeviceListFragment.this.getActivity().onBackPressed();
+      }
+    });
+    builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
+      @Override
+      public void onCancel(DialogInterface dialog) {
+        DeviceListFragment.this.getActivity().onBackPressed();
+      }
+    });
+
+    AlertDialog dialog = builder.create();
+    // This method is not available in the Builder class.
+    dialog.setCanceledOnTouchOutside(false);
+    dialog.show();
   }
 
   private void handleDisconnectDevice(final long deviceId) {

--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -159,9 +159,7 @@ public class DeviceListFragment extends ListFragment
       }
     });
 
-    AlertDialog dialog = builder.create();
-    dialog.setCanceledOnTouchOutside(true);
-    dialog.show();
+    builder.show();
   }
 
   private void handleDisconnectDevice(final long deviceId) {

--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -146,8 +146,7 @@ public class DeviceListFragment extends ListFragment
       }
     });
 
-    builder.setNegativeButton(android.R.string.cancel,
-            new DialogInterface.OnClickListener() {
+    builder.setNegativeButton(android.R.string.cancel, new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
         DeviceListFragment.this.getActivity().onBackPressed();
@@ -161,8 +160,7 @@ public class DeviceListFragment extends ListFragment
     });
 
     AlertDialog dialog = builder.create();
-    // This method is not available in the Builder class.
-    dialog.setCanceledOnTouchOutside(false);
+    dialog.setCanceledOnTouchOutside(true);
     dialog.show();
   }
 


### PR DESCRIPTION
When the user enters to the device management in the settings and the network connection fails the AlertDialog with the message and option to try again is displayed to him. Currently user can cancel the dialog in which case he will see only the blank screen. That might be quite confusing to him.

I have fixed it by adding a cancel button, OnCancelListener and set the dialog to not be cancelable by clicking outside of it. 