### PR TITLE
Update PR template to help auto-closing issues

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@
  * Device B, Android Z.Y
  * Virtual device W, Android Y.Y.Z
 - [ ] My contribution is fully baked and ready to be merged as is
-- [ ] If there are open issues that my contribution fixes, I am referring to them using the [`Fixes #1234` syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) in my **Git commit message**
-- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my **Git commit message**
+- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
+- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit
 
 ----------
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,12 +12,13 @@
  * Device B, Android Z.Y
  * Virtual device W, Android Y.Y.Z
 - [ ] My contribution is fully baked and ready to be merged as is
-- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message
+- [ ] If there are open issues that my contribution fixes, I am referring to them using the [`Fixes #1234` syntax](https://help.github.com/articles/closing-issues-via-commit-messages/) in my **Git commit message**
+- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my **Git commit message**
 
 ----------
 
 ### Description
 <!--
-Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
+Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
 Also, please describe shortly how you tested that your fix actually works.
 -->


### PR DESCRIPTION
### Contributor checklist

- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these browsers:
 * Ubuntu 15.10, Chrome 49.0.2623.110
 * Ubuntu 15.10, Firefox 45.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

It's probably the eighth deadly sin to update the templates every week – or if it wasn't before, it is now. (Aaand here comes the but) but this is important as this reduces micromanaging.

Using the [`Fixes #616` syntax in PR descriptions](https://github.com/blog/1506-closing-issues-via-pull-requests) seems to only work if the PR is merged with GitHub. But as merging that way is not the preferred method at this repository, the referenced issues won't get closed automatically, and someone has to undertake the tedious task of **remembering** to close them manually.

However, the `Fixes #666` syntax also works from commit messages and without the aforementioned issue. This way also fits with the repository's established workflow. Thus we should encourage the contributor to use this method by making it a checklist item.

In short, this change will help to prevent leaving orphaned issues endlessly wandering at the repository and releases them back to the light automatically :ghost::soon:::high_brightness::sparkles:

Edit:
If I can read correctly, this new feature could also help https://github.com/blog/2141-squash-your-commits