### PR TITLE
Fix archiving plurals

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -185,11 +185,15 @@
     </plurals>
     <string name="ConversationListFragment_deleting">Deleting</string>
     <string name="ConversationListFragment_deleting_selected_conversations">Deleting selected conversations...</string>
-    <string name="ConversationListFragment_conversations_archived">Conversations archived</string>
+    <plurals name="ConversationListFragment_conversations_archived">
+        <item quantity="one">Conversation archived</item>
+        <item quantity="other">%d conversations archived</item>
+    </plurals>
     <string name="ConversationListFragment_undo">UNDO</string>
-    <string name="ConversationListFragment_moved_conversation_to_inbox">Moved conversation to inbox</string>
-    <string name="ConversationListFragment_conversation_archived">Conversation archived</string>
-    <string name="ConversationListFragment_moved_conversations_to_inbox">Moved conversations to inbox</string>
+    <plurals name="ConversationListFragment_moved_conversations_to_inbox">
+        <item quantity="one">Moved conversation to inbox</item>
+        <item quantity="other">Moved %d conversations to inbox</item>
+    </plurals>
 
     <!-- ConversationListItem -->
     <string name="ConversationListItem_key_exchange_message">Key exchange message...</string>

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -201,10 +201,13 @@ public class ConversationListFragment extends Fragment
     final Set<Long> selectedConversations = new HashSet<>(getListAdapter().getBatchSelections());
     final boolean   archive               = this.archive;
 
-    String snackBarTitle;
+    int snackBarTitleId;
 
-    if (archive) snackBarTitle = getString(R.string.ConversationListFragment_moved_conversations_to_inbox);
-    else         snackBarTitle = getString(R.string.ConversationListFragment_conversations_archived);
+    if (archive) snackBarTitleId = R.plurals.ConversationListFragment_moved_conversations_to_inbox;
+    else         snackBarTitleId = R.plurals.ConversationListFragment_conversations_archived;
+
+    int count            = selectedConversations.size();
+    String snackBarTitle = getResources().getQuantityString(snackBarTitleId, count, count);
 
     new SnackbarAsyncTask<Void>(getView(), snackBarTitle,
                                 getString(R.string.ConversationListFragment_undo),
@@ -438,7 +441,7 @@ public class ConversationListFragment extends Fragment
 
       if (archive) {
         new SnackbarAsyncTask<Long>(getView(),
-                                    getString(R.string.ConversationListFragment_moved_conversation_to_inbox),
+                                    getResources().getQuantityString(R.plurals.ConversationListFragment_moved_conversations_to_inbox, 1, 1),
                                     getString(R.string.ConversationListFragment_undo),
                                     getResources().getColor(R.color.amber_500),
                                     Snackbar.LENGTH_LONG, false)
@@ -455,7 +458,7 @@ public class ConversationListFragment extends Fragment
         }.execute(threadId);
       } else {
         new SnackbarAsyncTask<Long>(getView(),
-                                    getString(R.string.ConversationListFragment_conversation_archived),
+                                    getResources().getQuantityString(R.plurals.ConversationListFragment_conversations_archived, 1, 1),
                                     getString(R.string.ConversationListFragment_undo),
                                     getResources().getColor(R.color.amber_500),
                                     Snackbar.LENGTH_LONG, false)


### PR DESCRIPTION
Use plural strings for moving messages to or out of archive, see #4815

(CC @RiseT)