### PR TITLE
Adjust color scheme

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -87,9 +87,9 @@
         <item name="actionBarTabBarStyle">@style/TextSecure.LightActionBar.TabBar</item>
         <item name="colorPrimary">@color/textsecure_primary</item>
         <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
-        <item name="colorAccent">@color/textsecure_primary_dark</item>
-        <item name="colorControlActivated">@color/signal_primary</item>
-        <item name="colorControlHighlight">@color/signal_primary</item>
+        <item name="colorAccent">@color/signal_primary</item>
+        <item name="colorControlActivated">@color/signal_primary_dark</item>
+        <item name="colorControlHighlight">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@color/gray5</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyle</item>
         <!--<item name="android:windowContentOverlay">@drawable/compat_actionbar_shadow_background</item>-->
@@ -208,7 +208,7 @@
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="android:textColor">@color/text_color_dark_theme</item>
         <item name="android:textColorSecondary">@color/text_color_secondary_dark_theme</item>
-        <item name="colorAccent">@color/textsecure_primary_dark</item>
+        <item name="colorAccent">@color/signal_primary</item>
         <item name="colorControlActivated">@color/signal_primary_dark</item>
         <item name="colorControlHighlight">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@color/black</item>


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CM11)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
I adjusted the attributes colorAccent, colorControlHighlight and colorControlActivated for light and dark theme. This affects the following elements' colors:
- colorAccent: new conversation button, when not pressed
- colorControlHighlight: buttons, when pressed (including new conversation button and buttons during registration and invitation)
- colorControlActivated: checkboxes, switches, text cursors and tab highlighting (export/import backup)

### Pictures
new conversation button #5034
before
![before_dark-button](https://cloud.githubusercontent.com/assets/16167751/14068081/6737df46-f478-11e5-81df-519b5670a795.gif) ![before_light-button](https://cloud.githubusercontent.com/assets/16167751/14068080/6737a288-f478-11e5-81de-70557a6afdd3.gif)
after
![after_dark-button](https://cloud.githubusercontent.com/assets/16167751/14068084/673abfc2-f478-11e5-85c4-e340a9c0e70b.gif) ![after_light-button](https://cloud.githubusercontent.com/assets/16167751/14068079/6736a18a-f478-11e5-9a39-a7db8fef1beb.gif)
tab highlighting #5387
![light-backup](https://cloud.githubusercontent.com/assets/16167751/14068082/673a299a-f478-11e5-9774-af35471d7794.gif)
text cursors #5382
![light-search](https://cloud.githubusercontent.com/assets/16167751/14068086/674ac778-f478-11e5-8787-009ee0dffdef.gif)

side effects:
other buttons, when pressed
![invite](https://cloud.githubusercontent.com/assets/16167751/14068083/673a447a-f478-11e5-88ea-d98f4346844f.gif)
checkboxes and switches
![light-notifications](https://cloud.githubusercontent.com/assets/16167751/14068085/674a67b0-f478-11e5-9ac2-0421eb6a8df9.gif)

Fixes #5034
Fixes #5382
Fixes #5387
// FREEBIE