### PR TITLE
Attack vector: added alternative to failed bitmap, otherwise app becomes unusable.

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -22,6 +22,7 @@ import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.resource.bitmap.BitmapResource;
 import com.bumptech.glide.load.resource.bitmap.Downsampler;
 import com.bumptech.glide.load.resource.bitmap.FitCenter;
+import com.bumptech.glide.Util;
 
 import org.thoughtcrime.securesms.mms.MediaConstraints;
 
@@ -101,7 +102,9 @@ public class BitmapUtil {
                                                      DecodeFormat.PREFER_RGB_565);
 
     final Resource<Bitmap> resource = BitmapResource.obtain(rough, Glide.get(context).getBitmapPool());
-    final Resource<Bitmap> result   = new FitCenter(context).transform(resource, width, height);
+    final Resource<Bitmap> result   = Util.isValidDimensions(width,height)?
+                            new FitCenter(context).transform(resource, width, height):
+                      BitmapFactory.decodeResource(context.getResources(),R.drawable.ic_error_red_24dp);
 
     if (result == null) {
       throw new BitmapDecodingException("unable to transform Bitmap");


### PR DESCRIPTION
This could be used by attacker to force use of less secure methods, and possibly
other damage to device, simply by renaming a file to an incorrect mime-type. A bug report was filed (4228) so  more elegant solutions are welcome! This patch adds a "Util.isValidDimensions()" call from Glide to anticipate failure, and prepare a default Bitmap instead of crashing. The default error is left, in case the default BitMap cannot be used. 