### PR TITLE
Replace Toasts in PassphraseChangeActivity with Errors

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseChangeActivity.java
@@ -16,16 +16,15 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.os.AsyncTask;
 import android.content.Context;
-import android.util.Log;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.Editable;
+import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 import android.widget.EditText;
-import android.widget.Toast;
 
 import org.thoughtcrime.securesms.crypto.InvalidPassphraseException;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -101,15 +100,11 @@ public class PassphraseChangeActivity extends PassphraseActivity {
     }
 
     if (!passphrase.equals(passphraseRepeat)) {
-      Toast.makeText(getApplicationContext(),
-                     R.string.PassphraseChangeActivity_passphrases_dont_match_exclamation,
-                     Toast.LENGTH_SHORT).show();
       this.newPassphrase.setText("");
       this.repeatPassphrase.setText("");
+      this.newPassphrase.setError(getString(R.string.PassphraseChangeActivity_passphrases_dont_match_exclamation));
     } else if (passphrase.equals("")) {
-      Toast.makeText(getApplicationContext(),
-                     R.string.PassphraseChangeActivity_enter_new_passphrase_exclamation,
-                     Toast.LENGTH_SHORT).show();
+      this.newPassphrase.setError(getString(R.string.PassphraseChangeActivity_enter_new_passphrase_exclamation));
     } else {
       new ChangePassphraseTask(this).execute(original, passphrase);
     }
@@ -160,9 +155,8 @@ public class PassphraseChangeActivity extends PassphraseActivity {
       if (masterSecret != null) {
         setMasterSecret(masterSecret);
       } else {
-        Toast.makeText(context, R.string.PassphraseChangeActivity_incorrect_old_passphrase_exclamation,
-                       Toast.LENGTH_LONG).show();
         originalPassphrase.setText("");
+        originalPassphrase.setError(getString(R.string.PassphraseChangeActivity_incorrect_old_passphrase_exclamation));
       }
     }
   }


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

As a follow-up to #5268, this replaces the toasts in the change passphrase activity with error popups that are displayed in the corresponding input boxes.

