### PR TITLE
Use switch instead of checkbox for emoji setting.

### DIFF
--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -13,7 +13,8 @@
                         android:summary="@string/preferences__pressing_the_enter_key_will_send_text_messages"
                         android:title="@string/preferences__pref_enter_sends_title"/>
 
-    <CheckBoxPreference android:defaultValue="false"
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
                         android:key="pref_system_emoji"
                         android:title="@string/preferences_advanced__use_system_emoji"
                         android:summary="@string/preferences_advanced__disable_signal_built_in_emoji_support" />


### PR DESCRIPTION
Material design guidelines recommend on/off switches instead of checkboxes
for toggling single value options.

// FREEBIE