### PR TITLE
Only send group avatar when modified

### DIFF
--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -65,12 +65,12 @@ import org.thoughtcrime.securesms.util.BitmapUtil;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.GroupUtil;
-import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 import org.thoughtcrime.securesms.util.SelectedRecipientsAdapter;
 import org.thoughtcrime.securesms.util.SelectedRecipientsAdapter.OnRecipientDeletedListener;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
+import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.util.InvalidNumberException;
 
@@ -277,7 +277,9 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleGroupUpdate() {
-    new UpdateSignalGroupTask(this, masterSecret, groupToUpdate.get().id, avatarBmp,
+    final Bitmap currentAvatar = groupToUpdate.get().avatarBmp;
+    final Bitmap newAvatar = (currentAvatar != null && currentAvatar.equals(avatarBmp)) ? null : avatarBmp;
+    new UpdateSignalGroupTask(this, masterSecret, groupToUpdate.get().id, newAvatar,
                               getGroupName(), getAdapter().getRecipients()).execute();
   }
 

--- a/src/org/thoughtcrime/securesms/groups/GroupManager.java
+++ b/src/org/thoughtcrime/securesms/groups/GroupManager.java
@@ -79,7 +79,7 @@ public class GroupManager {
     memberE164Numbers.add(TextSecurePreferences.getLocalNumber(context));
     groupDatabase.updateMembers(groupId, new LinkedList<>(memberE164Numbers));
     groupDatabase.updateTitle(groupId, name);
-    groupDatabase.updateAvatar(groupId, avatarBytes);
+    if (avatarBytes != null) groupDatabase.updateAvatar(groupId, avatarBytes);
 
     return sendGroupUpdate(context, masterSecret, groupId, memberE164Numbers, name, avatarBytes);
   }
@@ -104,7 +104,7 @@ public class GroupManager {
 
     if (avatar != null) {
       Uri avatarUri = SingleUseBlobProvider.getInstance().createUri(avatar);
-      avatarAttachment = new UriAttachment(avatarUri, ContentType.IMAGE_JPEG, AttachmentDatabase.TRANSFER_PROGRESS_DONE, avatar.length);
+      avatarAttachment = new UriAttachment(avatarUri, ContentType.IMAGE_PNG, AttachmentDatabase.TRANSFER_PROGRESS_DONE, avatar.length);
     }
 
     OutgoingGroupMediaMessage outgoingMessage = new OutgoingGroupMediaMessage(groupRecipient, groupContext, avatarAttachment, System.currentTimeMillis());


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Fixes #3380. Only include the avatar in the update when it was modified. This works because `null` avatars will not trigger any update on the receiving side.

Also, avatar bitmaps are currently compressed as `png`.

// FREEBIE