### PR TITLE
Fix call volume

### DIFF
--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -293,12 +293,14 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
     AudioManager audioManager = ServiceUtil.getAudioManager(this);
     AudioUtils.resetConfiguration(this);
 
+    Log.d(TAG, "request STREAM_VOICE_CALL audio focus");
     audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
                                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
   }
 
   private void shutdownAudio() {
-    AudioManager am = (AudioManager) getSystemService(AUDIO_SERVICE);
+    Log.d(TAG, "reset audio mode and abandon focus");
+    AudioManager am = ServiceUtil.getAudioManager(this);
     am.setMode(AudioManager.MODE_NORMAL);
     am.abandonAudioFocus(null);
   }

--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -294,15 +294,16 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
     AudioUtils.resetConfiguration(this);
 
     Log.d(TAG, "request STREAM_VOICE_CALL audio focus");
-    audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
-                                   AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
+    audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL, AudioManager.AUDIOFOCUS_GAIN);
   }
 
   private void shutdownAudio() {
     Log.d(TAG, "reset audio mode and abandon focus");
+    AudioUtils.resetConfiguration(this);
     AudioManager am = ServiceUtil.getAudioManager(this);
     am.setMode(AudioManager.MODE_NORMAL);
     am.abandonAudioFocus(null);
+    am.stopBluetoothSco();
   }
 
   public int getState() {

--- a/src/org/thoughtcrime/redphone/audio/CallAudioManager.java
+++ b/src/org/thoughtcrime/redphone/audio/CallAudioManager.java
@@ -45,6 +45,7 @@ public class CallAudioManager {
 
   public void start(@NonNull Context context) throws AudioException {
     if (Build.VERSION.SDK_INT >= 11) {
+      Log.d(TAG, "set MODE_IN_COMMUNICATION audio mode");
       ServiceUtil.getAudioManager(context).setMode(AudioManager.MODE_IN_COMMUNICATION);
     } else {
 //      ServiceUtil.getAudioManager(context).setMode(AudioManager.MODE_IN_CALL);

--- a/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
@@ -17,7 +17,6 @@
 
 package org.thoughtcrime.redphone.audio;
 
-import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.media.AudioManager;
@@ -91,6 +90,7 @@ public class IncomingRinger {
     }
 
     if (player != null && ringerMode == AudioManager.RINGER_MODE_NORMAL ) {
+      Log.d(TAG, "set MODE_RINGTONE audio mode");
       audioManager.setMode(AudioManager.MODE_RINGTONE);
       try {
         if(!player.isPlaying()) {
@@ -117,6 +117,7 @@ public class IncomingRinger {
     Log.d(TAG, "Cancelling vibrator");
     vibrator.cancel();
 
+    Log.d(TAG, "reset audio mode");
     AudioManager audioManager = ServiceUtil.getAudioManager(context);
     audioManager.setMode(AudioManager.MODE_NORMAL);
   }
@@ -134,7 +135,7 @@ public class IncomingRinger {
 
   @TargetApi(Build.VERSION_CODES.HONEYCOMB)
   private boolean shouldVibrateNew(Context context) {
-    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager audioManager = ServiceUtil.getAudioManager(context);
     Vibrator vibrator = (Vibrator) context.getSystemService(Context.VIBRATOR_SERVICE);
 
     if (vibrator == null || !vibrator.hasVibrator()) {
@@ -151,7 +152,7 @@ public class IncomingRinger {
   }
 
   private boolean shouldVibrateOld(Context context) {
-    AudioManager audioManager = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager audioManager = ServiceUtil.getAudioManager(context);
     return audioManager.shouldVibrate(AudioManager.VIBRATE_TYPE_RINGER);
   }
 }

--- a/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
@@ -24,6 +24,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.ServiceUtil;
 
 import java.io.IOException;
 
@@ -133,9 +134,10 @@ public class OutgoingRinger implements MediaPlayer.OnCompletionListener, MediaPl
   public void onPrepared(MediaPlayer mp) {
     mediaPlayer.setLooping(loopEnabled);
 
-    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager am = ServiceUtil.getAudioManager(context);
 
     if (am.isBluetoothScoAvailableOffCall()) {
+      Log.d(TAG, "bluetooth sco is available");
       try {
         am.startBluetoothSco();
         am.setBluetoothScoOn(true);

--- a/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
@@ -140,7 +140,6 @@ public class OutgoingRinger implements MediaPlayer.OnCompletionListener, MediaPl
       Log.d(TAG, "bluetooth sco is available");
       try {
         am.startBluetoothSco();
-        am.setBluetoothScoOn(true);
       } catch (NullPointerException e) {
         // Lollipop bug (https://stackoverflow.com/questions/26642218/audiomanager-startbluetoothsco-crashes-on-android-lollipop)
       }

--- a/src/org/thoughtcrime/redphone/util/AudioUtils.java
+++ b/src/org/thoughtcrime/redphone/util/AudioUtils.java
@@ -5,6 +5,8 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.util.Log;
 
+import org.thoughtcrime.securesms.util.ServiceUtil;
+
 /**
  * Utilities for manipulating device audio configuration
  *
@@ -13,22 +15,23 @@ import android.util.Log;
 public class AudioUtils {
   private static final String TAG = AudioUtils.class.getName();
   public static void enableDefaultRouting(Context context) {
-    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager am = ServiceUtil.getAudioManager(context);
     am.setSpeakerphoneOn(false);
     am.setBluetoothScoOn(false);
     Log.d(TAG, "Set default audio routing");
   }
 
   public static void enableSpeakerphoneRouting(Context context) {
-    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager am = ServiceUtil.getAudioManager(context);
     am.setSpeakerphoneOn(true);
     Log.d(TAG, "Set speakerphone audio routing");
   }
 
   public static void enableBluetoothRouting(Context context) {
-    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager am = ServiceUtil.getAudioManager(context);
     am.startBluetoothSco();
     am.setBluetoothScoOn(true);
+    Log.d(TAG, "Set bluetooth audio routing");
   }
 
   public static void resetConfiguration(Context context) {
@@ -42,7 +45,7 @@ public class AudioUtils {
   }
 
   public static AudioMode getCurrentAudioMode(Context context) {
-    AudioManager am = (AudioManager) context.getSystemService(Context.AUDIO_SERVICE);
+    AudioManager am = ServiceUtil.getAudioManager(context);
     if (am.isBluetoothScoOn()) {
       return AudioMode.HEADSET;
     } else if (am.isSpeakerphoneOn()) {


### PR DESCRIPTION
I am also affected by the low sound volume in calls, see #4733.
In my case that is because of the `setBluetoothScoOn(true)` for all calls. It will switch to bluetooth (although not connected) and thus show the bluetooth icon for the current volume setting.
The workaround that was mentioned, which is enabling and disabling the speaker, works because it will call `setBluetoothScoOn(false)` in `enableDefaultRouting`.
Furthermore `stopBluetoothSco()` was never called.
~~I also removed the `initializeAudio()`, because the ringers will now request the audio focus themselves.
And for every audio mode setting I added a focus request, and vice versa.~~
Also fixes #4188.