### PR TITLE
Replace passphrase mismatch toast with error

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphrasePromptActivity.java
@@ -35,7 +35,6 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.EditText;
 import android.widget.ImageButton;
 import android.widget.TextView;
-import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.AnimatingToggle;
 import org.thoughtcrime.securesms.crypto.InvalidPassphraseException;
@@ -116,8 +115,8 @@ public class PassphrasePromptActivity extends PassphraseActivity {
       setMasterSecret(masterSecret);
     } catch (InvalidPassphraseException ipe) {
       passphraseText.setText("");
-      Toast.makeText(this, R.string.PassphrasePromptActivity_invalid_passphrase_exclamation,
-                     Toast.LENGTH_SHORT).show();
+      passphraseText.setError(
+              getString(R.string.PassphrasePromptActivity_invalid_passphrase_exclamation));
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Display a form error instead of a toast if the passphrase
doesn't match. This is easier to spot, especially on larger devices where the distance between the input field and the toast can be pretty large and is persistent until the next character is typed.

The result looks like this:
<img src="https://cloud.githubusercontent.com/assets/9906/13192189/40e2b67e-d761-11e5-90d7-980a6e01a1d8.png" width=400>

I've looked through previous issues/PRs but couldn't find anything about this. I'm not sure if there was a reason for choosing toasts over errors.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/whispersystems/signal-android/5268)
<!-- Reviewable:end -->
