### PR TITLE
Check if bitmap is not null in createScaledBitmapInto

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -101,6 +101,10 @@ public class BitmapUtil {
                                                      DecodeFormat.PREFER_RGB_565);
 
     final Resource<Bitmap> resource = BitmapResource.obtain(rough, Glide.get(context).getBitmapPool());
+    if (resource == null) {
+      throw new BitmapDecodingException("unable to obtain Bitmap");
+    }
+
     final Resource<Bitmap> result   = new FitCenter(context).transform(resource, width, height);
 
     if (result == null) {


### PR DESCRIPTION
Once I've tried to share an image from the gallery application on my phone to Signal and it failed, resulting in a state such that Signal would not be able to start any more and would directly crash with a NullPointerException. I've fixed the reason for this with the following:

This patch adds an additional check in createScaledBitmapInto that checks if the bitmap resource could be obtained before trying to apply a transformation on it to prevent a NullPointerException.