### PR TITLE
Extend DPAD support.

### DIFF
--- a/res/drawable/clickable_card_dark.xml
+++ b/res/drawable/clickable_card_dark.xml
@@ -6,5 +6,11 @@
         </shape>
         <layer-list android:src="@drawable/import_export_item_background_dark" />
     </item>
+    <item android:state_focused="true">
+        <shape>
+            <solid android:color="@color/import_export_touch_highlight_dark" />
+        </shape>
+        <layer-list android:src="@drawable/import_export_item_background_dark" />
+    </item>
     <item android:drawable="@drawable/import_export_item_background_dark" />
 </selector>

--- a/res/drawable/clickable_card_light.xml
+++ b/res/drawable/clickable_card_light.xml
@@ -6,5 +6,11 @@
         </shape>
         <layer-list android:src="@drawable/import_export_item_background_light" />
     </item>
+    <item android:state_focused="true">
+        <shape>
+            <solid android:color="@color/import_export_touch_highlight_light" />
+        </shape>
+        <layer-list android:src="@drawable/import_export_item_background_light" />
+    </item>
     <item android:drawable="@drawable/import_export_item_background_light" />
 </selector>

--- a/res/drawable/conversation_item_background.xml
+++ b/res/drawable/conversation_item_background.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
+    <item android:drawable="@color/signal_primary_alpha_focus" android:state_focused="true" />
 </selector>

--- a/res/drawable/conversation_list_item_read_background.xml
+++ b/res/drawable/conversation_list_item_read_background.xml
@@ -2,5 +2,6 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/signal_primary_alpha_focus" android:state_focused="true" />
     <item android:drawable="@color/conversation_list_item_background_read_light" />
 </selector>

--- a/res/drawable/conversation_list_item_read_background_dark.xml
+++ b/res/drawable/conversation_list_item_read_background_dark.xml
@@ -2,5 +2,6 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/signal_primary_alpha_focus" android:state_focused="true" />
     <item android:drawable="@color/conversation_list_item_background_read_dark" />
 </selector>

--- a/res/drawable/conversation_list_item_unread_background.xml
+++ b/res/drawable/conversation_list_item_unread_background.xml
@@ -2,5 +2,6 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/signal_primary_alpha_focus" android:state_focused="true" />
     <item android:drawable="@color/conversation_list_item_background_unread_light" />
 </selector>

--- a/res/drawable/conversation_list_item_unread_background_dark.xml
+++ b/res/drawable/conversation_list_item_unread_background_dark.xml
@@ -2,5 +2,6 @@
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_selected="true" />
     <item android:drawable="@color/textsecure_primary_alpha33" android:state_pressed="true" />
+    <item android:drawable="@color/signal_primary_alpha_focus" android:state_focused="true" />
     <item android:drawable="@color/conversation_list_item_background_unread_dark" />
 </selector>

--- a/res/drawable/reminder_background.xml
+++ b/res/drawable/reminder_background.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:state_pressed="true" android:drawable="@color/touch_highlight" />
+    <item android:state_pressed="true" android:drawable="@color/signal_primary" />
     <item android:state_focused="true" android:drawable="@color/signal_primary" />
-    <item android:drawable="@android:color/transparent" />
+    <item android:drawable="@color/signal_primary_dark" />
 </selector>

--- a/res/layout/contact_filter_toolbar.xml
+++ b/res/layout/contact_filter_toolbar.xml
@@ -47,6 +47,7 @@
                            android:layout_gravity="center_vertical"
                            android:gravity="center_vertical"
                            android:clickable="true"
+                           android:focusable="true"
                            android:background="@drawable/circle_touch_highlight_background"
                            android:src="@drawable/ic_dialpad_white_24dp" />
 
@@ -57,6 +58,7 @@
                            android:gravity="center_vertical"
                            android:clickable="true"
                            android:visibility="gone"
+                           android:focusable="true"
                            android:background="@drawable/circle_touch_highlight_background"
                            android:src="@drawable/ic_keyboard_white_24dp" />
 
@@ -67,6 +69,7 @@
                            android:gravity="center_vertical"
                            android:clickable="true"
                            android:visibility="gone"
+                           android:focusable="true"
                            android:background="@drawable/circle_touch_highlight_background"
                            android:src="@drawable/ic_clear_white_24dp" />
 

--- a/res/layout/contact_selection_list_item.xml
+++ b/res/layout/contact_selection_list_item.xml
@@ -8,6 +8,8 @@
         android:layout_height="?android:attr/listPreferredItemHeight"
         android:orientation="horizontal"
         android:gravity="center_vertical"
+        android:focusable="true"
+        android:background="@drawable/conversation_item_background"
         android:paddingLeft="48dp"
         android:paddingRight="20dp">
 

--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -6,6 +6,9 @@
         android:paddingRight="10dip"
         android:orientation="vertical"
         android:background="@drawable/conversation_item_background"
+        android:focusable="true"
+        android:nextFocusLeft="@+id/container"
+        android:nextFocusRight="@+id/embedded_text_editor"
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -7,6 +7,9 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
+        android:focusable="true"
+        android:nextFocusLeft="@id/container"
+        android:nextFocusRight="@id/embedded_text_editor"
         android:background="@drawable/conversation_item_background">
 
     <RelativeLayout android:layout_width="match_parent"

--- a/res/layout/conversation_list_item_view.xml
+++ b/res/layout/conversation_list_item_view.xml
@@ -4,6 +4,9 @@
         xmlns:app="http://schemas.android.com/apk/res-auto"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
+        android:focusable="true"
+        android:nextFocusRight="@+id/fab"
+        android:nextFocusLeft="@+id/container"
         android:layout_height="70dp">
 
     <org.thoughtcrime.securesms.components.AvatarImageView

--- a/res/layout/export_fragment.xml
+++ b/res/layout/export_fragment.xml
@@ -60,7 +60,8 @@
                       android:layout_height="wrap_content"
                       android:layout_marginTop="10dip"
                       android:background="?import_export_item_card_background"
-                      android:orientation="vertical">
+                      android:orientation="vertical"
+                      android:focusable="true">
 
             <LinearLayout android:orientation="horizontal"
                           android:layout_width="wrap_content"

--- a/res/layout/import_fragment.xml
+++ b/res/layout/import_fragment.xml
@@ -17,6 +17,7 @@
                   android:layout_width="match_parent"
                   android:layout_height="wrap_content"
                   android:background="?import_export_item_card_background"
+                  android:focusable="true"
                   android:orientation="vertical">
 
         <LinearLayout android:orientation="horizontal"
@@ -60,6 +61,7 @@
                   android:layout_height="wrap_content"
                   android:layout_marginTop="10dip"
                   android:background="?import_export_item_card_background"
+                  android:focusable="true"
                   android:orientation="vertical">
 
         <LinearLayout android:orientation="horizontal"
@@ -104,6 +106,7 @@
                   android:layout_height="wrap_content"
                   android:layout_marginTop="10dip"
                   android:background="?import_export_item_card_background"
+                  android:focusable="true"
                   android:orientation="vertical">
 
         <LinearLayout android:orientation="horizontal"

--- a/res/layout/reminder_header.xml
+++ b/res/layout/reminder_header.xml
@@ -13,7 +13,9 @@
                   tools:visibility="visible"
                   android:padding="2dp"
                   android:gravity="center_vertical"
-                  android:background="?reminder_header_background">
+                  android:focusable="true"
+                  android:nextFocusRight="@+id/cancel"
+                  android:background="@drawable/reminder_background">
 
         <LinearLayout android:id="@+id/reminder"
                       android:layout_width="0dp"
@@ -55,6 +57,9 @@
                              android:layout_width="40dp"
                              android:layout_height="40dp"
                              android:padding="10dp"
+                             android:focusable="true"
+                             android:nextFocusRight="@+id/container"
+                             android:nextFocusLeft="@+id/container"
                              android:background="@drawable/touch_highlight_background"
                              android:src="@drawable/ic_close_white_24dp"/>
             </LinearLayout>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -3,6 +3,7 @@
     <color name="signal_primary">#ff2090ea</color>
     <color name="signal_primary_dark">#ff1c7ac5</color>
     <color name="signal_primary_alpha33">#552090ea</color>
+    <color name="signal_primary_alpha_focus">#882090ea</color>
 
     <color name="textsecure_primary">@color/signal_primary</color>
     <color name="textsecure_primary_dark">@color/signal_primary_dark</color>

--- a/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
+++ b/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
@@ -109,6 +109,7 @@ public class MessageRecipientListItem extends RelativeLayout
     } else if (networkFailure != null || (!isPushGroup && record.isFailed())) {
       resendButton.setVisibility(View.VISIBLE);
       resendButton.setEnabled(true);
+      resendButton.requestFocus();
       conflictButton.setVisibility(View.GONE);
 
       errorText = getContext().getString(R.string.MessageDetailsRecipient_failed_to_send);

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -9,6 +9,7 @@ import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ArrayAdapter;
@@ -118,6 +119,17 @@ public class RegistrationActivity extends BaseActionBarActivity {
           startActivityForResult(intent, PICK_COUNTRY);
         }
         return true;
+      }
+    });
+    this.countrySpinner.setOnKeyListener(new View.OnKeyListener() {
+      @Override
+      public boolean onKey(View v, int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_DPAD_CENTER && event.getAction() == KeyEvent.ACTION_UP) {
+          Intent intent = new Intent(RegistrationActivity.this, CountrySelectionActivity.class);
+          startActivityForResult(intent, PICK_COUNTRY);
+          return true;
+        }
+        return false;
       }
     });
   }


### PR DESCRIPTION
This pull request is built upon the previous (#3585)

What this pull request adds:
* Allows the following to be selected, interacted with and visably indicated:
 * Conversations
 * Individual messages
 * Contacts
* Selection of the "Reminder" UI element, also interaction of the Reminder X (cancel) button
* Interaction with "Resend" button
* Left to jump to reminder notices, Right to jump to FAB or compose input while in a list.
* Control of the Country UI element in the registration screen.

Notes:
* Default to focus on Resend button on send error screen
  * Focus sink on error list item (only on some Android versions? 4.0.4), cannot navigate away, which means cannot actually select resend button. Other Android versions can focus away from the list item, but cannot select the actual Resend button. Default focus to address this problem.
  * Focus is set in code, might also be possible to set "request focus" in XML, but couldn't manage to cause a send fail manually to test
* While selection of "Reminder" alerts are possible, DPAD_CENTER does not actually perform the action. Don't know how to make this happen.
 * DPAD_CENTER on the X (cancel) button works, however.

The following are things that I couldn't figure out how to allow for hardware keypad to control these items:
* Cannot select the tick box in the upper left to accept members to add to a group (can mark their checkboxes though)
* Cannot select the X remove button to remove someone from group
* Cannot navigate pop-up Menu (New group, Mark all read, Invite friends, Import / export, etc... that menu)
* Cannot select/use the "Attachment" or camera/acquire UI elements
