### PR TITLE
Change device add string to refer only to Desktop

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -688,7 +688,7 @@
     <string name="country_selection_fragment__search">Search</string>
 
     <!-- device_add_fragment -->
-    <string name="device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link">Scan the QR code displayed on the device to link</string>
+    <string name="device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link">Scan the QR code displayed on Signal Desktop to link</string>
 
     <!-- device_link_fragment -->
     <string name="device_link_fragment__link_device">Link device</string>


### PR DESCRIPTION
It seems that some users (#4642, #5102, https://github.com/WhisperSystems/Signal-Desktop/issues/624) are trying to link Signal with their other mobile devices even though only Desktop beta is supported.

This will change the string in the scanning view to give a nudge in the right direction:
_"Scan the QR code displayed on **the device** to link"_
**-->**
_"Scan the QR code displayed on **Signal Desktop** to link"_

This is a temporary fix so I didn't change the name of the string itself.

// FREEBIE