### PR TITLE
Unify dialog button colors

### DIFF
--- a/res/drawable-v21/dialog_background.xml
+++ b/res/drawable-v21/dialog_background.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<inset xmlns:android="http://schemas.android.com/apk/res/android"
+    android:insetLeft="0dp"
+    android:insetTop="16dp"
+    android:insetRight="0dp"
+    android:insetBottom="16dp">
+    <shape android:shape="rectangle">
+        <corners android:radius="2dp" />
+        <solid android:color="?dialog_background_color" />
+    </shape>
+</inset>

--- a/res/drawable/dialog_background.xml
+++ b/res/drawable/dialog_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/transparent" />
+</shape>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -77,6 +77,7 @@
 
     <attr name="dialog_info_icon" format="reference" />
     <attr name="dialog_alert_icon" format="reference" />
+    <attr name="dialog_background_color" format="reference|color" />
 
     <attr name="conversation_icon_attach_audio" format="reference"/>
     <attr name="conversation_icon_attach_video" format="reference" />

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -24,6 +24,7 @@
 
     <style name="AppCompatAlertDialogStyleDark" parent="Theme.AppCompat.Dialog.Alert">
         <item name="colorAccent">@color/signal_primary</item>
+        <item name="android:textColor">@null</item>
     </style>
 
     <style name="AppCompatDialogStyleLight" parent="Theme.AppCompat.Light.Dialog">
@@ -34,6 +35,7 @@
     <style name="AppCompatDialogStyleDark" parent="Theme.AppCompat.Dialog">
         <item name="colorAccent">@color/signal_primary</item>
         <item name="android:windowBackground">@drawable/dialog_background</item>
+        <item name="android:textColor">@null</item>
     </style>
 
     <!-- ActionBar styles -->

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -18,11 +18,12 @@
         <item name="android:backgroundDimEnabled">false</item>
     </style>
 
-    <style name="AppCompatAlertDialogStyle" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorAccent">@color/textsecure_primary_dark</item>
-        <item name="colorPrimary">@color/textsecure_primary</item>
-        <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
-        <item name="android:textColorLink">@color/textsecure_primary_dark</item>
+    <style name="AppCompatAlertDialogStyleLight" parent="Theme.AppCompat.Light.Dialog.Alert">
+        <item name="colorAccent">@color/signal_primary</item>
+    </style>
+
+    <style name="AppCompatAlertDialogStyleDark" parent="Theme.AppCompat.Dialog.Alert">
+        <item name="colorAccent">@color/signal_primary_dark</item>
     </style>
 
     <!-- ActionBar styles -->

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -26,6 +26,14 @@
         <item name="colorAccent">@color/signal_primary_dark</item>
     </style>
 
+    <style name="AppCompatDialogStyleLight" parent="Theme.AppCompat.Light.Dialog">
+        <item name="colorAccent">@color/signal_primary</item>
+    </style>
+
+    <style name="AppCompatDialogStyleDark" parent="Theme.AppCompat.Dialog">
+        <item name="colorAccent">@color/signal_primary_dark</item>
+    </style>
+
     <!-- ActionBar styles -->
     <style name="TextSecure.DarkActionBar"
            parent="@style/Widget.AppCompat.ActionBar">

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -19,7 +19,7 @@
     </style>
 
     <style name="AppCompatAlertDialogStyleLight" parent="Theme.AppCompat.Light.Dialog.Alert">
-        <item name="colorAccent">@color/signal_primary</item>
+        <item name="colorAccent">@color/signal_primary_dark</item>
     </style>
 
     <style name="AppCompatAlertDialogStyleDark" parent="Theme.AppCompat.Dialog.Alert">
@@ -27,7 +27,7 @@
     </style>
 
     <style name="AppCompatDialogStyleLight" parent="Theme.AppCompat.Light.Dialog">
-        <item name="colorAccent">@color/signal_primary</item>
+        <item name="colorAccent">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@drawable/dialog_background</item>
     </style>
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -23,7 +23,7 @@
     </style>
 
     <style name="AppCompatAlertDialogStyleDark" parent="Theme.AppCompat.Dialog.Alert">
-        <item name="colorAccent">@color/signal_primary_dark</item>
+        <item name="colorAccent">@color/signal_primary</item>
     </style>
 
     <style name="AppCompatDialogStyleLight" parent="Theme.AppCompat.Light.Dialog">
@@ -32,7 +32,7 @@
     </style>
 
     <style name="AppCompatDialogStyleDark" parent="Theme.AppCompat.Dialog">
-        <item name="colorAccent">@color/signal_primary_dark</item>
+        <item name="colorAccent">@color/signal_primary</item>
         <item name="android:windowBackground">@drawable/dialog_background</item>
     </style>
 

--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -28,10 +28,12 @@
 
     <style name="AppCompatDialogStyleLight" parent="Theme.AppCompat.Light.Dialog">
         <item name="colorAccent">@color/signal_primary</item>
+        <item name="android:windowBackground">@drawable/dialog_background</item>
     </style>
 
     <style name="AppCompatDialogStyleDark" parent="Theme.AppCompat.Dialog">
         <item name="colorAccent">@color/signal_primary_dark</item>
+        <item name="android:windowBackground">@drawable/dialog_background</item>
     </style>
 
     <!-- ActionBar styles -->

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -17,6 +17,7 @@
         <item name="contact_selection_push_user">#ff000000</item>
         <item name="contact_selection_lay_user">#a0000000</item>
         <item name="contact_selection_header_text">@color/textsecure_primary_dark</item>
+        <item name="dialog_background_color">@color/background_material_light</item>
     </style>
 
     <style name="TextSecure.DarkNoActionBar" parent="@style/Theme.AppCompat.NoActionBar">
@@ -32,6 +33,7 @@
         <item name="contact_selection_push_user">#ffeeeeee</item>
         <item name="contact_selection_lay_user">#afeeeeee</item>
         <item name="contact_selection_header_text">#66eeeeee</item>
+        <item name="dialog_background_color">@color/background_material_dark</item>
     </style>
 
     <style name="TextSecure.HighlightTheme" parent="@style/TextSecure.LightTheme">
@@ -172,6 +174,7 @@
 
         <item name="dialog_info_icon">@drawable/ic_info_outline_light</item>
         <item name="dialog_alert_icon">@drawable/ic_warning_light</item>
+        <item name="dialog_background_color">@color/background_material_light</item>
 
         <item name="device_link_item_card_background">@color/device_link_item_background_light</item>
 
@@ -260,6 +263,7 @@
 
         <item name="dialog_info_icon">@drawable/ic_info_outline_dark</item>
         <item name="dialog_alert_icon">@drawable/ic_warning_dark</item>
+        <item name="dialog_background_color">@color/background_material_dark</item>
 
         <item name="device_link_item_card_background">@color/device_link_item_background_dark</item>
 

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -9,6 +9,7 @@
         <item name="colorPrimary">@color/textsecure_primary</item>
         <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
         <item name="colorAccent">@color/textsecure_primary_dark</item>
+        <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleLight</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66000000</item>
@@ -22,6 +23,7 @@
         <item name="actionBarStyle">@style/TextSecure.DarkActionBar</item>
         <item name="actionBarTabBarStyle">@style/TextSecure.DarkActionBar.TabBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
+        <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleDark</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66eeeeee</item>
@@ -94,7 +96,7 @@
         <item name="colorControlActivated">@color/signal_primary</item>
         <item name="colorControlHighlight">@color/signal_primary</item>
         <item name="android:windowBackground">@color/gray5</item>
-        <item name="alertDialogTheme">@style/AppCompatAlertDialogStyle</item>
+        <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleLight</item>
         <!--<item name="android:windowContentOverlay">@drawable/compat_actionbar_shadow_background</item>-->
         <item name="attachment_type_selector_background">@color/white</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_light</item>
@@ -225,6 +227,7 @@
         <item name="colorControlActivated">@color/signal_primary_dark</item>
         <item name="colorControlHighlight">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@color/black</item>
+        <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleDark</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_dark</item>
         <item name="conversation_list_item_background_unread">@drawable/conversation_list_item_unread_background_dark</item>
         <item name="conversation_list_item_background_read">@drawable/conversation_list_item_read_background_dark</item>

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -10,6 +10,7 @@
         <item name="colorPrimaryDark">@color/textsecure_primary_dark</item>
         <item name="colorAccent">@color/textsecure_primary_dark</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleLight</item>
+        <item name="android:alertDialogTheme">@style/AppCompatDialogStyleLight</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66000000</item>
@@ -24,6 +25,7 @@
         <item name="actionBarTabBarStyle">@style/TextSecure.DarkActionBar.TabBar</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleDark</item>
+        <item name="android:alertDialogTheme">@style/AppCompatDialogStyleDark</item>
 
         <item name="recipient_preference_blocked">#d00000</item>
         <item name="contact_selection_label_text">#66eeeeee</item>
@@ -97,6 +99,7 @@
         <item name="colorControlHighlight">@color/signal_primary</item>
         <item name="android:windowBackground">@color/gray5</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleLight</item>
+        <item name="android:alertDialogTheme">@style/AppCompatDialogStyleLight</item>
         <!--<item name="android:windowContentOverlay">@drawable/compat_actionbar_shadow_background</item>-->
         <item name="attachment_type_selector_background">@color/white</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_light</item>
@@ -228,6 +231,7 @@
         <item name="colorControlHighlight">@color/signal_primary_dark</item>
         <item name="android:windowBackground">@color/black</item>
         <item name="alertDialogTheme">@style/AppCompatAlertDialogStyleDark</item>
+        <item name="android:alertDialogTheme">@style/AppCompatDialogStyleDark</item>
         <item name="conversation_list_item_background_selected">@drawable/list_selected_holo_dark</item>
         <item name="conversation_list_item_background_unread">@drawable/conversation_list_item_unread_background_dark</item>
         <item name="conversation_list_item_background_read">@drawable/conversation_list_item_read_background_dark</item>


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Sony Xperia U, Android 4.4.4
  - AVD: Nexus 5, Android 5.1
  - AVD: Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

There are two types of dialogs I colored separately here:
- alert dialogs: e.g. when you attempt unregister from Signal
- (choose) dialogs: e.g. when you change the app's language

I styled the (radio) buttons for both with the same colors per theme. I chose the lighter blue for the light theme and the darker blue for the dark theme. After just setting the colors, there were some OS version specific problems with the dialogs' layout to fix:
- Marshmallow/Lollipop: height too large
- KitKat: smaller dialog with rectangle in the background (had the size of the original dialog)

I shouldn't be at all surprised if other OS versions offer further challenges :unamused:.

Fixes #5227
### Screenshots

OS order: KitKat, Lollipop, Marshmallow
![alert-dark-kitkat](https://cloud.githubusercontent.com/assets/16167751/14268918/0810ee68-fae0-11e5-889d-fcbe928cc231.png)
![alert-dark-lollipop](https://cloud.githubusercontent.com/assets/16167751/14268919/081285fc-fae0-11e5-92b4-1fa656f3d9f5.png)
![alert-dark-marshmallow](https://cloud.githubusercontent.com/assets/16167751/14268920/08138808-fae0-11e5-9e85-ae02c4259ef1.png)
![alert-light-kitkat](https://cloud.githubusercontent.com/assets/16167751/14268923/08149cca-fae0-11e5-9d1c-06c1495e0f70.png)
![alert-light-lollipop](https://cloud.githubusercontent.com/assets/16167751/14268922/08142100-fae0-11e5-8542-df47d1a81a32.png)
![alert-light-marshmallow](https://cloud.githubusercontent.com/assets/16167751/14268921/0813eafa-fae0-11e5-88d9-41dccb2192b7.png)
![dialog-dark-kitkat](https://cloud.githubusercontent.com/assets/16167751/14268925/082d4978-fae0-11e5-82a3-cde1f50a309f.png)
![dialog-dark-lollipop](https://cloud.githubusercontent.com/assets/16167751/14268924/082b736e-fae0-11e5-8a1e-fc5b2f4ed5d1.png)
![dialog-dark-marshmallow](https://cloud.githubusercontent.com/assets/16167751/14268926/08379af4-fae0-11e5-9190-4f17e64a39fd.png)
![dialog-light-kitkat](https://cloud.githubusercontent.com/assets/16167751/14268929/083fc3d2-fae0-11e5-8069-98e44a7cb290.png)
![dialog-light-lollipop](https://cloud.githubusercontent.com/assets/16167751/14268927/083e46d8-fae0-11e5-8e87-dc0a8ea9a6d2.png)
![dialog-light-marshmallow](https://cloud.githubusercontent.com/assets/16167751/14268928/084099d8-fae0-11e5-81be-32e248688476.png)
