### PR TITLE
Accept verification SMSes with missing colons

### DIFF
--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -41,7 +41,7 @@ public class SmsListener extends BroadcastReceiver {
   private static final String SMS_RECEIVED_ACTION  = Telephony.Sms.Intents.SMS_RECEIVED_ACTION;
   private static final String SMS_DELIVERED_ACTION = Telephony.Sms.Intents.SMS_DELIVER_ACTION;
 
-  private static final Pattern CHALLENGE_PATTERN = Pattern.compile(".*Your (Signal|TextSecure) verification code: ([0-9]{3,4})-([0-9]{3,4}).*", Pattern.DOTALL);
+  private static final Pattern CHALLENGE_PATTERN = Pattern.compile(".*Your (Signal|TextSecure) verification code:? ([0-9]{3,4})-([0-9]{3,4}).*", Pattern.DOTALL);
 
   private boolean isExemption(SmsMessage message, String messageBody) {
 

--- a/test/unitTest/java/org/thoughtcrime/securesms/service/SmsListenerTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/service/SmsListenerTest.java
@@ -24,6 +24,7 @@ public class SmsListenerTest extends BaseUnitTest {
       put("Your TextSecure verification code: 1337-1337",      "13371337");
       put("XXXYour TextSecure verification code: 1337-1337",   "13371337");
       put("Your TextSecure verification code: 1337-1337XXX",   "13371337");
+      put("Your TextSecure verification code 1337-1337",       "13371337");
 
       put("Your Signal verification code: 337-337",        "337337");
       put("XXX\nYour Signal verification code: 1337-1337", "13371337");
@@ -32,6 +33,7 @@ public class SmsListenerTest extends BaseUnitTest {
       put("Your Signal verification code: 1337-1337",      "13371337");
       put("XXXYour Signal verification code: 1337-1337",   "13371337");
       put("Your Signal verification code: 1337-1337XXX",   "13371337");
+      put("Your Signal verification code 1337-1337",       "13371337");
   }};
 
   private SmsListener listener;


### PR DESCRIPTION
### Contributor checklist
<!-- mark with x between the brackets -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * using the modified `SmsListenerTest`
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Apparently some Argentinian mobile providers [strip the colons](http://smg.photobucket.com/user/francopellegrini/media/2016-03-21%2018.13.57.png.html) from Signal's verification SMS messages. This has been reported by two users with two different providers ("PERSONAL" and "Tuenti", see the issues below).

Fixes #5363
Fixes #3490

// FREEBIE