### PR TITLE
Color cursor visible in conversation list search

### DIFF
--- a/res/drawable/actionbar_cursor.xml
+++ b/res/drawable/actionbar_cursor.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle" >
+    <solid android:color="@color/signal_primary_dark" />
+    <size android:width="2dp" />
+</shape>

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -30,6 +30,8 @@ import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.EditText;
+import android.widget.TextView;
 
 import org.thoughtcrime.securesms.components.RatingManager;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -42,6 +44,8 @@ import org.thoughtcrime.securesms.service.KeyCachingService;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+import java.lang.reflect.Field;
 
 public class ConversationListActivity extends PassphraseRequiredActionBarActivity
     implements ConversationListFragment.ConversationSelectedListener
@@ -108,6 +112,14 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   private void initializeSearch(MenuItem searchViewItem) {
     SearchView searchView = (SearchView)MenuItemCompat.getActionView(searchViewItem);
     searchView.setQueryHint(getString(R.string.ConversationListActivity_search));
+
+    final EditText searchTextView = (EditText) searchView.findViewById(android.support.v7.appcompat.R.id.search_src_text);
+    try {
+      Field field = TextView.class.getDeclaredField("mCursorDrawableRes");
+      field.setAccessible(true);
+      field.set(searchTextView,R.drawable.actionbar_cursor);
+    } catch (Exception e) {}
+
     searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
       @Override
       public boolean onQueryTextSubmit(String query) {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (screenshots)
 * AVD: Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
I tried an `.xml`-based solution instead of manipulating `ConversationListActivity.java` before, but it did only work with the 6.0 AVD (not with the 4.4.4 device). This former attempt was based on this source's code: http://stackoverflow.com/questions/27730253/how-to-style-the-cursor-color-of-searchview-under-appcompat/28311351#28311351

Fixes #5382

// FREEBIE

### Screenshots
![cursor-dark](https://cloud.githubusercontent.com/assets/16167751/14233882/2f35e946-f9d5-11e5-9bc4-301c7e53aeaf.png)
![cursor-light](https://cloud.githubusercontent.com/assets/16167751/14233883/2f5cefdc-f9d5-11e5-9034-3f4c7b2afd4b.png)
