### PR TITLE
Improve error handling when group members unregister

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -104,10 +104,16 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
       }
 
       database.addFailures(messageId, failures);
-      database.markAsSentFailed(messageId);
       database.markAsPush(messageId);
 
-      notifyMediaMessageDeliveryFailed(context, messageId);
+      if (e.getNetworkExceptions().isEmpty() && e.getUntrustedIdentityExceptions().isEmpty()) {
+        database.markAsSecure(messageId);
+        database.markAsSent(messageId);
+        markAttachmentsUploaded(messageId, message.getAttachments());
+      } else {
+        database.markAsSentFailed(messageId);
+        notifyMediaMessageDeliveryFailed(context, messageId);
+      }
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulator, Android 5.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

- ~~Store `UnregisteredUser`s in the DB (just like `NetworkFailure`s / `IdentityKeyMismatch`es) and display an error text for them in the message details~~
- ~~Add a "More info" button to the `MessageRecipientListItem` of the unregistered recipient which opens an AlertDialog, informing the user of the problem~~
- ~~After acknowledging / closing the dialog,~~ group messages to this recipient no longer fail (in the UI)

#### Screenshots

*Edit: These are all obsolete*
<img src="https://cloud.githubusercontent.com/assets/264472/13549305/c4b02840-e302-11e5-8326-ca46547e81be.png" height="100"> <img src="https://cloud.githubusercontent.com/assets/264472/13549310/e35bbfde-e302-11e5-8e09-8c246b22f293.png" height="100"> <img src="https://cloud.githubusercontent.com/assets/264472/13549323/184687f6-e303-11e5-9baa-e4bc587b8779.png" height="100"> <img src="https://cloud.githubusercontent.com/assets/264472/13549337/2edfbbb8-e303-11e5-80c1-01e42aa1960a.png" height="100"> <img src="https://cloud.githubusercontent.com/assets/264472/13549340/32a17cf0-e303-11e5-8d08-e5888785c373.png" height="100"> <img src="https://cloud.githubusercontent.com/assets/264472/13550974/75fc51b0-e32a-11e5-9750-d2eee3e3760f.png" height="100">

Fixes #2408
Fixes #4550