### PR TITLE
Exclude call screen from recents

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -108,6 +108,7 @@
                android:value="GlideModule" />
 
     <activity android:name="org.thoughtcrime.redphone.RedPhone"
+              android:excludeFromRecents="true"
               android:screenOrientation="portrait"
               android:configChanges="mcc|mnc|locale|touchscreen|keyboard|keyboardHidden|navigation|orientation|screenLayout|screenSize|fontScale"
               android:launchMode="singleTask">
@@ -339,6 +340,7 @@
     </activity>
 
     <activity android:name="org.thoughtcrime.redphone.RedPhoneShare"
+              android:excludeFromRecents="true"
               android:theme="@style/NoAnimation.Theme.BlackScreen"
               android:launchMode="singleTask"
               android:configChanges="touchscreen|keyboard|keyboardHidden|orientation|screenLayout|screenSize">


### PR DESCRIPTION
Opening Signal from recent apps list after a call is flawed.

Steps to reproduce:
- open a Signal contact in Android system contacts app
- click "Signal call" -> call screen shows up, Signal immediately starts the call
- end the call -> Signal disappears to the background
- open Signal from recent apps list

Problem: Signal opens in call screen, starts a new call to the last called contact

Another glitch: opening Signal from recent apps list after ending or rejecting an incoming call is also unusable

// FREEBIE