### PR TITLE
Theme background color in device link card

### DIFF
--- a/res/layout/device_add_fragment.xml
+++ b/res/layout/device_add_fragment.xml
@@ -30,7 +30,7 @@
             android:layout_weight="1"
             android:paddingLeft="16dp"
             android:paddingRight="16dp"
-            android:background="@color/gray5"
+            android:background="?android:windowBackground"
             android:gravity="center">
 
             <ImageView android:id="@+id/devices"
@@ -44,7 +44,7 @@
             <TextView android:text="@string/device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
-                      android:textColor="#ff6d6d6d"/>
+                      android:textColor="?android:textColorSecondary"/>
 
 
         </LinearLayout>

--- a/res/layout/device_link_fragment.xml
+++ b/res/layout/device_link_fragment.xml
@@ -22,7 +22,8 @@
 
         <LinearLayout android:layout_width="match_parent"
                       android:layout_height="match_parent"
-                      android:orientation="vertical">
+                      android:orientation="vertical"
+                      android:background="?device_link_item_card_background">
 
             <TextView
                     android:layout_width="wrap_content"

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -78,6 +78,8 @@
     <attr name="contact_selection_label_text" format="reference|color" />
     <attr name="contact_selection_header_text" format="reference|color" />
 
+    <attr name="device_link_item_card_background" format="reference|color" />
+
     <attr name="import_export_item_background_color" format="reference|color" />
     <attr name="import_export_item_background_shadow_color" format="reference|color" />
     <attr name="import_export_item_card_background" format="reference" />

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -40,6 +40,9 @@
     <color name="light_button">#33ffffff</color>
     <color name="light_button_highlight">#66ffffff</color>
 
+    <color name="device_link_item_background_light">#ffffffff</color>
+    <color name="device_link_item_background_dark">#ff333333</color>
+
     <color name="import_export_item_background_light">#ffeeeeee</color>
     <color name="import_export_item_background_dark">#ff333333</color>
     <color name="import_export_item_background_shadow_light">#ffd5d5d5</color>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -155,6 +155,8 @@
         <item name="dialog_info_icon">@drawable/ic_info_outline_light</item>
         <item name="dialog_alert_icon">@drawable/ic_warning_light</item>
 
+        <item name="device_link_item_card_background">@color/device_link_item_background_light</item>
+
         <item name="import_export_item_background_color">@color/import_export_item_background_light</item>
         <item name="import_export_item_background_shadow_color">@color/import_export_item_background_shadow_light</item>
         <item name="import_export_item_card_background">@drawable/clickable_card_light</item>
@@ -233,6 +235,8 @@
 
         <item name="dialog_info_icon">@drawable/ic_info_outline_dark</item>
         <item name="dialog_alert_icon">@drawable/ic_warning_dark</item>
+
+        <item name="device_link_item_card_background">@color/device_link_item_background_dark</item>
 
         <item name="import_export_item_background_color">@color/import_export_item_background_dark</item>
         <item name="import_export_item_background_shadow_color">@color/import_export_item_background_shadow_dark</item>


### PR DESCRIPTION
Fix an issue where the card was almost unreadable on dark theme. The text was themed as expected, to very light grey, but the background of the card remained white.

Before and after:

![Before and after comparison](https://i.imgur.com/lVy2MBk.png)