### PR TITLE
Fix Redphone race conditions

### DIFF
--- a/src/org/thoughtcrime/redphone/RedPhone.java
+++ b/src/org/thoughtcrime/redphone/RedPhone.java
@@ -65,8 +65,9 @@ public class RedPhone extends Activity {
   public static final String DENY_ACTION     = RedPhone.class.getCanonicalName() + ".DENY_ACTION";
   public static final String END_CALL_ACTION = RedPhone.class.getCanonicalName() + ".END_CALL_ACTION";
 
-  private CallScreen        callScreen;
-  private BroadcastReceiver bluetoothStateReceiver;
+  private CallScreen          callScreen;
+  private BroadcastReceiver   bluetoothStateReceiver;
+  private AlertDialog.Builder dialog;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
@@ -161,7 +162,6 @@ public class RedPhone extends Activity {
       startService(intent);
 
       callScreen.setActiveCall(event.getRecipient(), getString(org.thoughtcrime.securesms.R.string.RedPhone_ending_call));
-      delayedFinish();
     }
   }
 
@@ -170,12 +170,6 @@ public class RedPhone extends Activity {
     Intent intent = new Intent(RedPhone.this, RedPhoneService.class);
     intent.setAction(RedPhoneService.ACTION_HANGUP_CALL);
     startService(intent);
-
-    RedPhoneEvent event = EventBus.getDefault().getStickyEvent(RedPhoneEvent.class);
-
-    if (event != null) {
-      RedPhone.this.handleTerminate(event.getRecipient());
-    }
   }
 
   private void handleIncomingCall(@NonNull RedPhoneEvent event) {
@@ -187,13 +181,7 @@ public class RedPhone extends Activity {
   }
 
   private void handleTerminate(@NonNull Recipient recipient /*, int terminationType */) {
-    Log.w(TAG, "handleTerminate called");
-    Log.w(TAG, "Termination Stack:", new Exception());
-
     callScreen.setActiveCall(recipient, getString(R.string.RedPhone_ending_call));
-    EventBus.getDefault().removeStickyEvent(RedPhoneEvent.class);
-
-    delayedFinish();
   }
 
   private void handleCallRinging(@NonNull RedPhoneEvent event) {
@@ -202,8 +190,6 @@ public class RedPhone extends Activity {
 
   private void handleCallBusy(@NonNull RedPhoneEvent event) {
     callScreen.setActiveCall(event.getRecipient(), getString(R.string.RedPhone_busy));
-
-    delayedFinish(BUSY_SIGNAL_DELAY_FINISH);
   }
 
   private void handleCallConnected(@NonNull RedPhoneEvent event) {
@@ -219,12 +205,10 @@ public class RedPhone extends Activity {
 
   private void handleHandshakeFailed(@NonNull RedPhoneEvent event) {
     callScreen.setActiveCall(event.getRecipient(), getString(R.string.RedPhone_handshake_failed));
-    delayedFinish();
   }
 
   private void handleRecipientUnavailable(@NonNull RedPhoneEvent event) {
     callScreen.setActiveCall(event.getRecipient(), getString(R.string.RedPhone_recipient_unavailable));
-    delayedFinish();
   }
 
   private void handlePerformingHandshake(@NonNull RedPhoneEvent event) {
@@ -233,67 +217,60 @@ public class RedPhone extends Activity {
 
   private void handleServerFailure(@NonNull RedPhoneEvent event) {
     callScreen.setActiveCall(event.getRecipient(), getString(R.string.RedPhone_network_failed));
-    delayedFinish();
   }
 
   private void handleClientFailure(final @NonNull RedPhoneEvent event) {
     callScreen.setActiveCall(event.getRecipient(), getString(R.string.RedPhone_client_failed));
     if( event.getExtra() != null && !isFinishing() ) {
-      AlertDialog.Builder ad = new AlertDialog.Builder(this);
-      ad.setTitle(R.string.RedPhone_fatal_error);
-      ad.setMessage(event.getExtra());
-      ad.setCancelable(false);
-      ad.setPositiveButton(android.R.string.ok, new OnClickListener() {
+      dialog = new AlertDialog.Builder(this);
+      dialog.setTitle(R.string.RedPhone_fatal_error);
+      dialog.setMessage(event.getExtra());
+      dialog.setCancelable(false);
+      dialog.setPositiveButton(android.R.string.ok, new OnClickListener() {
         public void onClick(DialogInterface dialog, int arg) {
-          RedPhone.this.handleTerminate(event.getRecipient());
+          RedPhone.this.delayedFinish(0);
         }
       });
-      ad.show();
+      dialog.show();
     }
   }
 
   private void handleLoginFailed(@NonNull RedPhoneEvent event) {
     callScreen.setActiveCall(event.getRecipient(), getString(R.string.RedPhone_login_failed));
-    delayedFinish();
   }
 
   private void handleServerMessage(final @NonNull RedPhoneEvent event) {
     if( isFinishing() ) return; //we're already shutting down, this might crash
-    AlertDialog.Builder ad = new AlertDialog.Builder(this);
-    ad.setTitle(R.string.RedPhone_message_from_the_server);
-    ad.setMessage(event.getExtra());
-    ad.setCancelable(false);
-    ad.setPositiveButton(android.R.string.ok, new OnClickListener() {
+    dialog = new AlertDialog.Builder(this);
+    dialog.setTitle(R.string.RedPhone_message_from_the_server);
+    dialog.setMessage(event.getExtra());
+    dialog.setCancelable(false);
+    dialog.setPositiveButton(android.R.string.ok, new OnClickListener() {
       public void onClick(DialogInterface dialog, int arg) {
-        RedPhone.this.handleTerminate(event.getRecipient());
+        RedPhone.this.delayedFinish(0);
       }
     });
-    ad.show();
+    dialog.show();
   }
 
   private void handleNoSuchUser(final @NonNull RedPhoneEvent event) {
     if (isFinishing()) return; // XXX Stuart added this check above, not sure why, so I'm repeating in ignorance. - moxie
-    AlertDialog.Builder dialog = new AlertDialog.Builder(this);
+    dialog = new AlertDialog.Builder(this);
     dialog.setTitle(R.string.RedPhone_number_not_registered);
     dialog.setIconAttribute(R.attr.dialog_alert_icon);
     dialog.setMessage(R.string.RedPhone_the_number_you_dialed_does_not_support_secure_voice);
-    dialog.setCancelable(true);
+    dialog.setCancelable(false);
     dialog.setPositiveButton(R.string.RedPhone_got_it, new OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        RedPhone.this.handleTerminate(event.getRecipient());
-      }
-    });
-    dialog.setOnCancelListener(new DialogInterface.OnCancelListener() {
-      @Override
-      public void onCancel(DialogInterface dialog) {
-        RedPhone.this.handleTerminate(event.getRecipient());
+        RedPhone.this.delayedFinish(0);
       }
     });
     dialog.show();
   }
 
   private void delayedFinish() {
+    if (dialog != null) return;
     delayedFinish(STANDARD_DELAY_FINISH);
   }
 
@@ -324,7 +301,8 @@ public class RedPhone extends Activity {
       case OUTGOING_CALL:           handleOutgoingCall(event);             break;
       case CALL_BUSY:               handleCallBusy(event);                 break;
       case LOGIN_FAILED:            handleLoginFailed(event);              break;
-      case CLIENT_FAILURE:			    handleClientFailure(event);            break;
+      case CLIENT_FAILURE:          handleClientFailure(event);            break;
+      case TERMINATE_NOW:           delayedFinish();                       break;
     }
   }
 

--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -79,11 +79,12 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
 
   private static final String TAG = RedPhoneService.class.getSimpleName();
 
-  private static final int STATE_IDLE      = 0;
-  private static final int STATE_RINGING   = 2;
-  private static final int STATE_DIALING   = 3;
-  private static final int STATE_ANSWERING = 4;
-  private static final int STATE_CONNECTED = 5;
+  private static final int STATE_IDLE        = 0;
+  private static final int STATE_RINGING     = 2;
+  private static final int STATE_DIALING     = 3;
+  private static final int STATE_ANSWERING   = 4;
+  private static final int STATE_CONNECTED   = 5;
+  private static final int STATE_TERMINATING = 6;
 
   public static final String EXTRA_REMOTE_NUMBER      = "remote_number";
   public static final String EXTRA_SESSION_DESCRIPTOR = "session_descriptor";
@@ -260,7 +261,6 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
   }
 
   private void handleDenyCall(Intent intent) {
-    state = STATE_IDLE;
     incomingRinger.stop();
     DatabaseFactory.getSmsDatabase(this).insertMissedCall(remoteNumber);
     if(currentCallManager != null) {
@@ -270,7 +270,10 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
   }
 
   private void handleHangupCall(Intent intent) {
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      sendMessage(Type.CALL_DISCONNECTED, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   private void handleSetMute(Intent intent) {
@@ -289,6 +292,15 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
 
   private boolean isIdle() {
     return state == STATE_IDLE;
+  }
+
+  private synchronized boolean getAndSetTerminated() {
+    if (state == STATE_IDLE || state == STATE_TERMINATING) {
+      return true;
+    }
+
+    state = STATE_TERMINATING;
+    return false;
   }
 
   private void initializeAudio() {
@@ -362,6 +374,7 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
 
   private synchronized void terminate() {
     Log.w(TAG, "termination stack", new Exception());
+    state = STATE_TERMINATING;
     lockManager.updatePhoneState(LockManager.PhoneState.PROCESSING);
     NotificationBarManager.setCallEnded(this);
 
@@ -375,6 +388,8 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
 
     shutdownAudio();
 
+    sendMessage(Type.TERMINATE_NOW, getRecipient(), null);
+    EventBus.getDefault().removeStickyEvent(RedPhoneEvent.class);
     state = STATE_IDLE;
     lockManager.updatePhoneState(LockManager.PhoneState.IDLE);
   }
@@ -435,22 +450,26 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
     if (state == STATE_RINGING)
       handleMissedCall(remoteNumber, false);
 
-    sendMessage(Type.CALL_DISCONNECTED, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      sendMessage(Type.CALL_DISCONNECTED, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyHandshakeFailed() {
-    state = STATE_IDLE;
-    outgoingRinger.playFailure();
-    sendMessage(Type.HANDSHAKE_FAILED, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      outgoingRinger.playFailure();
+      sendMessage(Type.HANDSHAKE_FAILED, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyRecipientUnavailable() {
-    state = STATE_IDLE;
-    outgoingRinger.playFailure();
-    sendMessage(Type.RECIPIENT_UNAVAILABLE, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      outgoingRinger.playFailure();
+      sendMessage(Type.RECIPIENT_UNAVAILABLE, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyPerformingHandshake() {
@@ -462,45 +481,54 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
     if (state == STATE_RINGING)
       handleMissedCall(remoteNumber, true);
 
-    state = STATE_IDLE;
-    outgoingRinger.playFailure();
-    sendMessage(Type.SERVER_FAILURE, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      outgoingRinger.playFailure();
+      sendMessage(Type.SERVER_FAILURE, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyClientFailure() {
     if (state == STATE_RINGING)
       handleMissedCall(remoteNumber, false);
 
-    state = STATE_IDLE;
-    outgoingRinger.playFailure();
-    sendMessage(Type.CLIENT_FAILURE, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      outgoingRinger.playFailure();
+      sendMessage(Type.CLIENT_FAILURE, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyLoginFailed() {
     if (state == STATE_RINGING)
       handleMissedCall(remoteNumber, true);
 
-    state = STATE_IDLE;
-    outgoingRinger.playFailure();
-    sendMessage(Type.LOGIN_FAILED, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      outgoingRinger.playFailure();
+      sendMessage(Type.LOGIN_FAILED, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyNoSuchUser() {
-    sendMessage(Type.NO_SUCH_USER, getRecipient(), null);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      sendMessage(Type.NO_SUCH_USER, getRecipient(), null);
+      this.terminate();
+    }
   }
 
   public void notifyServerMessage(String message) {
-    sendMessage(Type.SERVER_MESSAGE, getRecipient(), message);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      sendMessage(Type.SERVER_MESSAGE, getRecipient(), message);
+      this.terminate();
+    }
   }
 
   public void notifyClientError(String msg) {
-    sendMessage(Type.CLIENT_FAILURE, getRecipient(), msg);
-    this.terminate();
+    if (!this.getAndSetTerminated()) {
+      sendMessage(Type.CLIENT_FAILURE, getRecipient(), msg);
+      this.terminate();
+    }
   }
 
   public void notifyCallConnecting() {
@@ -537,6 +565,7 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
       case STATE_RINGING:
       case STATE_ANSWERING:
       case STATE_CONNECTED:
+      case STATE_TERMINATING:
         return true;
       default:
         Log.e(TAG, "Unhandled call state: " + state);

--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -443,6 +443,7 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
   }
 
   public void notifyConnectingtoInitiator() {
+    outgoingRinger.playHandshake();
     sendMessage(Type.CONNECTING_TO_INITIATOR, getRecipient(), null);
   }
 

--- a/src/org/thoughtcrime/redphone/audio/CallAudioManager.java
+++ b/src/org/thoughtcrime/redphone/audio/CallAudioManager.java
@@ -60,6 +60,7 @@ public class CallAudioManager {
   }
 
   public void terminate() {
+    Log.d(TAG, "terminate");
     stop(handle);
     dispose(handle);
   }

--- a/src/org/thoughtcrime/redphone/call/InitiatingCallManager.java
+++ b/src/org/thoughtcrime/redphone/call/InitiatingCallManager.java
@@ -31,6 +31,7 @@ import org.thoughtcrime.redphone.signaling.NetworkConnector;
 import org.thoughtcrime.redphone.signaling.NoSuchUserException;
 import org.thoughtcrime.redphone.signaling.OtpCounterProvider;
 import org.thoughtcrime.redphone.signaling.ServerMessageException;
+import org.thoughtcrime.redphone.signaling.SessionDescriptor;
 import org.thoughtcrime.redphone.signaling.SessionInitiationFailureException;
 import org.thoughtcrime.redphone.signaling.SignalingException;
 import org.thoughtcrime.redphone.signaling.SignalingSocket;
@@ -68,30 +69,36 @@ public class InitiatingCallManager extends CallManager {
   @Override
   public void run() {
     try {
-      callStateListener.notifyCallConnecting();
+      synchronized (this.initLock) {
+        if (this.terminated) return;
+        Log.d(TAG, "run");
 
-      signalingSocket = new SignalingSocket(context, BuildConfig.REDPHONE_RELAY_HOST,
-                                            31337, localNumber, password,
-                                            OtpCounterProvider.getInstance());
+        callStateListener.notifyCallConnecting();
 
-      sessionDescriptor = signalingSocket.initiateConnection(remoteNumber);
+        SignalingSocket signalingSocket = new SignalingSocket(context, BuildConfig.REDPHONE_RELAY_HOST,
+                                                              31337, localNumber, password,
+                                                              OtpCounterProvider.getInstance());
 
-      int localPort = new NetworkConnector(sessionDescriptor.sessionId,
-                                           sessionDescriptor.getFullServerName(),
-                                           sessionDescriptor.relayPort).makeConnection();
+        SessionDescriptor sessionDescriptor = signalingSocket.initiateConnection(remoteNumber);
 
-      InetSocketAddress remoteAddress = new InetSocketAddress(sessionDescriptor.getFullServerName(),
-                                                              sessionDescriptor.relayPort);
+        int localPort = new NetworkConnector(sessionDescriptor.sessionId,
+                                             sessionDescriptor.getFullServerName(),
+                                             sessionDescriptor.relayPort).makeConnection();
 
-      secureSocket  = new SecureRtpSocket(new RtpSocket(localPort, remoteAddress));
+        InetSocketAddress remoteAddress = new InetSocketAddress(sessionDescriptor.getFullServerName(),
+                                                                sessionDescriptor.relayPort);
 
-      zrtpSocket    = new ZRTPInitiatorSocket(context, secureSocket, zid, remoteNumber);
+        SecureRtpSocket secureSocket = new SecureRtpSocket(new RtpSocket(localPort, remoteAddress));
 
-      processSignals();
+        zrtpSocket = new ZRTPInitiatorSocket(context, secureSocket, zid, remoteNumber);
 
-      callStateListener.notifyWaitingForResponder();
+        processSignals(signalingSocket, sessionDescriptor);
+
+        callStateListener.notifyWaitingForResponder();
+      }
 
       super.run();
+
     } catch (NoSuchUserException nsue) {
       Log.w(TAG, nsue);
       callStateListener.notifyNoSuchUser();

--- a/src/org/thoughtcrime/redphone/call/ResponderCallManager.java
+++ b/src/org/thoughtcrime/redphone/call/ResponderCallManager.java
@@ -55,6 +55,8 @@ public class ResponderCallManager extends CallManager {
 
   private int answer = 0;
 
+  private SessionDescriptor sessionDescriptor;
+
   public ResponderCallManager(Context context, CallStateListener callStateListener,
                               String remoteNumber, String localNumber,
                               String password, SessionDescriptor sessionDescriptor,
@@ -70,34 +72,43 @@ public class ResponderCallManager extends CallManager {
   @Override
   public void run() {
     try {
-      signalingSocket = new SignalingSocket(context,
-                                            sessionDescriptor.getFullServerName(),
-                                            31337,
-                                            localNumber, password,
-                                            OtpCounterProvider.getInstance());
+      synchronized (this.initLock) {
+        if (this.terminated) return;
+        Log.d(TAG, "run");
 
-      signalingSocket.setRinging(sessionDescriptor.sessionId);
-      callStateListener.notifyCallFresh();
+        SignalingSocket signalingSocket = new SignalingSocket(context,
+                                                              sessionDescriptor.getFullServerName(),
+                                                              31337,
+                                                              localNumber, password,
+                                                              OtpCounterProvider.getInstance());
 
-      processSignals();
+        signalingSocket.setRinging(sessionDescriptor.sessionId);
+        callStateListener.notifyCallFresh();
+
+        processSignals(signalingSocket, sessionDescriptor);
+      }
 
       if (!waitForAnswer()) {
         return;
       }
 
-      int localPort = new NetworkConnector(sessionDescriptor.sessionId,
-                                           sessionDescriptor.getFullServerName(),
-                                           sessionDescriptor.relayPort).makeConnection();
+      synchronized (this.initLock) {
+        if (this.terminated) return;
+        int localPort = new NetworkConnector(sessionDescriptor.sessionId,
+                                             sessionDescriptor.getFullServerName(),
+                                             sessionDescriptor.relayPort).makeConnection();
 
-      InetSocketAddress remoteAddress = new InetSocketAddress(sessionDescriptor.getFullServerName(),
-                                                              sessionDescriptor.relayPort);
+        InetSocketAddress remoteAddress = new InetSocketAddress(sessionDescriptor.getFullServerName(),
+                                                                sessionDescriptor.relayPort);
 
-      secureSocket  = new SecureRtpSocket(new RtpSocket(localPort, remoteAddress));
-      zrtpSocket    = new ZRTPResponderSocket(context, secureSocket, zid, remoteNumber, sessionDescriptor.version <= 0);
+        SecureRtpSocket secureSocket = new SecureRtpSocket(new RtpSocket(localPort, remoteAddress));
+        zrtpSocket = new ZRTPResponderSocket(context, secureSocket, zid, remoteNumber, sessionDescriptor.version <= 0);
 
-      callStateListener.notifyConnectingtoInitiator();
+        callStateListener.notifyConnectingtoInitiator();
+      }
 
       super.run();
+
     } catch (SignalingException | SessionInitiationFailureException se) {
       Log.w(TAG, se);
       callStateListener.notifyServerFailure();

--- a/src/org/thoughtcrime/redphone/call/SignalManager.java
+++ b/src/org/thoughtcrime/redphone/call/SignalManager.java
@@ -33,6 +33,10 @@ public class SignalManager {
     this.queue.execute(new SignalListenerTask());
   }
 
+  public SessionDescriptor getSessionDescriptor() {
+    return this.sessionDescriptor;
+  }
+
   public void terminate() {
     Log.w(TAG, "Queuing hangup signal...");
     queue.execute(new Runnable() {

--- a/src/org/thoughtcrime/securesms/events/RedPhoneEvent.java
+++ b/src/org/thoughtcrime/securesms/events/RedPhoneEvent.java
@@ -24,7 +24,8 @@ public class RedPhoneEvent {
     LOGIN_FAILED,
     CLIENT_FAILURE,
     DEBUG_INFO,
-    NO_SUCH_USER
+    NO_SUCH_USER,
+    TERMINATE_NOW
   }
 
   private final @NonNull  Type      type;


### PR DESCRIPTION
Fixes #4172 

The debug log shows that `CallManager.terminate()` can be called by the user before the thread has run and the `signalManager` was initialized. It is then still initialized later but thus never properly terminated. That is fixed in the first commit.

```
RedPhoneService: onStart(): Intent { act=org.thoughtcrime.redphone.RedPhoneService.OUTGOING_CALL cmp=org.thoughtcrime.securesms/org.thoughtcrime.redphone.RedPhoneService (has extras) }
RedPhoneService: Received Intent: org.thoughtcrime.redphone.RedPhoneService.OUTGOING_CALL
RedPhoneService: request STREAM_VOICE_CALL audio focus
SignalingSocket: Connected to: 176.58.114.110
SignalingSocket: Sending signal...
RedPhoneService: onStart(): Intent { act=org.thoughtcrime.redphone.RedPhoneService.HANGUP cmp=org.thoughtcrime.securesms/org.thoughtcrime.redphone.RedPhoneService }
RedPhoneService: Received Intent: org.thoughtcrime.redphone.RedPhoneService.HANGUP
RedPhoneService: termination stack
                      java.lang.Exception
                          at org.thoughtcrime.redphone.RedPhoneService.terminate(RedPhoneService.java:361)
                          at org.thoughtcrime.redphone.RedPhoneService.handleHangupCall(RedPhoneService.java:271)
                          at org.thoughtcrime.redphone.RedPhoneService.onIntentReceived(RedPhoneService.java:150)
                          at org.thoughtcrime.redphone.RedPhoneService.access$200(RedPhoneService.java:77)
                          at org.thoughtcrime.redphone.RedPhoneService$IntentRunnable.run(RedPhoneService.java:525)
                          at java.lang.Thread.run(Thread.java:818)
CallManager: terminate
RedPhoneService: reset audio mode and abandon focus
CallManager: Starting signal processing loop...
CallManager: negotiating...
SignalManager: Running Signal Listener...
SignalManager: Signal Listener Running, interrupted: false
SignalManager: Received keep-alive...
... some time later ...
SignalManager: Running Signal Listener...
SignalManager: Signal Listener Running, interrupted: false
SignalManager: Received keep-alive...
...
```

During termination I noticed that for example network failures will still trigger a failure sound even if the user meanwhile ended the call. The second commit of this PR fixes that, the call screen will now stay visible until `RedPhoneService` has fully terminated.

Since the bug can still be caused intentionally, the time that a call can ring should be limited. Phone companies do that as well. See fourth commit.

I recommend to check the commits separately and suppress white space changes.