### PR TITLE
remove newlines in text-only group messages

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/OutgoingMediaMessage.java
+++ b/src/org/thoughtcrime/securesms/mms/OutgoingMediaMessage.java
@@ -29,7 +29,7 @@ public class OutgoingMediaMessage {
   public OutgoingMediaMessage(Recipients recipients, SlideDeck slideDeck, String message, long sentTimeMillis, int distributionType)
   {
     this(recipients,
-         TextUtils.isEmpty(message) ? slideDeck.getBody() : slideDeck.getBody() + "\n\n" + message,
+         buildMessage(slideDeck, message),
          slideDeck.asAttachments(),
          sentTimeMillis,
          distributionType);
@@ -71,4 +71,13 @@ public class OutgoingMediaMessage {
     return sentTimeMillis;
   }
 
+  private static String buildMessage(SlideDeck slideDeck, String message) {
+    if (!TextUtils.isEmpty(message) && !TextUtils.isEmpty(slideDeck.getBody())) {
+      return slideDeck.getBody() + "\n\n" + message;
+    } else if (!TextUtils.isEmpty(message)) {
+      return message;
+    } else {
+      return slideDeck.getBody();
+    }
+  }
 }


### PR DESCRIPTION
with this change (https://github.com/WhisperSystems/Signal-Android/commit/bcf95e50aa38cae2dfe640ea1a1e26cbaa3a84b7#diff-c36f0750d909b343079accc77ce529e2R32) text-only group messages always started with two newlines.

