### PR TITLE
Provide a fallback for building without git

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -250,14 +250,19 @@ tasks.whenTaskAdded { task ->
 }
 
 def getLastCommitTimestamp() {
-    new ByteArrayOutputStream().withStream { os ->
-        def result = exec {
-            executable = 'git'
-            args = ['log', '-1', '--pretty=format:%ct']
-            standardOutput = os
-        }
+    try {
+        new ByteArrayOutputStream().withStream { os ->
+            def result = exec {
+                executable = 'git'
+                args = ['log', '-1', '--pretty=format:%ct']
+                standardOutput = os
+            }
 
-        return os.toString() + "000"
+            return os.toString() + "000"
+        }
+    }
+    catch (org.gradle.process.internal.ExecException e) {
+        return System.currentTimeMillis()
     }
 }
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
This PR changes the behavior of the `getLastCommitTimestamp` function to fall back to the current time in cases where the `git log` command fails (for whatever reason). This allows people to build the app from the zip files provided on the releases page.

