### PR TITLE
Fix RedPhone init race conditions

### DIFF
--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -428,6 +428,7 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
   }
 
   public void notifyConnectingtoInitiator() {
+    outgoingRinger.playHandshake();
     sendMessage(Type.CONNECTING_TO_INITIATOR, getRecipient(), null);
   }
 

--- a/src/org/thoughtcrime/redphone/audio/CallAudioManager.java
+++ b/src/org/thoughtcrime/redphone/audio/CallAudioManager.java
@@ -60,6 +60,7 @@ public class CallAudioManager {
   }
 
   public void terminate() {
+    Log.d(TAG, "terminate");
     stop(handle);
     dispose(handle);
   }

--- a/src/org/thoughtcrime/redphone/call/CallManager.java
+++ b/src/org/thoughtcrime/redphone/call/CallManager.java
@@ -23,7 +23,6 @@ import android.util.Log;
 
 import org.thoughtcrime.redphone.audio.AudioException;
 import org.thoughtcrime.redphone.audio.CallAudioManager;
-import org.thoughtcrime.redphone.crypto.SecureRtpSocket;
 import org.thoughtcrime.redphone.crypto.zrtp.MasterSecret;
 import org.thoughtcrime.redphone.crypto.zrtp.NegotiationFailedException;
 import org.thoughtcrime.redphone.crypto.zrtp.RecipientUnavailableException;
@@ -31,7 +30,6 @@ import org.thoughtcrime.redphone.crypto.zrtp.SASInfo;
 import org.thoughtcrime.redphone.crypto.zrtp.ZRTPSocket;
 import org.thoughtcrime.redphone.signaling.SessionDescriptor;
 import org.thoughtcrime.redphone.signaling.SignalingSocket;
-import org.thoughtcrime.redphone.util.AudioUtils;
 
 import java.io.IOException;
 import java.net.DatagramSocket;
@@ -62,10 +60,7 @@ public abstract class CallManager extends Thread {
   private   boolean          muteEnabled;
   private   boolean          callConnected;
 
-  protected SessionDescriptor sessionDescriptor;
   protected ZRTPSocket        zrtpSocket;
-  protected SecureRtpSocket   secureSocket;
-  protected SignalingSocket   signalingSocket;
 
   public CallManager(Context context, CallStateListener callStateListener,
                     String remoteNumber, String threadName)
@@ -120,6 +115,7 @@ public abstract class CallManager extends Thread {
   }
 
   public void terminate() {
+    Log.d(TAG, "terminate");
     this.terminated = true;
 
     if (callAudioManager != null)
@@ -133,14 +129,14 @@ public abstract class CallManager extends Thread {
   }
 
   public SessionDescriptor getSessionDescriptor() {
-    return this.sessionDescriptor;
+    return this.signalManager == null ? null : this.signalManager.getSessionDescriptor();
   }
 
   public SASInfo getSasInfo() {
     return this.sasInfo;
   }
 
-  protected void processSignals() {
+  protected void processSignals(SignalingSocket signalingSocket, SessionDescriptor sessionDescriptor) {
     Log.w(TAG, "Starting signal processing loop...");
     this.signalManager = new SignalManager(callStateListener, signalingSocket, sessionDescriptor);
   }

--- a/src/org/thoughtcrime/redphone/call/ResponderCallManager.java
+++ b/src/org/thoughtcrime/redphone/call/ResponderCallManager.java
@@ -55,6 +55,8 @@ public class ResponderCallManager extends CallManager {
 
   private int answer = 0;
 
+  private SessionDescriptor sessionDescriptor;
+
   public ResponderCallManager(Context context, CallStateListener callStateListener,
                               String remoteNumber, String localNumber,
                               String password, SessionDescriptor sessionDescriptor,
@@ -70,16 +72,18 @@ public class ResponderCallManager extends CallManager {
   @Override
   public void run() {
     try {
-      signalingSocket = new SignalingSocket(context,
-                                            sessionDescriptor.getFullServerName(),
-                                            31337,
-                                            localNumber, password,
-                                            OtpCounterProvider.getInstance());
+      Log.d(TAG, "run");
+
+      SignalingSocket signalingSocket = new SignalingSocket(context,
+                                                            sessionDescriptor.getFullServerName(),
+                                                            31337,
+                                                            localNumber, password,
+                                                            OtpCounterProvider.getInstance());
 
       signalingSocket.setRinging(sessionDescriptor.sessionId);
       callStateListener.notifyCallFresh();
 
-      processSignals();
+      processSignals(signalingSocket, sessionDescriptor);
 
       if (!waitForAnswer()) {
         return;
@@ -92,8 +96,8 @@ public class ResponderCallManager extends CallManager {
       InetSocketAddress remoteAddress = new InetSocketAddress(sessionDescriptor.getFullServerName(),
                                                               sessionDescriptor.relayPort);
 
-      secureSocket  = new SecureRtpSocket(new RtpSocket(localPort, remoteAddress));
-      zrtpSocket    = new ZRTPResponderSocket(context, secureSocket, zid, remoteNumber, sessionDescriptor.version <= 0);
+      SecureRtpSocket secureSocket = new SecureRtpSocket(new RtpSocket(localPort, remoteAddress));
+      zrtpSocket = new ZRTPResponderSocket(context, secureSocket, zid, remoteNumber, sessionDescriptor.version <= 0);
 
       callStateListener.notifyConnectingtoInitiator();
 

--- a/src/org/thoughtcrime/redphone/call/SignalManager.java
+++ b/src/org/thoughtcrime/redphone/call/SignalManager.java
@@ -33,6 +33,10 @@ public class SignalManager {
     this.queue.execute(new SignalListenerTask());
   }
 
+  public SessionDescriptor getSessionDescriptor() {
+    return this.sessionDescriptor;
+  }
+
   public void terminate() {
     Log.w(TAG, "Queuing hangup signal...");
     queue.execute(new Runnable() {


### PR DESCRIPTION
### Contributor checklist

<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - HTC Sensation XE
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

Fixes #4172, was previously part of #5005.
- the first commit removes some class member variables from `CallManager`, nothing fancy
- the second commit basically adds 7 lines of code to synchronize `run` and `terminate` methods. But it also adds white-space changes, so the combined diff is not very nice!

---

The debug log shows that `CallManager.terminate()` can be called by the user before the thread has run and the `signalManager` was initialized. It is then still initialized later but thus never properly terminated.

```
RedPhoneService: onStart(): Intent { act=org.thoughtcrime.redphone.RedPhoneService.OUTGOING_CALL cmp=org.thoughtcrime.securesms/org.thoughtcrime.redphone.RedPhoneService (has extras) }
RedPhoneService: Received Intent: org.thoughtcrime.redphone.RedPhoneService.OUTGOING_CALL
RedPhoneService: request STREAM_VOICE_CALL audio focus
SignalingSocket: Connected to: 176.58.114.110
SignalingSocket: Sending signal...
RedPhoneService: onStart(): Intent { act=org.thoughtcrime.redphone.RedPhoneService.HANGUP cmp=org.thoughtcrime.securesms/org.thoughtcrime.redphone.RedPhoneService }
RedPhoneService: Received Intent: org.thoughtcrime.redphone.RedPhoneService.HANGUP
RedPhoneService: termination stack
                      java.lang.Exception
                          at org.thoughtcrime.redphone.RedPhoneService.terminate(RedPhoneService.java:361)
                          at org.thoughtcrime.redphone.RedPhoneService.handleHangupCall(RedPhoneService.java:271)
                          at org.thoughtcrime.redphone.RedPhoneService.onIntentReceived(RedPhoneService.java:150)
                          at org.thoughtcrime.redphone.RedPhoneService.access$200(RedPhoneService.java:77)
                          at org.thoughtcrime.redphone.RedPhoneService$IntentRunnable.run(RedPhoneService.java:525)
                          at java.lang.Thread.run(Thread.java:818)
CallManager: terminate
RedPhoneService: reset audio mode and abandon focus
CallManager: Starting signal processing loop...
CallManager: negotiating...
SignalManager: Running Signal Listener...
SignalManager: Signal Listener Running, interrupted: false
SignalManager: Received keep-alive...
... some time later ...
SignalManager: Running Signal Listener...
SignalManager: Signal Listener Running, interrupted: false
SignalManager: Received keep-alive...
...
```
