### PR TITLE
Release MediaPlayers immediately after stopping ringers

### DIFF
--- a/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
@@ -56,7 +56,6 @@ public class IncomingRinger {
   public IncomingRinger(Context context) {
     this.context = context.getApplicationContext();
     vibrator = (Vibrator)context.getSystemService(Context.VIBRATOR_SERVICE);
-    player = createPlayer();
   }
 
   private MediaPlayer createPlayer() {
@@ -77,10 +76,8 @@ public class IncomingRinger {
   public void start() {
     AudioManager audioManager = ServiceUtil.getAudioManager(context);
 
-    if(player == null) {
-      //retry player creation to pick up changed ringtones or audio server restarts
-      player = createPlayer();
-    }
+    if (player != null) player.release();
+    player = createPlayer();
 
     int ringerMode = audioManager.getRingerMode();
 
@@ -113,6 +110,8 @@ public class IncomingRinger {
     if (player != null) {
       Log.d(TAG, "Stopping ringer");
       player.stop();
+      player.release();
+      player = null;
     }
     Log.d(TAG, "Cancelling vibrator");
     vibrator.cancel();

--- a/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
@@ -95,14 +95,8 @@ public class IncomingRinger {
       try {
         if(!player.isPlaying()) {
           player.prepare();
-          player.setOnSeekCompleteListener(new MediaPlayer.OnSeekCompleteListener() {
-            @Override
-            public void onSeekComplete(MediaPlayer mp) {
-              Log.d(TAG, "Playing ringtone now...");
-              mp.start();
-            }
-          });
-          player.seekTo(0);
+          player.start();
+          Log.d(TAG, "Playing ringtone now...");
         } else {
           Log.d(TAG, "Ringtone is already playing, declining to restart.");
         }

--- a/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/IncomingRinger.java
@@ -95,8 +95,14 @@ public class IncomingRinger {
       try {
         if(!player.isPlaying()) {
           player.prepare();
-          player.start();
-          Log.d(TAG, "Playing ringtone now...");
+          player.setOnSeekCompleteListener(new MediaPlayer.OnSeekCompleteListener() {
+            @Override
+            public void onSeekComplete(MediaPlayer mp) {
+              Log.d(TAG, "Playing ringtone now...");
+              mp.start();
+            }
+          });
+          player.seekTo(0);
         } else {
           Log.d(TAG, "Ringtone is already playing, declining to restart.");
         }

--- a/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
+++ b/src/org/thoughtcrime/redphone/audio/OutgoingRinger.java
@@ -115,6 +115,8 @@ public class OutgoingRinger implements MediaPlayer.OnCompletionListener, MediaPl
     if( mediaPlayer == null ) return;
     try {
       mediaPlayer.stop();
+      mediaPlayer.release();
+      mediaPlayer = null;
     } catch( IllegalStateException e ) {
     }
     currentSoundID = -1;


### PR DESCRIPTION
When receiving multiple subsequent calls, my Android 4.2 MTK device was incorrectly playing the ringtone from where it left off last time.
We do already call `stop()` and the docs say that should be enough, but my phone needs an extra `seekTo(0)`.

// FREEBIE