### PR TITLE
Revert #4885 requestAudioFocus change

### DIFF
--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -293,8 +293,9 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
     AudioManager audioManager = ServiceUtil.getAudioManager(this);
     AudioUtils.resetConfiguration(this);
 
-    Log.d(TAG, "request STREAM_VOICE_CALL audio focus");
-    audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL, AudioManager.AUDIOFOCUS_GAIN);
+    Log.d(TAG, "request STREAM_VOICE_CALL transient audio focus");
+    audioManager.requestAudioFocus(null, AudioManager.STREAM_VOICE_CALL,
+                                   AudioManager.AUDIOFOCUS_GAIN_TRANSIENT);
   }
 
   private void shutdownAudio() {


### PR DESCRIPTION
@moxie0 this reverts a small change that I made in #4885, so it is relevant for a 3.9.1 release.
According to the docs, `TRANSIENT` should be used for "a short amount of time", but using it allows music etc. to automatically continue playing after the call.

// FREEBIE