### PR TITLE
Extract compose subhint for SIM name to string resource

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -664,6 +664,7 @@
     <string name="conversation_activity__type_message_push">Send Signal message</string>
     <string name="conversation_activity__type_message_sms_insecure">Send unsecured SMS</string>
     <string name="conversation_activity__type_message_mms_insecure">Send unsecured MMS</string>
+    <string name="conversation_activity__from_sim_name">From %1$s</string>
     <string name="conversation_activity__send">Send</string>
     <string name="conversation_activity__remove">Remove</string>
     <string name="conversation_activity__window_description">Conversation with %1$s</string>

--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -11,6 +11,7 @@ import android.text.TextUtils.TruncateAt;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
 
+import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.TransportOption;
 import org.thoughtcrime.securesms.components.emoji.EmojiEditText;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
@@ -104,6 +105,9 @@ public class ComposeText extends EmojiEditText {
 
     setInputType(inputType);
     setImeOptions(imeOptions);
-    setHint(transport.getComposeHint(), transport.getSimName().isPresent() ? "From " + transport.getSimName().get() : null);
+    setHint(transport.getComposeHint(),
+            transport.getSimName().isPresent()
+                ? getContext().getString(R.string.conversation_activity__from_sim_name, transport.getSimName().get())
+                : null);
   }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Google Nexus 5, Android 6.0.1
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Fixes #5304
// FREEBIE

Tested on a device without dual SIM by temporarily setting the subhint to the string resource when `transport.getSimName().isPresent()` returns `false` and observing in the UI.  

Also tested the production version that sets the subhint to `null` in this case.