### PR TITLE
Improve plaintext export and import

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.os.Environment;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.model.DisplayRecord;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
@@ -62,7 +63,7 @@ public class PlaintextBackupExporter {
                                         threadAddress, record.getDateReceived(),
                                         MmsSmsColumns.Types.translateToSystemBaseType(record.getType()),
                                         null, record.getDisplayBody().toString(), null,
-                                        1, record.getDeliveryStatus());
+                                        1, record.isDelivered() ? SmsDatabase.Status.STATUS_COMPLETE : record.getDeliveryStatus());
 
         writer.writeItem(item);
       }
@@ -90,7 +91,7 @@ public class PlaintextBackupExporter {
                         threadAddress, mmsRecord.getDateReceived(),
                         MmsSmsColumns.Types.translateToSystemBaseType(mmsRecord.getType()),
                         null, mmsRecord.getDisplayBody().toString(), null,
-                        1, mmsRecord.getDeliveryStatus());
+                        1, mmsRecord.isDelivered() ? SmsDatabase.Status.STATUS_COMPLETE : mmsRecord.getDeliveryStatus());
 
         writer.writeItem(item);
       }

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.os.Environment;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
+import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
 import org.thoughtcrime.securesms.recipients.Recipients;
 
@@ -41,7 +43,7 @@ public class PlaintextBackupExporter {
     SmsMessageRecord record;
     EncryptingSmsDatabase.Reader reader = null;
     int skip                            = 0;
-    int ROW_LIMIT                       = 500;
+    final int ROW_LIMIT                 = 500;
 
     do {
       if (reader != null)
@@ -67,6 +69,34 @@ public class PlaintextBackupExporter {
 
       skip += ROW_LIMIT;
     } while (reader.getCount() > 0);
+
+    skip = 0;
+    MmsDatabase.Reader mmsReader = null;
+    do {
+      if (mmsReader != null)
+        mmsReader.close();
+
+      mmsReader = DatabaseFactory.getMmsDatabase(context).getMessages(masterSecret, skip, ROW_LIMIT);
+
+      MessageRecord mmsRecord;
+      while ((mmsRecord = mmsReader.getNext()) != null) {
+        String threadAddress = null;
+        Recipients threadRecipients = threads.getRecipientsForThreadId(mmsRecord.getThreadId());
+        if (threadRecipients != null && !threadRecipients.isEmpty()) {
+          threadAddress = threadRecipients.getPrimaryRecipient().getNumber();
+        }
+        XmlBackup.XmlBackupItem item =
+                new XmlBackup.XmlBackupItem(1, mmsRecord.getIndividualRecipient().getNumber(),
+                        threadAddress, mmsRecord.getDateReceived(),
+                        MmsSmsColumns.Types.translateToSystemBaseType(mmsRecord.getType()),
+                        null, mmsRecord.getDisplayBody().toString(), null,
+                        1, mmsRecord.getDeliveryStatus());
+
+        writer.writeItem(item);
+      }
+
+      skip += ROW_LIMIT;
+    } while (mmsReader.getCount() > 0);
 
     writer.close();
   }

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -55,15 +55,15 @@ public class PlaintextBackupImporter {
       XmlBackup.XmlBackupItem item;
 
       while ((item = backup.getNext()) != null) {
-        Recipients      recipients = RecipientFactory.getRecipientsFromString(context, item.getAddress(), false);
-        long            threadId   = threads.getThreadIdFor(recipients);
-        SQLiteStatement statement  = db.createInsertStatement(transaction);
-
         if (item.getAddress() == null || item.getAddress().equals("null"))
           continue;
 
         if (!isAppropriateTypeForImport(item.getType()))
           continue;
+
+        Recipients      recipients = RecipientFactory.getRecipientsFromString(context, item.getAddress(), false);
+        long            threadId   = threads.getThreadIdFor(recipients);
+        SQLiteStatement statement  = db.createInsertStatement(transaction);
 
         addStringToStatement(statement, 1, item.getAddress());
         addNullToStatement(statement, 2);

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -62,8 +62,14 @@ public class PlaintextBackupImporter {
           continue;
 
         Recipients      recipients = RecipientFactory.getRecipientsFromString(context, item.getAddress(), false);
-        long            threadId   = threads.getThreadIdFor(recipients);
+        long            threadId;
         SQLiteStatement statement  = db.createInsertStatement(transaction);
+
+        if (item.getThreadAddress() != null) {
+          threadId = threads.getThreadIdFor(RecipientFactory.getRecipientsFromString(context, item.getThreadAddress(), false));
+        } else {
+          threadId = threads.getThreadIdFor(recipients);
+        }
 
         addStringToStatement(statement, 1, item.getAddress());
         addNullToStatement(statement, 2);

--- a/src/org/thoughtcrime/securesms/database/XmlBackup.java
+++ b/src/org/thoughtcrime/securesms/database/XmlBackup.java
@@ -18,6 +18,7 @@ public class XmlBackup {
 
   private static final String PROTOCOL       = "protocol";
   private static final String ADDRESS        = "address";
+  private static final String THREAD_ADDRESS = "thread_address";
   private static final String DATE           = "date";
   private static final String TYPE           = "type";
   private static final String SUBJECT        = "subject";
@@ -62,6 +63,7 @@ public class XmlBackup {
 
         if      (attributeName.equals(PROTOCOL      )) item.protocol      = Integer.parseInt(parser.getAttributeValue(i));
         else if (attributeName.equals(ADDRESS       )) item.address       = parser.getAttributeValue(i);
+        else if (attributeName.equals(THREAD_ADDRESS)) item.threadAddress = parser.getAttributeValue(i);
         else if (attributeName.equals(DATE          )) item.date          = Long.parseLong(parser.getAttributeValue(i));
         else if (attributeName.equals(TYPE          )) item.type          = Integer.parseInt(parser.getAttributeValue(i));
         else if (attributeName.equals(SUBJECT       )) item.subject       = parser.getAttributeValue(i);
@@ -80,6 +82,7 @@ public class XmlBackup {
   public static class XmlBackupItem {
     private int    protocol;
     private String address;
+    private String threadAddress;
     private long   date;
     private int    type;
     private String subject;
@@ -90,11 +93,12 @@ public class XmlBackup {
 
     public XmlBackupItem() {}
 
-    public XmlBackupItem(int protocol, String address, long date, int type, String subject,
+    public XmlBackupItem(int protocol, String address, String threadAddress, long date, int type, String subject,
                          String body, String serviceCenter, int read, int status)
     {
       this.protocol      = protocol;
       this.address       = address;
+      this.threadAddress = threadAddress;
       this.date          = date;
       this.type          = type;
       this.subject       = subject;
@@ -110,6 +114,10 @@ public class XmlBackup {
 
     public String getAddress() {
       return address;
+    }
+
+    public String getThreadAddress() {
+      return threadAddress;
     }
 
     public long getDate() {
@@ -172,6 +180,9 @@ public class XmlBackup {
       stringBuilder.append(OPEN_TAG_SMS);
       appendAttribute(stringBuilder, PROTOCOL, item.getProtocol());
       appendAttribute(stringBuilder, ADDRESS, escapeXML(item.getAddress()));
+      if (item.getThreadAddress() != null && !item.getThreadAddress().equals(item.getAddress())) {
+        appendAttribute(stringBuilder, THREAD_ADDRESS, escapeXML(item.getThreadAddress()));
+      }
       appendAttribute(stringBuilder, DATE, item.getDate());
       appendAttribute(stringBuilder, TYPE, item.getType());
       appendAttribute(stringBuilder, SUBJECT, escapeXML(item.getSubject()));

--- a/src/org/thoughtcrime/securesms/database/XmlBackup.java
+++ b/src/org/thoughtcrime/securesms/database/XmlBackup.java
@@ -187,12 +187,12 @@ public class XmlBackup {
       appendAttribute(stringBuilder, TYPE, item.getType());
       appendAttribute(stringBuilder, SUBJECT, escapeXML(item.getSubject()));
       appendAttribute(stringBuilder, BODY, escapeXML(item.getBody()));
-      appendAttribute(stringBuilder, TOA, "null");
-      appendAttribute(stringBuilder, SC_TOA, "null");
+      // appendAttribute(stringBuilder, TOA, "null");
+      // appendAttribute(stringBuilder, SC_TOA, "null");
       appendAttribute(stringBuilder, SERVICE_CENTER, item.getServiceCenter());
       appendAttribute(stringBuilder, READ, item.getRead());
       appendAttribute(stringBuilder, STATUS, item.getStatus());
-      appendAttribute(stringBuilder, LOCKED, 0);
+      // appendAttribute(stringBuilder, LOCKED, 0);
       stringBuilder.append(CLOSE_EMPTYTAG);
 
       bufferedWriter.newLine();


### PR DESCRIPTION
This PR implements the export of MMS messages (without attachments, only text), fixes the import of group messages to the correct group thread instead of the sender's thread and fixes the export of the delivered state of Signal messages.
Previously messages sent in group threads were not exported, because they are always stored in MmsDatabase even if they only contain text, I’m not sure if this is intended or a bug.

The assignment to the correct group thread is implemented by adding an additional xml attribute "thread_address" that contains the thread recipient if that differs from the message recipient. For groups this is an id like this: "`__textsecure_group__!1b92cba8…`". The app SMS Backup & Restore doesn’t know this tag but simply ignores it when opening the Signal backup.
When importing into a new Signal instance the group thread will be called "Unnamed group" and you can’t send messages to the group until another member sends a group update message.
Fixes #3024

The last commit removes some attributes from the xml items that are always stored as "null" or 0. These attributes are marked as optional in the schema file of SMS Backup & Restore, see http://android.riteshsahu.com/wp-content/uploads/2014/03/sms.xsd_.txt

I’ll have a look at exporting attachments later, but that will be for another PR.