### PR TITLE
add notification stacking to display message text properly on wearables

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -30,7 +30,7 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
       Log.w("TAG", "threadIds length: " + threadIds.length);
 
       ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-                                   .cancel(MessageNotifier.NOTIFICATION_ID);
+                                   .cancel(MessageNotifier.SUMMARY_NOTIFICATION_ID);
 
       new AsyncTask<Void, Void, Void>() {
         @Override

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -60,6 +60,7 @@ import org.whispersystems.textsecure.api.messages.TextSecureEnvelope;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import me.leolin.shortcutbadger.ShortcutBadger;
 
@@ -75,11 +76,15 @@ public class MessageNotifier {
 
   private static final String TAG = MessageNotifier.class.getSimpleName();
 
-  public static final int NOTIFICATION_ID = 1338;
+  private static AtomicInteger notificationCounter = new AtomicInteger(0);
+
+  public static final int SUMMARY_NOTIFICATION_ID = 1338;
 
   private volatile static long visibleThread = -1;
 
   public static final String EXTRA_VOICE_REPLY = "extra_voice_reply";
+
+  public final static String GROUP_KEY_MESSAGES = "group_key_messages";
 
   public static void setVisibleThread(long threadId) {
     visibleThread = threadId;
@@ -169,7 +174,7 @@ public class MessageNotifier {
           (pushCursor == null || pushCursor.isAfterLast()))
       {
         ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+          .cancel(SUMMARY_NOTIFICATION_ID);
         updateBadge(context, 0);
         clearReminder(context);
         return;
@@ -181,10 +186,10 @@ public class MessageNotifier {
         appendPushNotificationState(context, notificationState, pushCursor);
       }
 
-      if (notificationState.hasMultipleThreads()) {
+      sendSingleThreadNotification(context, masterSecret, notificationState, signal);
+
+      if (notificationState.getMessageCount() > 1) {
         sendMultipleThreadNotification(context, notificationState, signal);
-      } else {
-        sendSingleThreadNotification(context, masterSecret, notificationState, signal);
       }
 
       updateBadge(context, notificationState.getMessageCount());
@@ -203,9 +208,11 @@ public class MessageNotifier {
                                                    @NonNull  NotificationState notificationState,
                                                    boolean signal)
   {
+    int notificationId = notificationCounter.getAndIncrement();
+
     if (notificationState.getNotifications().isEmpty()) {
       ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+          .cancelAll();
       return;
     }
 
@@ -223,9 +230,9 @@ public class MessageNotifier {
     if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.addActions(masterSecret,
-                       notificationState.getMarkAsReadIntent(context),
-                       notificationState.getQuickReplyIntent(context, notifications.get(0).getRecipients()),
-                       notificationState.getWearableReplyIntent(context, notifications.get(0).getRecipients()));
+                       notificationState.getMarkAsReadIntent(context, notificationId, notifications.get(0).getThreadId()),
+                       notificationState.getQuickReplyIntent(context, notifications.get(0).getRecipients(), notificationId),
+                       notificationState.getWearableReplyIntent(context, notifications.get(0).getRecipients(), notificationId));
 
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
 
@@ -241,7 +248,12 @@ public class MessageNotifier {
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(NOTIFICATION_ID, builder.build());
+      .notify(notificationId, builder.build());
+
+    if (notificationState.getThreadCount() > 1) {
+      sendMultipleThreadNotification(context, notificationState, signal);
+    }
+
   }
 
   private static void sendMultipleThreadNotification(@NonNull  Context context,
@@ -257,7 +269,7 @@ public class MessageNotifier {
     long timestamp = notifications.get(0).getTimestamp();
     if (timestamp != 0) builder.setWhen(timestamp);
 
-    builder.addActions(notificationState.getMarkAsReadIntent(context));
+    builder.addActions(notificationState.getMarkAsReadIntent(context, SUMMARY_NOTIFICATION_ID, null));
 
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
 
@@ -272,7 +284,7 @@ public class MessageNotifier {
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(NOTIFICATION_ID, builder.build());
+      .notify(SUMMARY_NOTIFICATION_ID, builder.build());
   }
 
   private static void sendInThreadNotification(Context context, Recipients recipients) {

--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -31,6 +31,8 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(MessageNotifier.GROUP_KEY_MESSAGES);
+    setGroupSummary(true);
   }
 
   public void setMessageCount(int messageCount, int threadCount) {

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -70,13 +70,15 @@ public class NotificationState {
     return notifications;
   }
 
-  public PendingIntent getMarkAsReadIntent(Context context) {
+  public PendingIntent getMarkAsReadIntent(Context context, int notificationId, @Nullable Long threadId) {
     long[] threadArray = new long[threads.size()];
     int    index       = 0;
 
     for (long thread : threads) {
-      Log.w("NotificationState", "Added thread: " + thread);
-      threadArray[index++] = thread;
+      if (threadId == null || threadId == thread) {
+        Log.w("NotificationState", "Added thread: " + thread);
+        threadArray[index++] = thread;
+      }
     }
 
     Intent intent = new Intent(MarkReadReceiver.CLEAR_ACTION);
@@ -89,28 +91,24 @@ public class NotificationState {
     Log.w("NotificationState", "Pending array off intent length: " +
         intent.getLongArrayExtra("thread_ids").length);
 
-    return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getBroadcast(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
-  public PendingIntent getWearableReplyIntent(Context context, Recipients recipients) {
-    if (threads.size() != 1) throw new AssertionError("We only support replies to single thread notifications!");
-
+  public PendingIntent getWearableReplyIntent(Context context, Recipients recipients, int notificationId) {
     Intent intent = new Intent(WearReplyReceiver.REPLY_ACTION);
     intent.putExtra(WearReplyReceiver.RECIPIENT_IDS_EXTRA, recipients.getIds());
     intent.setPackage(context.getPackageName());
 
-    return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getBroadcast(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
-  public PendingIntent getQuickReplyIntent(Context context, Recipients recipients) {
-    if (threads.size() != 1) throw new AssertionError("We only support replies to single thread notifications!");
-
+  public PendingIntent getQuickReplyIntent(Context context, Recipients recipients, int notificationId) {
     Intent     intent           = new Intent(context, ConversationPopupActivity.class);
     intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, (long)threads.toArray()[0]);
     intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
 
-    return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
 

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -53,6 +53,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(MessageNotifier.GROUP_KEY_MESSAGES);
   }
 
   public void setThread(@NonNull Recipients recipients) {


### PR DESCRIPTION
<!-- You can remove this section if you have contributed before -->
### First time contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 6P, Android 6.0.1
 * Pebble Time, v3.9.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Just switched from Telegram and love Signal, but hated that notifications didn't work properly on my wearable, so I decided to take a stab at it. I implemented my fix based on [Stacking Notifications](http://developer.android.com/training/wearables/notifications/stacks.html).

- Summary notification always uses the same id
- the individual stacked notifications use an `AtomicInteger` to generate unique notification IDs
- all intents had to be changed to so that they are distinct ([see here](http://developer.android.com/intl/pt-br/reference/android/app/PendingIntent.html#getActivity(android.content.Context, int, android.content.Intent, int))), so that a reply sent from a wearable will go to the right person
- the `markAsRead` intent had to be modified so that it could mark individual messages as read from a wearable notification, as well as marking all as read with the already existing behavior
- tested with a Pebble, but it uses Android Wear, so it effectively works the same way interacting with notifications
- fix for #2525 