### PR TITLE
Stop inbox snippet from overflowing the thumbnail

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -178,6 +178,7 @@ public class ConversationListItem extends RelativeLayout
 
       LayoutParams subjectParams = (RelativeLayout.LayoutParams)this.subjectView.getLayoutParams();
       subjectParams.addRule(RelativeLayout.LEFT_OF, R.id.thumbnail);
+      subjectParams.addRule(RelativeLayout.START_OF, R.id.thumbnail);
       this.subjectView.setLayoutParams(subjectParams);
       this.post(new ThumbnailPositioner(thumbnailView, archivedView, deliveryStatusIndicator, dateView));
     } else {
@@ -185,6 +186,7 @@ public class ConversationListItem extends RelativeLayout
 
       LayoutParams subjectParams = (RelativeLayout.LayoutParams)this.subjectView.getLayoutParams();
       subjectParams.addRule(RelativeLayout.LEFT_OF, R.id.delivery_status);
+      subjectParams.addRule(RelativeLayout.START_OF, R.id.delivery_status);
       this.subjectView.setLayoutParams(subjectParams);
     }
   }
@@ -255,8 +257,10 @@ public class ConversationListItem extends RelativeLayout
           (archivedView.getWidth() + deliveryStatusView.getWidth()) > dateView.getWidth())
       {
         thumbnailParams.addRule(RelativeLayout.LEFT_OF, R.id.delivery_status);
+        thumbnailParams.addRule(RelativeLayout.START_OF, R.id.delivery_status);
       } else {
         thumbnailParams.addRule(RelativeLayout.LEFT_OF, R.id.date);
+        thumbnailParams.addRule(RelativeLayout.START_OF, R.id.date);
       }
 
       thumbnailView.setLayoutParams(thumbnailParams);


### PR DESCRIPTION
Also ensure the thumbnails are placed correctly in the archive view.

// FREEBIE

Before:
![kaputt](https://cloud.githubusercontent.com/assets/264472/11986654/523b803e-a9d2-11e5-89bd-188da1fbef0e.png)
After:
![gut](https://cloud.githubusercontent.com/assets/264472/11986657/566ced14-a9d2-11e5-9291-14a6b7c7f5ae.png)
