### PR TITLE
allow "panic button" apps to lock

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -373,6 +373,9 @@
         </intent-filter>
     </activity>
 
+    <activity android:name=".ExitActivity"
+              android:theme="@android:style/Theme.NoDisplay" />
+
     <service android:enabled="true" android:name="org.thoughtcrime.redphone.RedPhoneService"/>
 
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -363,6 +363,16 @@
 
     <activity android:name="com.soundcloud.android.crop.CropImageActivity" />
 
+    <!-- this can never have launchMode singleTask or singleInstance! -->
+    <activity android:name=".PanicResponderActivity"
+              android:noHistory="true"
+              android:theme="@android:style/Theme.NoDisplay">
+        <intent-filter>
+            <action android:name="info.guardianproject.panic.action.TRIGGER" />
+            <category android:name="android.intent.category.DEFAULT" />
+        </intent-filter>
+    </activity>
+
     <service android:enabled="true" android:name="org.thoughtcrime.redphone.RedPhoneService"/>
 
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     compile 'com.google.android.gms:play-services-location:8.1.0'
     compile 'com.jpardogo.materialtabstrip:library:1.0.9'
     compile 'org.w3c:smil:1.0.0'
+    compile 'info.guardianproject.trustedintents:trustedintents:0.2'
     compile 'org.apache.httpcomponents:httpclient-android:4.3.5'
     compile 'com.github.chrisbanes.photoview:library:1.2.3'
     compile 'com.github.bumptech.glide:glide:3.7.0'
@@ -104,6 +105,7 @@ dependencyVerification {
             'com.google.android.gms:play-services-location:8226f778aa86bd15b9143f62425262cc53d64021990f62eb1aaec108d4e25f35',
             'com.jpardogo.materialtabstrip:library:c6ef812fba4f74be7dc4a905faa4c2908cba261a94c13d4f96d5e67e4aad4aaa',
             'org.w3c:smil:085dc40f2bb249651578bfa07499fd08b16ad0886dbe2c4078586a408da62f9b',
+            'info.guardianproject.trustedintents:trustedintents:6221456d8821a8d974c2acf86306900237cf6afaaa94a4c9c44e161350f80f3e',
             'org.apache.httpcomponents:httpclient-android:6f56466a9bd0d42934b90bfbfe9977a8b654c058bf44a12bdc2877c4e1f033f1',
             'com.github.chrisbanes.photoview:library:8b5344e206f125e7ba9d684008f36c4992d03853c57e5814125f88496126e3cc',
             'com.github.bumptech.glide:glide:76ef123957b5fbaebb05fcbe6606dd58c3bc3fcdadb257f99811d0ac9ea9b88b',

--- a/src/org/thoughtcrime/securesms/ExitActivity.java
+++ b/src/org/thoughtcrime/securesms/ExitActivity.java
@@ -1,0 +1,53 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+/**
+ * After receiving a PanicKit trigger Intent and locking the app, remove from history.
+ * This makes the app fully exit, and removes it from the Recent Apps listing.
+ */
+public class ExitActivity extends Activity {
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    if (Build.VERSION.SDK_INT >= 21) {
+      finishAndRemoveTask();
+    } else {
+      finish();
+    }
+
+    System.exit(0);
+  }
+
+  public static void exitAndRemoveFromRecentApps(Activity activity) {
+    Intent intent = new Intent(activity, ExitActivity.class);
+
+    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK
+            | Intent.FLAG_ACTIVITY_CLEAR_TASK
+            | Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS
+            | Intent.FLAG_ACTIVITY_NO_ANIMATION);
+
+    activity.startActivity(intent);
+  }
+}

--- a/src/org/thoughtcrime/securesms/PanicResponderActivity.java
+++ b/src/org/thoughtcrime/securesms/PanicResponderActivity.java
@@ -62,6 +62,7 @@ public class PanicResponderActivity extends Activity {
             && !TextSecurePreferences.isPasswordDisabled(this)
             && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
       handleClearPassphrase();
+      ExitActivity.exitAndRemoveFromRecentApps(this);
     }
 
     if (Build.VERSION.SDK_INT >= 21) {

--- a/src/org/thoughtcrime/securesms/PanicResponderActivity.java
+++ b/src/org/thoughtcrime/securesms/PanicResponderActivity.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+
+import org.iilab.IilabEngineeringRSA2048Pin;
+import org.thoughtcrime.securesms.service.KeyCachingService;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import info.guardianproject.GuardianProjectRSA4096;
+import info.guardianproject.trustedintents.TrustedIntents;
+
+/**
+ * Respond to a PanicKit trigger Intent by locking the app.  PanicKit provides a
+ * common framework for creating "panic button" apps that can trigger actions
+ * in "panic responder" apps.  In this case, the response is to lock the app,
+ * if it has been configured to do so.
+ * <p/>
+ * This uses the TrustedIntents library to make sure that the apps sending the
+ * panic trigger Intents come from APKs that have been signed by the official
+ * signing key of Amnesty/iilab Panic Button and Guardian Project Ripple.
+ * <p/>
+ * {@link GuardianProjectRSA4096} is the signing key used for Guardian Project
+ * Ripple (info.guardianproject.ripple).  {@link IilabEngineeringRSA2048Pin} is
+ * the signing key use for Amnesty International's Panic Button, made by
+ * iilab.org (org.iilab.pb)
+ */
+public class PanicResponderActivity extends Activity {
+
+  private static final String TAG = PanicResponderActivity.class.getSimpleName();
+
+  public static final String PANIC_TRIGGER_ACTION = "info.guardianproject.panic.action.TRIGGER";
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    TrustedIntents trustedIntents = TrustedIntents.get(this);
+    trustedIntents.addTrustedSigner(GuardianProjectRSA4096.class);
+    trustedIntents.addTrustedSigner(IilabEngineeringRSA2048Pin.class);
+
+    Intent intent = trustedIntents.getIntentFromTrustedSender(this);
+    if (intent != null
+            && !TextSecurePreferences.isPasswordDisabled(this)
+            && PANIC_TRIGGER_ACTION.equals(intent.getAction())) {
+      handleClearPassphrase();
+    }
+
+    if (Build.VERSION.SDK_INT >= 21) {
+      finishAndRemoveTask();
+    } else {
+      finish();
+    }
+  }
+
+  private void handleClearPassphrase() {
+    Intent intent = new Intent(this, KeyCachingService.class);
+    intent.setAction(KeyCachingService.CLEAR_KEY_ACTION);
+    startService(intent);
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy Note 2, Android 4.4.4
 * Asus ZenFone2, Android 4.4.2 (x86)
 * its [included in SMSSecure](https://github.com/SMSSecure/SMSSecure/pulls?q=is%3Apr+is%3Aclosed+author%3Aeighthave) official releases, so its been tested on a bunch of devices there
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

As discussed back in October face to face with @moxie0 and @mcginty, here is the "panic button" support.  We've been developing "panic button" features in our apps for years, and now we are working to make a more flexible and open ecosystem of apps that can both trigger other apps, or respond to triggers.  This has now become a partnership effort called [Panic Initiative](https://github.com/PanicInitiative) that has been spun out of Amnesty International's work in conjunction with iilab, Guardian Project and Security First.

Since Signal already includes a "lock" feature, it is a natural panic responder app. This setup allows for easy configuration of a single trigger action (e.g. button press) which can then trigger multiple apps. The first commit adds support for receiving the panic trigger. The second commit wipes Signal from the Recent Apps after responding to the panic trigger.

You can see an example of this user experience in this video:
https://www.youtube.com/watch?v=mS1gstS6YS8

The first panic button app that sends this kind of trigger is called Ripple, and it is available here:
https://github.com/guardianproject/ripple
https://play.google.com/store/apps/details?id=info.guardianproject.ripple

Amnesty Panic Button supports this in the beta version (v1.4.1) right now:
https://panicbutton.io/
https://play.google.com/store/apps/details?id=org.iilab.pb

More info on the panic kit work here:
https://dev.guardianproject.info/projects/panic/wiki

The source repo for the included TrustedIntents library is here:
https://github.com/guardianproject/TrustedIntents
