### PR TITLE
Add contextual menu items to NewConversationActivity

### DIFF
--- a/res/menu/new_conversation_activity.xml
+++ b/res/menu/new_conversation_activity.xml
@@ -1,7 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
+
     <item android:title="@string/new_conversation_activity__refresh"
           android:id="@+id/menu_refresh"
           app:showAsAction="never" />
+
+    <item android:title="@string/text_secure_normal__menu_new_group"
+        android:id="@+id/menu_new_group" />
+
+    <item android:title="@string/text_secure_normal__invite_friends"
+        android:id="@+id/menu_invite" />
+
 </menu>

--- a/src/org/thoughtcrime/securesms/NewConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/NewConversationActivity.java
@@ -70,8 +70,10 @@ public class NewConversationActivity extends ContactSelectionActivity {
     super.onOptionsItemSelected(item);
 
     switch (item.getItemId()) {
-    case android.R.id.home: super.onBackPressed(); return true;
-    case R.id.menu_refresh: handleManualRefresh(); return true;
+    case android.R.id.home:   super.onBackPressed(); return true;
+    case R.id.menu_refresh:   handleManualRefresh(); return true;
+    case R.id.menu_new_group: handleCreateGroup();   return true;
+    case R.id.menu_invite:    handleInvite();        return true;
     }
 
     return false;
@@ -80,6 +82,14 @@ public class NewConversationActivity extends ContactSelectionActivity {
   private void handleManualRefresh() {
     contactsFragment.setRefreshing(true);
     onRefresh();
+  }
+
+  private void handleCreateGroup() {
+    startActivity(new Intent(this, GroupCreateActivity.class));
+  }
+
+  private void handleInvite() {
+    startActivity(new Intent(this, InviteActivity.class));
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Add "New group" and "Invite friends" to `NewConversationActivity`. Currently it only has "Refresh" in it, which is not very nice. It also makes these features more easily discoverable.

Screenshot:
![newmenu](https://cloud.githubusercontent.com/assets/3845150/14077022/745034d4-f4e7-11e5-9f38-3679b86db87b.png)


// FREEBIE