### PR TITLE
Wording: Improve some strings in Privacy preferences

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -938,15 +938,14 @@
     <string name="preferences__change_your_passphrase">Change your passphrase</string>
     <string name="preferences__enable_passphrase">Enable passphrase</string>
     <string name="preferences__passphrase_summary">Passphrase %s</string>
-    <string name="preferences__enable_lock_screen_for_messages">Enable lock screen for messages</string>
+    <string name="preferences__lock_signal_and_message_notifications_with_passphrase">Lock Signal and message notifications with passphrase</string>
     <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__screen_security_summary">Screen security %s</string>
     <string name="preferences__disable_screen_security_to_allow_screen_shots">Block screenshots in the recents list and inside the app</string>
-    <string name="preferences__forget_passphrase_from_memory_after_some_interval">Forget passphrase from memory after some interval</string>
+    <string name="preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity">Auto-lock Signal after a specified time interval of inactivity</string>
     <string name="preferences__timeout_passphrase">Timeout passphrase</string>
     <string name="preferences__pref_timeout_interval_dialogtitle">Select passphrase timeout</string>
     <string name="preferences__pref_timeout_interval_title">Timeout interval</string>
-    <string name="preferences__the_amount_of_time_to_wait_before_forgetting_passphrase">The amount of time to wait before forgetting passphrase from memory</string>
     <string name="preferences__notifications">Notifications</string>
     <string name="preferences__enable_message_notifications">Enable message notifications</string>
     <string name="preferences__led_color">LED color</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -943,9 +943,8 @@
     <string name="preferences__screen_security_summary">Screen security %s</string>
     <string name="preferences__disable_screen_security_to_allow_screen_shots">Block screenshots in the recents list and inside the app</string>
     <string name="preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity">Auto-lock Signal after a specified time interval of inactivity</string>
-    <string name="preferences__timeout_passphrase">Timeout passphrase</string>
-    <string name="preferences__pref_timeout_interval_dialogtitle">Select passphrase timeout</string>
-    <string name="preferences__pref_timeout_interval_title">Timeout interval</string>
+    <string name="preferences__inactivity_timeout_passphrase">Inactivity timeout passphrase</string>
+    <string name="preferences__inactivity_timeout_interval">Inactivity timeout interval</string>
     <string name="preferences__notifications">Notifications</string>
     <string name="preferences__enable_message_notifications">Enable message notifications</string>
     <string name="preferences__led_color">LED color</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -938,7 +938,7 @@
     <string name="preferences__change_your_passphrase">Change your passphrase</string>
     <string name="preferences__enable_passphrase">Enable passphrase</string>
     <string name="preferences__passphrase_summary">Passphrase %s</string>
-    <string name="preferences__lock_signal_and_message_notifications_with_passphrase">Lock Signal and message notifications with passphrase</string>
+    <string name="preferences__lock_signal_and_message_notifications_with_a_passphrase">Lock Signal and message notifications with a passphrase</string>
     <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__screen_security_summary">Screen security %s</string>
     <string name="preferences__disable_screen_security_to_allow_screen_shots">Block screenshots in the recents list and inside the app</string>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -14,11 +14,11 @@
 
     <CheckBoxPreference android:defaultValue="false"
                         android:key="pref_timeout_passphrase"
-                        android:title="@string/preferences__timeout_passphrase"
+                        android:title="@string/preferences__inactivity_timeout_passphrase"
                         android:summary="@string/preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity"
                         android:dependency="pref_enable_passphrase_temporary"/>
 
-    <Preference android:title="@string/preferences__pref_timeout_interval_title"
+    <Preference android:title="@string/preferences__inactivity_timeout_interval"
                 android:key="pref_timeout_interval"
                 android:dependency="pref_timeout_passphrase"/>
 

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -5,7 +5,7 @@
                         android:key="pref_enable_passphrase_temporary"
                         android:defaultValue="true"
                         android:title="@string/preferences__enable_passphrase"
-                        android:summary="@string/preferences__lock_signal_and_message_notifications_with_passphrase"/>
+                        android:summary="@string/preferences__lock_signal_and_message_notifications_with_a_passphrase"/>
 
     <Preference android:key="pref_change_passphrase"
                 android:title="@string/preferences__change_passphrase"

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -5,7 +5,7 @@
                         android:key="pref_enable_passphrase_temporary"
                         android:defaultValue="true"
                         android:title="@string/preferences__enable_passphrase"
-                        android:summary="@string/preferences__enable_lock_screen_for_messages"/>
+                        android:summary="@string/preferences__lock_signal_and_message_notifications_with_passphrase"/>
 
     <Preference android:key="pref_change_passphrase"
                 android:title="@string/preferences__change_passphrase"
@@ -15,7 +15,7 @@
     <CheckBoxPreference android:defaultValue="false"
                         android:key="pref_timeout_passphrase"
                         android:title="@string/preferences__timeout_passphrase"
-                        android:summary="@string/preferences__forget_passphrase_from_memory_after_some_interval"
+                        android:summary="@string/preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity"
                         android:dependency="pref_enable_passphrase_temporary"/>
 
     <Preference android:title="@string/preferences__pref_timeout_interval_title"


### PR DESCRIPTION
// FREEBIE

Fixes https://github.com/WhisperSystems/Signal-Android/pull/4651

- Change 'Enable lock screen for messages' to **'Lock Signal and message notifications with a passphrase'**
- Change 'Forget passphrase from memory after some interval' to **'Auto-lock Signal after a specified time interval of inactivity'**
- Change 'Timeout passphrase' to **'Inactivity timeout passphrase'**
- Change 'Timeout interval' to **'Inactivity timeout interval'**
- Remove unused string resource *preferences__the_amount_of_time_to_wait_before_forgetting_passphrase*
- Remove unused string resource *preferences__pref_timeout_interval_dialogtitle*

Possibly 'Auto-lock Signal after a specified time**out** interval of inactivity' would be better, not sure. Let me know if this is the case. Perhaps more in line with *preferences__inactivity_timeout_interval* ('Inactivity timeout interval')

I've added that 'inactivity' stuff as I've noticed that I had no clue if the timeout interval is calculated from a) the moment of entering the passphrase or b) the last activity (it's the latter - I've tested it).