### PR TITLE
Override startActivity to add CREATE_NEW_TAB extra

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -371,11 +371,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public void startActivity(Intent intent) {
-     if (intent.getStringExtra(Browser.EXTRA_APPLICATION_ID) != null) {
-        Log.d(TAG, "Adding EXTRA_CREATE_NEW_TAB to Browser intent.");
-        intent.putExtra(Browser.EXTRA_CREATE_NEW_TAB, true);
-     }
-     super.startActivity(intent);
+    if (intent.getStringExtra(Browser.EXTRA_APPLICATION_ID) != null) {
+      Log.d(TAG, "Adding EXTRA_CREATE_NEW_TAB to Browser intent.");
+      intent.putExtra(Browser.EXTRA_CREATE_NEW_TAB, true);
+    }
+    super.startActivity(intent);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -372,8 +372,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void startActivity(Intent intent) {
     if (intent.getStringExtra(Browser.EXTRA_APPLICATION_ID) != null) {
-      Log.d(TAG, "Adding EXTRA_CREATE_NEW_TAB to Browser intent.");
-      intent.putExtra(Browser.EXTRA_CREATE_NEW_TAB, true);
+      Log.d(TAG, "Starting the Browser without replacing current tab.");
+      intent.removeExtra(Browser.EXTRA_APPLICATION_ID);
     }
     super.startActivity(intent);
   }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -33,6 +33,7 @@ import android.os.AsyncTask;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Vibrator;
+import android.provider.Browser;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import android.support.v4.view.WindowCompat;
@@ -366,6 +367,15 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       attachmentManager.setLocation(masterSecret, place, getCurrentMediaConstraints());
       break;
     }
+  }
+
+  @Override
+  public void startActivity(Intent intent) {
+     if (intent.getStringExtra(Browser.EXTRA_APPLICATION_ID) != null) {
+        Log.d(TAG, "Adding EXTRA_CREATE_NEW_TAB to Browser intent.");
+        intent.putExtra(Browser.EXTRA_CREATE_NEW_TAB, true);
+     }
+     super.startActivity(intent);
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5 (hammerhead), Android 4.4.4 (Cyanogenmod 11)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

The TextView uses the URLSpan onClick to create the intent when a user
clicks on Linkified URLs, with an extra of Browser.EXTRA_APPLICATION_ID.
This results in the browser window being re-used for any future URLs. By
overriding onClick in the Activity and adding
Browser.EXTRA_CREATE_NEW_TAB to any Browser requests, we prevent the
window re-use.

[Further reading](https://www.reddit.com/r/androiddev/comments/4ci1en/peculiar_behavior_of_autolink/).

Fixes #4874
Fixes #5356

Tested by making sure links open new windows in Chrome and ensured consistent behavior of telephone numbers, email addresses, plain text, and long-presses.