### PR TITLE
add notification stacking to display message text properly on wearables

### DIFF
--- a/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
+++ b/src/org/thoughtcrime/securesms/database/DatabaseFactory.java
@@ -72,7 +72,8 @@ public class DatabaseFactory {
   private static final int INTRODUCED_CONVERSATION_LIST_STATUS_VERSION     = 25;
   private static final int MIGRATED_CONVERSATION_LIST_STATUS_VERSION       = 26;
   private static final int INTRODUCED_SUBSCRIPTION_ID_VERSION              = 27;
-  private static final int DATABASE_VERSION                                = 27;
+  private static final int INTRODUCED_ALREADY_NOTIFIED_VERSION              = 28;
+  private static final int DATABASE_VERSION                                = 28;
 
   private static final String DATABASE_NAME    = "messages.db";
   private static final Object lock             = new Object();
@@ -818,6 +819,11 @@ public class DatabaseFactory {
         db.execSQL("ALTER TABLE recipient_preferences ADD COLUMN default_subscription_id INTEGER DEFAULT -1");
         db.execSQL("ALTER TABLE sms ADD COLUMN subscription_id INTEGER DEFAULT -1");
         db.execSQL("ALTER TABLE mms ADD COLUMN subscription_id INTEGER DEFAULT -1");
+      }
+
+      if (oldVersion < INTRODUCED_ALREADY_NOTIFIED_VERSION) {
+        db.execSQL("ALTER TABLE sms ADD COLUMN already_notified INTEGER DEFAULT 0");
+        db.execSQL("ALTER TABLE mms ADD COLUMN already_notified INTEGER DEFAULT 0");
       }
 
       db.setTransactionSuccessful();

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -110,7 +110,7 @@ public class MmsDatabase extends MessagingDatabase {
     "ct_cls" + " INTEGER, " + "resp_txt" + " TEXT, " + "d_tm" + " INTEGER, "     +
     RECEIPT_COUNT + " INTEGER DEFAULT 0, " + MISMATCHED_IDENTITIES + " TEXT DEFAULT NULL, "     +
     NETWORK_FAILURE + " TEXT DEFAULT NULL," + "d_rpt" + " INTEGER, " +
-    SUBSCRIPTION_ID + " INTEGER DEFAULT -1);";
+    SUBSCRIPTION_ID + " INTEGER DEFAULT -1," + ALREADY_NOTIFIED + " INTEGER DEFAULT 0" + ");";
 
   public static final String[] CREATE_INDEXS = {
     "CREATE INDEX IF NOT EXISTS mms_thread_id_index ON " + TABLE_NAME + " (" + THREAD_ID + ");",
@@ -129,7 +129,7 @@ public class MmsDatabase extends MessagingDatabase {
       CONTENT_LOCATION, EXPIRY, MESSAGE_TYPE,
       MESSAGE_SIZE, STATUS, TRANSACTION_ID,
       BODY, PART_COUNT, ADDRESS, ADDRESS_DEVICE_ID,
-      RECEIPT_COUNT, MISMATCHED_IDENTITIES, NETWORK_FAILURE, SUBSCRIPTION_ID,
+      RECEIPT_COUNT, MISMATCHED_IDENTITIES, NETWORK_FAILURE, SUBSCRIPTION_ID, ALREADY_NOTIFIED,
       AttachmentDatabase.TABLE_NAME + "." + AttachmentDatabase.ROW_ID + " AS " + AttachmentDatabase.ATTACHMENT_ID_ALIAS,
       AttachmentDatabase.UNIQUE_ID,
       AttachmentDatabase.MMS_ID,
@@ -446,6 +446,14 @@ public class MmsDatabase extends MessagingDatabase {
     contentValues.put(READ, 1);
 
     database.update(TABLE_NAME, contentValues, null, null);
+  }
+
+  public void setAlreadyNotified(long messageId) {
+    SQLiteDatabase database     = databaseHelper.getWritableDatabase();
+    ContentValues contentValues = new ContentValues();
+    contentValues.put(ALREADY_NOTIFIED, 1);
+
+    database.update(TABLE_NAME, contentValues, ID + " = ?", new String[] {messageId + ""});
   }
 
   public void updateMessageBody(MasterSecretUnion masterSecret, long messageId, String body) {
@@ -1027,6 +1035,7 @@ public class MmsDatabase extends MessagingDatabase {
       int status                 = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.STATUS));
       int receiptCount           = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.RECEIPT_COUNT));
       int subscriptionId         = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.SUBSCRIPTION_ID));
+      int alreadyNotified        = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.ALREADY_NOTIFIED));
 
       byte[]contentLocationBytes = null;
       byte[]transactionIdBytes   = null;
@@ -1041,7 +1050,8 @@ public class MmsDatabase extends MessagingDatabase {
       return new NotificationMmsMessageRecord(context, id, recipients, recipients.getPrimaryRecipient(),
                                               addressDeviceId, dateSent, dateReceived, receiptCount, threadId,
                                               contentLocationBytes, messageSize, expiry, status,
-                                              transactionIdBytes, mailbox, subscriptionId);
+                                              transactionIdBytes, mailbox, subscriptionId,
+                                              alreadyNotified == 1);
     }
 
     private MediaMmsMessageRecord getMediaMmsMessageRecord(Cursor cursor) {
@@ -1058,6 +1068,7 @@ public class MmsDatabase extends MessagingDatabase {
       String mismatchDocument = cursor.getString(cursor.getColumnIndexOrThrow(MmsDatabase.MISMATCHED_IDENTITIES));
       String networkDocument  = cursor.getString(cursor.getColumnIndexOrThrow(MmsDatabase.NETWORK_FAILURE));
       int subscriptionId      = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.SUBSCRIPTION_ID));
+      int alreadyNotified     = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.ALREADY_NOTIFIED));
 
       Recipients                recipients      = getRecipientsFor(address);
       List<IdentityKeyMismatch> mismatches      = getMismatchedIdentities(mismatchDocument);
@@ -1067,7 +1078,7 @@ public class MmsDatabase extends MessagingDatabase {
       return new MediaMmsMessageRecord(context, id, recipients, recipients.getPrimaryRecipient(),
                                        addressDeviceId, dateSent, dateReceived, receiptCount,
                                        threadId, body, slideDeck, partCount, box, mismatches,
-                                       networkFailures, subscriptionId);
+                                       networkFailures, subscriptionId, alreadyNotified == 1);
     }
 
     private Recipients getRecipientsFor(String address) {

--- a/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsColumns.java
@@ -15,6 +15,7 @@ public interface MmsSmsColumns {
   public static final String MISMATCHED_IDENTITIES    = "mismatched_identities";
   public static final String UNIQUE_ROW_ID            = "unique_row_id";
   public  static final String SUBSCRIPTION_ID         = "subscription_id";
+  public  static final String ALREADY_NOTIFIED        = "already_notified";
 
   public static class Types {
     protected static final long TOTAL_MASK = 0xFFFFFFFF;

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -54,6 +54,7 @@ public class MmsSmsDatabase extends Database {
                                               MmsSmsColumns.MISMATCHED_IDENTITIES,
                                               MmsDatabase.NETWORK_FAILURE,
                                               MmsSmsColumns.SUBSCRIPTION_ID, TRANSPORT,
+                                              MmsSmsColumns.ALREADY_NOTIFIED,
                                               AttachmentDatabase.ATTACHMENT_ID_ALIAS,
                                               AttachmentDatabase.UNIQUE_ID,
                                               AttachmentDatabase.MMS_ID,
@@ -134,6 +135,7 @@ public class MmsSmsDatabase extends Database {
                               MmsDatabase.MESSAGE_SIZE, MmsDatabase.EXPIRY, MmsDatabase.STATUS,
                               MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
                               MmsSmsColumns.SUBSCRIPTION_ID, MmsDatabase.NETWORK_FAILURE,  TRANSPORT,
+                              MmsSmsColumns.ALREADY_NOTIFIED,
                               AttachmentDatabase.UNIQUE_ID,
                               AttachmentDatabase.MMS_ID,
                               AttachmentDatabase.SIZE,
@@ -159,6 +161,7 @@ public class MmsSmsDatabase extends Database {
                               MmsSmsColumns.RECEIPT_COUNT, MmsSmsColumns.MISMATCHED_IDENTITIES,
                               MmsSmsColumns.SUBSCRIPTION_ID,
                               MmsDatabase.NETWORK_FAILURE, TRANSPORT,
+                              MmsSmsColumns.ALREADY_NOTIFIED,
                               AttachmentDatabase.UNIQUE_ID,
                               AttachmentDatabase.MMS_ID,
                               AttachmentDatabase.SIZE,
@@ -206,6 +209,7 @@ public class MmsSmsDatabase extends Database {
     mmsColumnsPresent.add(MmsDatabase.EXPIRY);
     mmsColumnsPresent.add(MmsDatabase.STATUS);
     mmsColumnsPresent.add(MmsDatabase.NETWORK_FAILURE);
+    mmsColumnsPresent.add(MmsDatabase.ALREADY_NOTIFIED);
 
     mmsColumnsPresent.add(AttachmentDatabase.ROW_ID);
     mmsColumnsPresent.add(AttachmentDatabase.UNIQUE_ID);
@@ -231,6 +235,7 @@ public class MmsSmsDatabase extends Database {
     smsColumnsPresent.add(SmsDatabase.DATE_SENT);
     smsColumnsPresent.add(SmsDatabase.DATE_RECEIVED);
     smsColumnsPresent.add(SmsDatabase.STATUS);
+    smsColumnsPresent.add(SmsDatabase.ALREADY_NOTIFIED);
 
     @SuppressWarnings("deprecation")
     String mmsSubQuery = mmsQueryBuilder.buildUnionSubQuery(TRANSPORT, mmsProjection, mmsColumnsPresent, 4, MMS_TRANSPORT, selection, null, null, null);

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -77,7 +77,8 @@ public class SmsDatabase extends MessagingDatabase {
     DATE_RECEIVED  + " INTEGER, " + DATE_SENT + " INTEGER, " + PROTOCOL + " INTEGER, " + READ + " INTEGER DEFAULT 0, " +
     STATUS + " INTEGER DEFAULT -1," + TYPE + " INTEGER, " + REPLY_PATH_PRESENT + " INTEGER, " +
     RECEIPT_COUNT + " INTEGER DEFAULT 0," + SUBJECT + " TEXT, " + BODY + " TEXT, " +
-    MISMATCHED_IDENTITIES + " TEXT DEFAULT NULL, " + SERVICE_CENTER + " TEXT, " + SUBSCRIPTION_ID + " INTEGER DEFAULT -1);";
+    MISMATCHED_IDENTITIES + " TEXT DEFAULT NULL, " + SERVICE_CENTER + " TEXT, " + SUBSCRIPTION_ID + " INTEGER DEFAULT -1," +
+    ALREADY_NOTIFIED + " INTERGER DEFAULT 0" + ");";
 
   public static final String[] CREATE_INDEXS = {
     "CREATE INDEX IF NOT EXISTS sms_thread_id_index ON " + TABLE_NAME + " (" + THREAD_ID + ");",
@@ -94,7 +95,7 @@ public class SmsDatabase extends MessagingDatabase {
       DATE_SENT + " AS " + NORMALIZED_DATE_SENT,
       PROTOCOL, READ, STATUS, TYPE,
       REPLY_PATH_PRESENT, SUBJECT, BODY, SERVICE_CENTER, RECEIPT_COUNT,
-      MISMATCHED_IDENTITIES, SUBSCRIPTION_ID
+      MISMATCHED_IDENTITIES, SUBSCRIPTION_ID, ALREADY_NOTIFIED
   };
 
   private static final EarlyReceiptCache earlyReceiptCache = new EarlyReceiptCache();
@@ -318,6 +319,14 @@ public class SmsDatabase extends MessagingDatabase {
     database.update(TABLE_NAME, contentValues, null, null);
   }
 
+  public void setAlreadyNotified(long messageId) {
+    SQLiteDatabase database     = databaseHelper.getWritableDatabase();
+    ContentValues contentValues = new ContentValues();
+    contentValues.put(ALREADY_NOTIFIED, 1);
+
+    database.update(TABLE_NAME, contentValues, ID + " = ?", new String[] {messageId + ""});
+  }
+
   protected Pair<Long, Long> updateMessageBodyAndType(long messageId, String body, long maskOff, long maskOn) {
     SQLiteDatabase db = databaseHelper.getWritableDatabase();
     db.execSQL("UPDATE " + TABLE_NAME + " SET " + BODY + " = ?, " +
@@ -357,7 +366,7 @@ public class SmsDatabase extends MessagingDatabase {
 
     jobManager.add(new TrimThreadJob(context, record.getThreadId()));
     reader.close();
-    
+
     return new Pair<>(newMessageId, record.getThreadId());
   }
 
@@ -665,6 +674,7 @@ public class SmsDatabase extends MessagingDatabase {
       int receiptCount        = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.RECEIPT_COUNT));
       String mismatchDocument = cursor.getString(cursor.getColumnIndexOrThrow(SmsDatabase.MISMATCHED_IDENTITIES));
       int subscriptionId      = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.SUBSCRIPTION_ID));
+      int alreadyNotified     = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.ALREADY_NOTIFIED));
 
       List<IdentityKeyMismatch> mismatches = getMismatches(mismatchDocument);
       Recipients                recipients = getRecipientsFor(address);
@@ -674,7 +684,7 @@ public class SmsDatabase extends MessagingDatabase {
                                   recipients.getPrimaryRecipient(),
                                   addressDeviceId,
                                   dateSent, dateReceived, receiptCount, type,
-                                  threadId, status, mismatches, subscriptionId);
+                                  threadId, status, mismatches, subscriptionId, alreadyNotified == 1);
     }
 
     private Recipients getRecipientsFor(String address) {

--- a/src/org/thoughtcrime/securesms/database/model/MediaMmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MediaMmsMessageRecord.java
@@ -53,10 +53,11 @@ public class MediaMmsMessageRecord extends MessageRecord {
                                @NonNull SlideDeck slideDeck,
                                int partCount, long mailbox,
                                List<IdentityKeyMismatch> mismatches,
-                               List<NetworkFailure> failures, int subscriptionId)
+                               List<NetworkFailure> failures, int subscriptionId,
+                               boolean alreadyNotified)
   {
     super(context, id, body, recipients, individualRecipient, recipientDeviceId, dateSent,
-          dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox, mismatches, failures, subscriptionId);
+          dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox, mismatches, failures, subscriptionId, alreadyNotified);
 
     this.context   = context.getApplicationContext();
     this.partCount = partCount;

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -51,6 +51,7 @@ public abstract class MessageRecord extends DisplayRecord {
   private final List<IdentityKeyMismatch> mismatches;
   private final List<NetworkFailure>      networkFailures;
   private final int                       subscriptionId;
+  private final boolean                   alreadyNotified;
 
   MessageRecord(Context context, long id, Body body, Recipients recipients,
                 Recipient individualRecipient, int recipientDeviceId,
@@ -58,7 +59,8 @@ public abstract class MessageRecord extends DisplayRecord {
                 int deliveryStatus, int receiptCount, long type,
                 List<IdentityKeyMismatch> mismatches,
                 List<NetworkFailure> networkFailures,
-                int subscriptionId)
+                int subscriptionId,
+                boolean alreadyNotified)
   {
     super(context, body, recipients, dateSent, dateReceived, threadId, deliveryStatus, receiptCount,
           type);
@@ -68,6 +70,7 @@ public abstract class MessageRecord extends DisplayRecord {
     this.mismatches          = mismatches;
     this.networkFailures     = networkFailures;
     this.subscriptionId      = subscriptionId;
+    this.alreadyNotified     = alreadyNotified;
   }
 
   public abstract boolean isMms();
@@ -200,5 +203,9 @@ public abstract class MessageRecord extends DisplayRecord {
 
   public int getSubscriptionId() {
     return subscriptionId;
+  }
+
+  public boolean isAlreadyNotified() {
+    return alreadyNotified;
   }
 }

--- a/src/org/thoughtcrime/securesms/database/model/NotificationMmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/NotificationMmsMessageRecord.java
@@ -50,11 +50,12 @@ public class NotificationMmsMessageRecord extends MessageRecord {
                                       long dateSent, long dateReceived, int receiptCount,
                                       long threadId, byte[] contentLocation, long messageSize,
                                       long expiry, int status, byte[] transactionId, long mailbox,
-                                      int subscriptionId)
+                                      int subscriptionId, boolean alreadyNotified)
   {
     super(context, id, new Body("", true), recipients, individualRecipient, recipientDeviceId,
           dateSent, dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox,
-          new LinkedList<IdentityKeyMismatch>(), new LinkedList<NetworkFailure>(), subscriptionId);
+          new LinkedList<IdentityKeyMismatch>(), new LinkedList<NetworkFailure>(), subscriptionId,
+          alreadyNotified);
 
     this.contentLocation = contentLocation;
     this.messageSize     = messageSize;

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -48,11 +48,11 @@ public class SmsMessageRecord extends MessageRecord {
                           int receiptCount,
                           long type, long threadId,
                           int status, List<IdentityKeyMismatch> mismatches,
-                          int subscriptionId)
+                          int subscriptionId, boolean alreadyNotified)
   {
     super(context, id, body, recipients, individualRecipient, recipientDeviceId,
           dateSent, dateReceived, threadId, status, receiptCount, type,
-          mismatches, new LinkedList<NetworkFailure>(), subscriptionId);
+          mismatches, new LinkedList<NetworkFailure>(), subscriptionId, alreadyNotified);
   }
 
   public long getType() {

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -16,6 +16,7 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
   private static final String TAG              = MarkReadReceiver.class.getSimpleName();
   public static final  String CLEAR_ACTION     = "org.thoughtcrime.securesms.notifications.CLEAR";
   public static final  String THREAD_IDS_EXTRA = "thread_ids";
+  public static final  String NOTIFICATION_ID  = "notification_id";
 
   @Override
   protected void onReceive(final Context context, Intent intent,
@@ -24,13 +25,14 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
     if (!CLEAR_ACTION.equals(intent.getAction()))
       return;
 
+    final int notificationId = intent.getIntExtra(NOTIFICATION_ID, MessageNotifier.SUMMARY_NOTIFICATION_ID);
     final long[] threadIds = intent.getLongArrayExtra(THREAD_IDS_EXTRA);
 
     if (threadIds != null) {
       Log.w("TAG", "threadIds length: " + threadIds.length);
 
       ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-                                   .cancel(MessageNotifier.NOTIFICATION_ID);
+                                   .cancel(notificationId);
 
       new AsyncTask<Void, Void, Void>() {
         @Override

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -199,7 +199,7 @@ public class MessageNotifier {
         }
 
         if (notificationState.hasMultipleThreads()) {
-          sendMultipleThreadNotification(context, notificationState, signal, item);
+          sendMultipleThreadNotification(context, notificationState, signal);
         } else {
           sendSingleThreadNotification(context, masterSecret, notificationState, signal, item, true);
         }
@@ -273,16 +273,15 @@ public class MessageNotifier {
 
   private static void sendMultipleThreadNotification(@NonNull  Context context,
                                                      @NonNull  NotificationState notificationState,
-                                                     boolean signal,
-                                                     NotificationItem notificationItem)
+                                                     boolean signal)
   {
     MultipleRecipientNotificationBuilder builder       = new MultipleRecipientNotificationBuilder(context, TextSecurePreferences.getNotificationPrivacy(context));
     List<NotificationItem>               notifications = notificationState.getNotifications();
 
     builder.setMessageCount(notificationState.getMessageCount(), notificationState.getThreadCount());
-    builder.setMostRecentSender(notificationItem.getIndividualRecipient());
+    builder.setMostRecentSender(notifications.get(0).getIndividualRecipient());
 
-    long timestamp = notificationItem.getTimestamp();
+    long timestamp = notifications.get(0).getTimestamp();
     if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.addActions(notificationState.getMarkAsReadIntent(context, SUMMARY_NOTIFICATION_ID, null));
@@ -296,7 +295,7 @@ public class MessageNotifier {
 
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
-      builder.setTicker(notificationItem.getText());
+      builder.setTicker(notifications.get(0).getText());
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -244,7 +244,7 @@ public class MessageNotifier {
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getIndividualRecipient(),
-          notifications.get(0).getText());
+                        notifications.get(0).getText());
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -60,6 +60,7 @@ import org.whispersystems.textsecure.api.messages.TextSecureEnvelope;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import me.leolin.shortcutbadger.ShortcutBadger;
 
@@ -75,11 +76,15 @@ public class MessageNotifier {
 
   private static final String TAG = MessageNotifier.class.getSimpleName();
 
-  public static final int NOTIFICATION_ID = 1338;
+  private static AtomicInteger notificationCounter = new AtomicInteger(0);
+
+  public static final int SUMMARY_NOTIFICATION_ID = 1338;
 
   private volatile static long visibleThread = -1;
 
   public static final String EXTRA_VOICE_REPLY = "extra_voice_reply";
+
+  public final static String GROUP_KEY_MESSAGES = "group_key_messages";
 
   public static void setVisibleThread(long threadId) {
     visibleThread = threadId;
@@ -169,7 +174,7 @@ public class MessageNotifier {
           (pushCursor == null || pushCursor.isAfterLast()))
       {
         ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+          .cancel(SUMMARY_NOTIFICATION_ID);
         updateBadge(context, 0);
         clearReminder(context);
         return;
@@ -181,10 +186,10 @@ public class MessageNotifier {
         appendPushNotificationState(context, notificationState, pushCursor);
       }
 
-      if (notificationState.hasMultipleThreads()) {
+      sendSingleThreadNotification(context, masterSecret, notificationState, signal);
+
+      if (notificationState.getMessageCount() > 1) {
         sendMultipleThreadNotification(context, notificationState, signal);
-      } else {
-        sendSingleThreadNotification(context, masterSecret, notificationState, signal);
       }
 
       updateBadge(context, notificationState.getMessageCount());
@@ -203,9 +208,11 @@ public class MessageNotifier {
                                                    @NonNull  NotificationState notificationState,
                                                    boolean signal)
   {
+    int notificationId = notificationCounter.getAndIncrement();
+
     if (notificationState.getNotifications().isEmpty()) {
       ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+          .cancelAll();
       return;
     }
 
@@ -223,9 +230,9 @@ public class MessageNotifier {
     if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.addActions(masterSecret,
-                       notificationState.getMarkAsReadIntent(context),
-                       notificationState.getQuickReplyIntent(context, notifications.get(0).getRecipients()),
-                       notificationState.getWearableReplyIntent(context, notifications.get(0).getRecipients()));
+                       notificationState.getMarkAsReadIntent(context, notificationId, notifications.get(0).getThreadId()),
+                       notificationState.getQuickReplyIntent(context, notifications.get(0).getRecipients(), notificationId),
+                       notificationState.getWearableReplyIntent(context, notifications.get(0).getRecipients(), notificationId));
 
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
 
@@ -237,11 +244,11 @@ public class MessageNotifier {
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getIndividualRecipient(),
-                        notifications.get(0).getText());
+          notifications.get(0).getText());
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(NOTIFICATION_ID, builder.build());
+      .notify(notificationId, builder.build());
   }
 
   private static void sendMultipleThreadNotification(@NonNull  Context context,
@@ -252,19 +259,20 @@ public class MessageNotifier {
     List<NotificationItem>               notifications = notificationState.getNotifications();
 
     builder.setMessageCount(notificationState.getMessageCount(), notificationState.getThreadCount());
-    builder.setMostRecentSender(notifications.get(0).getIndividualRecipient());
 
     long timestamp = notifications.get(0).getTimestamp();
     if (timestamp != 0) builder.setWhen(timestamp);
 
-    builder.addActions(notificationState.getMarkAsReadIntent(context));
+    builder.addActions(notificationState.getMarkAsReadIntent(context, SUMMARY_NOTIFICATION_ID, null));
 
-    ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
+    ListIterator<NotificationItem> iterator = notifications.listIterator();
 
-    while(iterator.hasPrevious()) {
-      NotificationItem item = iterator.previous();
+    while(iterator.hasNext()) {
+      NotificationItem item = iterator.next();
       builder.addMessageBody(item.getIndividualRecipient(), item.getText());
     }
+
+    builder.setMostRecentSender(notifications.get(0).getIndividualRecipient());
 
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
@@ -272,7 +280,7 @@ public class MessageNotifier {
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(NOTIFICATION_ID, builder.build());
+      .notify(SUMMARY_NOTIFICATION_ID, builder.build());
   }
 
   private static void sendInThreadNotification(Context context, Recipients recipients) {

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -259,7 +259,7 @@ public class MessageNotifier {
       }
     }
 
-    if (signal) {
+    if (signal && summary) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notificationItem.getIndividualRecipient(),
                         notificationItem.getText());

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -32,6 +32,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationManagerCompat;
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.TextUtils;
@@ -78,8 +79,6 @@ public class MessageNotifier {
   public static final int SUMMARY_NOTIFICATION_ID = 1338;
 
   private static int notificationCounter = 2000;
-
-  private static NotificationState lastNotificationState = new NotificationState();
 
   private volatile static long visibleThread = -1;
 
@@ -174,8 +173,9 @@ public class MessageNotifier {
       if ((telcoCursor == null || telcoCursor.isAfterLast()) &&
           (pushCursor == null || pushCursor.isAfterLast()))
       {
-        ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(SUMMARY_NOTIFICATION_ID);
+        NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+        notificationManager.cancel(SUMMARY_NOTIFICATION_ID);
+
         updateBadge(context, 0);
         clearReminder(context);
         return;
@@ -194,14 +194,14 @@ public class MessageNotifier {
       while(iterator.hasNext()) {
         NotificationItem item = iterator.next();
 
-        if (!item.isNotified()) {
+        if (!item.isAlreadyNotified()) {
           sendSingleThreadNotification(context, masterSecret, notificationState, signal, item, false);
-        }
 
-        if (notificationState.hasMultipleThreads()) {
-          sendMultipleThreadNotification(context, notificationState, signal);
-        } else {
-          sendSingleThreadNotification(context, masterSecret, notificationState, signal, item, true);
+          if (notificationState.hasMultipleThreads()) {
+            sendMultipleThreadNotification(context, notificationState, signal);
+          } else {
+            sendSingleThreadNotification(context, masterSecret, notificationState, signal, item, true);
+          }
         }
       }
 
@@ -225,9 +225,10 @@ public class MessageNotifier {
   {
     int notificationId = (summary) ? SUMMARY_NOTIFICATION_ID : notificationCounter++;
 
+    NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+
     if (notificationState.getNotifications().isEmpty()) {
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancelAll();
+      notificationManager.cancelAll();
       return;
     }
 
@@ -265,10 +266,9 @@ public class MessageNotifier {
                         notificationItem.getText());
     }
 
-    ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(notificationId, builder.build());
+    notificationManager.notify(notificationId, builder.build());
 
-    notificationItem.setNotified(true);
+    notificationItem.setAlreadyNotified(context);
   }
 
   private static void sendMultipleThreadNotification(@NonNull  Context context,
@@ -285,6 +285,7 @@ public class MessageNotifier {
     if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.addActions(notificationState.getMarkAsReadIntent(context, SUMMARY_NOTIFICATION_ID, null));
+    builder.addActions(notificationState.getMarkAsReadIntent(context, SUMMARY_NOTIFICATION_ID, null));
 
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
 
@@ -298,8 +299,8 @@ public class MessageNotifier {
       builder.setTicker(notifications.get(0).getText());
     }
 
-    ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-      .notify(SUMMARY_NOTIFICATION_ID, builder.build());
+    NotificationManagerCompat notificationManager = NotificationManagerCompat.from(context);
+    notificationManager.notify(SUMMARY_NOTIFICATION_ID, builder.build());
   }
 
   private static void sendInThreadNotification(Context context, Recipients recipients) {
@@ -366,7 +367,7 @@ public class MessageNotifier {
         body.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC), 0, body.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
         if (!recipients.isMuted()) {
-          notificationState.addNotification(new NotificationItem(recipient, recipients, null, threadId, body, 0, null, false));
+          notificationState.addNotification(new NotificationItem(recipient, recipients, null, threadId, -1, body, 0, null, false));
         }
       }
     } finally {
@@ -379,8 +380,6 @@ public class MessageNotifier {
                                                               @Nullable MasterSecret masterSecret,
                                                               @NonNull  Cursor cursor)
   {
-    List<NotificationItem> prevNotifications = lastNotificationState.getNotifications();
-
     NotificationState notificationState = new NotificationState();
     MessageRecord record;
     MmsSmsDatabase.Reader reader;
@@ -392,11 +391,13 @@ public class MessageNotifier {
       Recipient    recipient        = record.getIndividualRecipient();
       Recipients   recipients       = record.getRecipients();
       long         threadId         = record.getThreadId();
+      long         messageId        = record.getId();
       CharSequence body             = record.getDisplayBody();
       Recipients   threadRecipients = null;
       SlideDeck    slideDeck        = null;
       long         timestamp        = record.getTimestamp();
-      
+      boolean      alreadyNotified  = record.isAlreadyNotified();
+
 
       if (threadId != -1) {
         threadRecipients = DatabaseFactory.getThreadDatabase(context).getRecipientsForThreadId(threadId);
@@ -415,19 +416,13 @@ public class MessageNotifier {
       }
 
       if (threadRecipients == null || !threadRecipients.isMuted()) {
-        NotificationItem item = new NotificationItem(recipient, recipients, threadRecipients, threadId, body, timestamp, slideDeck, false);
-
-        if (prevNotifications.contains(item)) {
-          NotificationItem prevNotification = prevNotifications.get(prevNotifications.indexOf(item));
-          item.setNotified(prevNotification.isNotified());
-        }
+        NotificationItem item = new NotificationItem(recipient, recipients, threadRecipients, threadId, messageId, body, timestamp, slideDeck, alreadyNotified);
 
         notificationState.addNotification(item);
       }
     }
 
     reader.close();
-    lastNotificationState = notificationState;
     return notificationState;
   }
 

--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -31,6 +31,8 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(MessageNotifier.GROUP_KEY_MESSAGES);
+    setGroupSummary(true);
   }
 
   public void setMessageCount(int messageCount, int threadCount) {
@@ -41,7 +43,9 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
   }
 
   public void setMostRecentSender(Recipient recipient) {
-    if (privacy.isDisplayContact()) {
+    if (privacy.isDisplayMessage()) {
+      setContentText(messageBodies.get(0));
+    } else if (privacy.isDisplayContact()) {
       setContentText(context.getString(R.string.MessageNotifier_most_recent_from_s,
                                        recipient.toShortString()));
     }

--- a/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/MultipleRecipientNotificationBuilder.java
@@ -43,9 +43,7 @@ public class MultipleRecipientNotificationBuilder extends AbstractNotificationBu
   }
 
   public void setMostRecentSender(Recipient recipient) {
-    if (privacy.isDisplayMessage()) {
-      setContentText(messageBodies.get(0));
-    } else if (privacy.isDisplayContact()) {
+    if (privacy.isDisplayContact()) {
       setContentText(context.getString(R.string.MessageNotifier_most_recent_from_s,
                                        recipient.toShortString()));
     }

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -4,32 +4,36 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.TaskStackBuilder;
+import android.util.Log;
 
 import org.thoughtcrime.securesms.ConversationActivity;
+import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 
 public class NotificationItem {
 
+  private static final    String            TAG = NotificationItem.class.getSimpleName();
   private final @NonNull  Recipients        recipients;
   private final @NonNull  Recipient         individualRecipient;
   private final @Nullable Recipients        threadRecipients;
   private final long                        threadId;
+  private final long                        messageId;
   private final @Nullable CharSequence      text;
   private final long                        timestamp;
   private final @Nullable SlideDeck         slideDeck;
-  private Boolean                           notified = false;
+  private final boolean                     alreadyNotified;
 
   public NotificationItem(@NonNull   Recipient individualRecipient,
-                          @NonNull   Recipients recipients,
-                          @Nullable  Recipients threadRecipients,
-                          long threadId, @Nullable CharSequence text, long timestamp,
-                          @Nullable SlideDeck slideDeck,
-                          boolean notified)
+                           @NonNull   Recipients recipients,
+                           @Nullable  Recipients threadRecipients,
+                           long threadId, long messageId, @Nullable CharSequence text,
+                           long timestamp, @Nullable SlideDeck slideDeck, boolean alreadyNotified)
 
   {
     this.individualRecipient = individualRecipient;
@@ -37,9 +41,10 @@ public class NotificationItem {
     this.threadRecipients    = threadRecipients;
     this.text                = text;
     this.threadId            = threadId;
+    this.messageId           = messageId;
     this.timestamp           = timestamp;
     this.slideDeck           = slideDeck;
-    this.notified            = notified;
+    this.alreadyNotified     = alreadyNotified;
   }
 
   public @NonNull  Recipients getRecipients() {
@@ -66,12 +71,23 @@ public class NotificationItem {
     return slideDeck;
   }
 
-  public boolean isNotified() {
-    return this.notified;
+  public boolean isAlreadyNotified() {
+    return this.alreadyNotified;
   }
 
-  public void setNotified(boolean notified) {
-    this.notified = notified;
+  public void setAlreadyNotified(final Context context) {
+    if (this.messageId == -1) return;
+
+    new AsyncTask<Void, Void, Void>() {
+      @Override
+      protected Void doInBackground(Void... params) {
+        Log.w(TAG, "Marking as read: " + threadId);
+        DatabaseFactory.getSmsDatabase(context).setAlreadyNotified(messageId);
+        DatabaseFactory.getMmsDatabase(context).setAlreadyNotified(messageId);
+
+        return null;
+      }
+    }.execute();
   }
 
   public PendingIntent getPendingIntent(Context context) {

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -22,12 +22,15 @@ public class NotificationItem {
   private final @Nullable CharSequence      text;
   private final long                        timestamp;
   private final @Nullable SlideDeck         slideDeck;
+  private Boolean                           notified = false;
 
   public NotificationItem(@NonNull   Recipient individualRecipient,
                           @NonNull   Recipients recipients,
                           @Nullable  Recipients threadRecipients,
                           long threadId, @Nullable CharSequence text, long timestamp,
-                          @Nullable SlideDeck slideDeck)
+                          @Nullable SlideDeck slideDeck,
+                          boolean notified)
+
   {
     this.individualRecipient = individualRecipient;
     this.recipients          = recipients;
@@ -36,6 +39,7 @@ public class NotificationItem {
     this.threadId            = threadId;
     this.timestamp           = timestamp;
     this.slideDeck           = slideDeck;
+    this.notified            = notified;
   }
 
   public @NonNull  Recipients getRecipients() {
@@ -62,6 +66,14 @@ public class NotificationItem {
     return slideDeck;
   }
 
+  public boolean isNotified() {
+    return this.notified;
+  }
+
+  public void setNotified(boolean notified) {
+    this.notified = notified;
+  }
+
   public PendingIntent getPendingIntent(Context context) {
     Intent     intent           = new Intent(context, ConversationActivity.class);
     Recipients notifyRecipients = threadRecipients != null ? threadRecipients : recipients;
@@ -73,6 +85,35 @@ public class NotificationItem {
     return TaskStackBuilder.create(context)
                            .addNextIntentWithParentStack(intent)
                            .getPendingIntent(0, PendingIntent.FLAG_UPDATE_CURRENT);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof NotificationItem)) {
+      return false;
+    }
+
+    final NotificationItem other = (NotificationItem) obj;
+
+    if (this.timestamp != other.timestamp) {
+      return false;
+    }
+
+    if (this.threadId != other.threadId) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = 17;
+
+    result = 31 * result + (int) (this.timestamp ^ (this.timestamp >>> 32));
+    result = 31 * result + (int) (this.threadId ^ (this.threadId >>> 32));
+
+    return result;
   }
 
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -70,17 +70,20 @@ public class NotificationState {
     return notifications;
   }
 
-  public PendingIntent getMarkAsReadIntent(Context context) {
+  public PendingIntent getMarkAsReadIntent(Context context, int notificationId, @Nullable Long threadId) {
     long[] threadArray = new long[threads.size()];
     int    index       = 0;
 
     for (long thread : threads) {
-      Log.w("NotificationState", "Added thread: " + thread);
-      threadArray[index++] = thread;
+      if (threadId == null || threadId == thread) {
+        Log.w("NotificationState", "Added thread: " + thread);
+        threadArray[index++] = thread;
+      }
     }
 
     Intent intent = new Intent(MarkReadReceiver.CLEAR_ACTION);
     intent.putExtra(MarkReadReceiver.THREAD_IDS_EXTRA, threadArray);
+    intent.putExtra(MarkReadReceiver.NOTIFICATION_ID, notificationId);
     intent.setPackage(context.getPackageName());
 
     // XXX : This is an Android bug.  If we don't pull off the extra
@@ -89,28 +92,24 @@ public class NotificationState {
     Log.w("NotificationState", "Pending array off intent length: " +
         intent.getLongArrayExtra("thread_ids").length);
 
-    return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getBroadcast(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
-  public PendingIntent getWearableReplyIntent(Context context, Recipients recipients) {
-    if (threads.size() != 1) throw new AssertionError("We only support replies to single thread notifications!");
-
+  public PendingIntent getWearableReplyIntent(Context context, Recipients recipients, int notificationId) {
     Intent intent = new Intent(WearReplyReceiver.REPLY_ACTION);
     intent.putExtra(WearReplyReceiver.RECIPIENT_IDS_EXTRA, recipients.getIds());
     intent.setPackage(context.getPackageName());
 
-    return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getBroadcast(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
-  public PendingIntent getQuickReplyIntent(Context context, Recipients recipients) {
-    if (threads.size() != 1) throw new AssertionError("We only support replies to single thread notifications!");
-
+  public PendingIntent getQuickReplyIntent(Context context, Recipients recipients, int notificationId) {
     Intent     intent           = new Intent(context, ConversationPopupActivity.class);
     intent.putExtra(ConversationActivity.RECIPIENTS_EXTRA, recipients.getIds());
     intent.putExtra(ConversationActivity.THREAD_ID_EXTRA, (long)threads.toArray()[0]);
     intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
 
-    return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT);
+    return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
   }
 
 

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -40,6 +40,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
 
   private       SlideDeck    slideDeck;
   private final MasterSecret masterSecret;
+  private final boolean      summary;
 
   public SingleRecipientNotificationBuilder(@NonNull Context context,
                                             @Nullable MasterSecret masterSecret,
@@ -48,6 +49,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
   {
     super(context, privacy);
     this.masterSecret = masterSecret;
+    this.summary = summary;
 
     setSmallIcon(R.drawable.icon_notification);
     setColor(context.getResources().getColor(R.color.textsecure_primary));
@@ -223,10 +225,15 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
   private CharSequence getBigText(List<CharSequence> messageBodies) {
     SpannableStringBuilder content = new SpannableStringBuilder();
 
-    for (CharSequence message : messageBodies) {
-      content.append(message);
-      content.append('\n');
+    if (summary) {
+      for (CharSequence message : messageBodies) {
+        content.append(message);
+        content.append('\n');
+      }
+    } else {
+      content.append(messageBodies.get(messageBodies.size() - 1));
     }
+
 
     return content;
   }

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -43,7 +43,8 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
 
   public SingleRecipientNotificationBuilder(@NonNull Context context,
                                             @Nullable MasterSecret masterSecret,
-                                            @NonNull NotificationPrivacyPreference privacy)
+                                            @NonNull NotificationPrivacyPreference privacy,
+                                            boolean summary)
   {
     super(context, privacy);
     this.masterSecret = masterSecret;
@@ -54,6 +55,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
     setGroup(MessageNotifier.GROUP_KEY_MESSAGES);
+    setGroupSummary(summary);
   }
 
   public void setThread(@NonNull Recipients recipients) {

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -53,6 +53,7 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     setPriority(NotificationCompat.PRIORITY_HIGH);
     setCategory(NotificationCompat.CATEGORY_MESSAGE);
     setDeleteIntent(PendingIntent.getBroadcast(context, 0, new Intent(MessageNotifier.DeleteReceiver.DELETE_REMINDER_ACTION), 0));
+    setGroup(MessageNotifier.GROUP_KEY_MESSAGES);
   }
 
   public void setThread(@NonNull Recipients recipients) {


### PR DESCRIPTION
<!-- You can remove this section if you have contributed before -->
### First time contributor checklist
<!-- mark with x between the brackets -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 6P, Android 6.0.1
 * Pebble Time, v3.9.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Just switched from Telegram and love Signal, but hated that notifications didn't work properly on my wearable, so I decided to take a stab at it. I implemented my fix based on [Stacking Notifications](http://developer.android.com/training/wearables/notifications/stacks.html).

- Summary notification always uses the same id
- the individual stacked notifications use a static variable to generate unique notification IDs
- all intents had to be changed to so that they are distinct ([see here](http://developer.android.com/intl/pt-br/reference/android/app/PendingIntent.html#getActivity(android.content.Context, int, android.content.Intent, int))), so that a reply sent from a wearable will go to the right person
- the `markAsRead` intent had to be modified so that it could mark individual messages as read from a wearable notification, as well as marking all as read with the already existing behavior
- tested with a Pebble, but it uses Android Wear, so it effectively works the same way interacting with notifications
- revised #5286. Guess it maybe wasn't the greatest idea to submit a pull request hours after I should be in bed. All is well now.
- fix for #2525 

// FREEBIE