### PR TITLE
Fix text emoji pane font size and vertical align

### DIFF
--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiView.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiView.java
@@ -3,7 +3,6 @@ package org.thoughtcrime.securesms.components.emoji;
 import android.content.Context;
 import android.graphics.Canvas;
 import android.graphics.Paint;
-import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.util.AttributeSet;
@@ -17,7 +16,6 @@ public class EmojiView extends View implements Drawable.Callback {
   private Drawable drawable;
 
   private final Paint paint      = new Paint(Paint.ANTI_ALIAS_FLAG | Paint.FILTER_BITMAP_FLAG);
-  private final Rect  textBounds = new Rect();
 
   public EmojiView(Context context) {
     this(context, null);
@@ -54,12 +52,17 @@ public class EmojiView extends View implements Drawable.Callback {
       float targetFontSize = 0.75f * getHeight() - getPaddingTop() - getPaddingBottom();
       paint.setTextSize(targetFontSize);
       paint.setColor(ResUtil.getColor(getContext(), R.attr.emoji_text_color));
-      paint.getTextBounds(emoji, 0, emoji.length(), textBounds);
-      float overflow = textBounds.width() / (getWidth() - getPaddingLeft() - getPaddingRight());
+      paint.setTextAlign(Paint.Align.CENTER);
+      int xPos = (canvas.getWidth() / 2);
+      int yPos = (int) ((canvas.getHeight() / 2) - ((paint.descent() + paint.ascent()) / 2));
+
+      float overflow = paint.measureText(emoji) /
+          (getWidth() - getPaddingLeft() - getPaddingRight());
       if (overflow > 1f) {
         paint.setTextSize(targetFontSize / overflow);
+        yPos = (int) ((canvas.getHeight() / 2) - ((paint.descent() + paint.ascent()) / 2));
       }
-      canvas.drawText(emoji, 0.5f * (getWidth() - textBounds.width()), 0.5f * (getHeight() + textBounds.height()), paint);
+      canvas.drawText(emoji, xPos, yPos, paint);
     }
   }
 


### PR DESCRIPTION
The font size/resizing due to width overflow isn't working correctly, plus vertical alignment is inconsistent in the text-emoji drawer pane. This converts to the more precise `measureText()` instead of `getTextBounds()`, plus removes the Rect.

Example images use numbers to show the decreasing font size, `fg` as an example of high ascender and low descender letters, and a few new text-emoji. Max usable text size seems to be about 9 characters, but depends on content.

**Before**
![signal-badresize](https://cloud.githubusercontent.com/assets/195061/12901610/74f69898-ce71-11e5-8e01-4eb3cb723224.png)

**After**
![signal-goodresize](https://cloud.githubusercontent.com/assets/195061/12901613/773c99b8-ce71-11e5-8c41-0849005734d2.png)

Found during and for #5191
Fixes #3426