### PR TITLE
completely hide location button on API < 16

### DIFF
--- a/res/layout/attachment_type_selector.xml
+++ b/res/layout/attachment_type_selector.xml
@@ -137,34 +137,27 @@
 
         </LinearLayout>
 
-        <LinearLayout android:layout_width="match_parent"
+        <LinearLayout android:id="@+id/location_linear_layout"
+                      android:layout_width="match_parent"
                       android:layout_height="wrap_content"
                       android:layout_weight="1"
                       android:gravity="center"
                       android:orientation="vertical">
 
-            <LinearLayout android:layout_width="match_parent"
-                          android:layout_height="wrap_content"
-                          android:layout_weight="1"
-                          android:gravity="center"
-                          android:orientation="vertical">
+            <org.thoughtcrime.securesms.components.CircleColorImageView
+                    android:id="@+id/location_button"
+                    android:layout_width="60dp"
+                    android:layout_height="60dp"
+                    android:src="@drawable/ic_location_on_white_36dp"
+                    android:scaleType="center"
+                    android:elevation="4dp"
+                    app:circleColor="@color/blue_grey_400"/>
 
-                <org.thoughtcrime.securesms.components.CircleColorImageView
-                        android:id="@+id/location_button"
-                        android:layout_width="60dp"
-                        android:layout_height="60dp"
-                        android:src="@drawable/ic_location_on_white_36dp"
-                        android:scaleType="center"
-                        android:elevation="4dp"
-                        app:circleColor="@color/blue_grey_400"/>
-
-                <TextView android:layout_marginTop="10dp"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          style="@style/AttachmentTypeLabel"
-                          android:text="@string/attachment_type_selector__location"/>
-
-            </LinearLayout>
+            <TextView android:layout_marginTop="10dp"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      style="@style/AttachmentTypeLabel"
+                      android:text="@string/attachment_type_selector__location"/>
 
         </LinearLayout>
 

--- a/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
+++ b/src/org/thoughtcrime/securesms/components/AttachmentTypeSelector.java
@@ -74,7 +74,7 @@ public class AttachmentTypeSelector extends PopupWindow {
     this.closeButton.setOnClickListener(new CloseClickListener());
 
     if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
-      this.locationButton.setVisibility(View.INVISIBLE);
+      ViewUtil.findById(layout, R.id.location_linear_layout).setVisibility(View.INVISIBLE);
     }
 
     setContentView(layout);


### PR DESCRIPTION
before / after (on GB):
![location](https://cloud.githubusercontent.com/assets/5296073/12003183/0d535548-ab15-11e5-9b6f-7865f233ac1b.png)

this also removes some unnecessary `LinearLayout` nesting...