### PR TITLE
Improve group update descriptions

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -402,7 +402,8 @@
     <!-- MessageRecord -->
     <string name="MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported">Received a message encrypted using an old version of Signal that is no longer supported. Please ask the sender to update to the most recent version and resend the message.</string>
     <string name="MessageRecord_left_group">You have left the group.</string>
-    <string name="MessageRecord_updated_group">Updated the group.</string>
+    <string name="MessageRecord_you_updated_group">You updated the group.</string>
+    <string name="MessageRecord_s_updated_group">%s updated the group.</string>
     <string name="MessageRecord_s_called_you">%s called you</string>
     <string name="MessageRecord_called_s">Called %s</string>
     <string name="MessageRecord_missed_call_from">Missed call from %s</string>
@@ -569,6 +570,7 @@
     <string name="SmsMessageRecord_duplicate_message">Duplicate message.</string>
 
     <!-- ThreadRecord -->
+    <string name="ThreadRecord_group_updated">Group updated</string>
     <string name="ThreadRecord_left_the_group">Left the group</string>
     <string name="ThreadRecord_secure_session_reset">Secure session reset.</string>
     <string name="ThreadRecord_draft">Draft:</string>
@@ -876,7 +878,6 @@
         <item quantity="one">%1$s joined the group.</item>
         <item quantity="other">%1$s joined the group.</item>
     </plurals>
-    <string name="GroupUtil_group_updated">Group updated.</string>
     <string name="GroupUtil_group_name_is_now">Group name is now \'%1$s\'.</string>
 
     <!-- prompt_passphrase_activity -->

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -25,8 +25,8 @@ import android.text.style.StyleSpan;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.MmsSmsColumns;
 import org.thoughtcrime.securesms.database.SmsDatabase;
-import org.thoughtcrime.securesms.database.documents.NetworkFailure;
 import org.thoughtcrime.securesms.database.documents.IdentityKeyMismatch;
+import org.thoughtcrime.securesms.database.documents.NetworkFailure;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.ExpirationUtil;
@@ -93,9 +93,12 @@ public abstract class MessageRecord extends DisplayRecord {
   @Override
   public SpannableString getDisplayBody() {
     if (isGroupUpdate() && isOutgoing()) {
-      return emphasisAdded(context.getString(R.string.MessageRecord_updated_group));
+      return emphasisAdded(context.getString(R.string.MessageRecord_you_updated_group));
     } else if (isGroupUpdate()) {
-      return emphasisAdded(GroupUtil.getDescription(context, getBody().getBody()).toString());
+      String description = context.getString(R.string.MessageRecord_s_updated_group, getIndividualRecipient().toShortString());
+      String details     = GroupUtil.getDescription(context, getBody().getBody()).toString();
+      if (!details.trim().isEmpty()) description += "\n" + details;
+      return emphasisAdded(description);
     } else if (isGroupQuit() && isOutgoing()) {
       return emphasisAdded(context.getString(R.string.MessageRecord_left_group));
     } else if (isGroupQuit()) {

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -95,10 +95,7 @@ public abstract class MessageRecord extends DisplayRecord {
     if (isGroupUpdate() && isOutgoing()) {
       return emphasisAdded(context.getString(R.string.MessageRecord_you_updated_group));
     } else if (isGroupUpdate()) {
-      String description = context.getString(R.string.MessageRecord_s_updated_group, getIndividualRecipient().toShortString());
-      String details     = GroupUtil.getDescription(context, getBody().getBody()).toString();
-      if (!details.trim().isEmpty()) description += "\n" + details;
-      return emphasisAdded(description);
+      return emphasisAdded(GroupUtil.getDescription(context, getBody().getBody()).toString(getIndividualRecipient()));
     } else if (isGroupQuit() && isOutgoing()) {
       return emphasisAdded(context.getString(R.string.MessageRecord_left_group));
     } else if (isGroupQuit()) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -28,10 +28,8 @@ import android.text.style.StyleSpan;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.MmsSmsColumns;
 import org.thoughtcrime.securesms.database.SmsDatabase;
-import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.ExpirationUtil;
-import org.thoughtcrime.securesms.util.GroupUtil;
 
 /**
  * The message record model which represents thread heading messages.
@@ -75,7 +73,7 @@ public class ThreadRecord extends DisplayRecord {
     if (SmsDatabase.Types.isDecryptInProgressType(type)) {
       return emphasisAdded(context.getString(R.string.MessageDisplayHelper_decrypting_please_wait));
     } else if (isGroupUpdate()) {
-      return emphasisAdded(GroupUtil.getDescription(context, getBody().getBody()).toString());
+      return emphasisAdded(context.getString(R.string.ThreadRecord_group_updated));
     } else if (isGroupQuit()) {
       return emphasisAdded(context.getString(R.string.ThreadRecord_left_the_group));
     } else if (isKeyExchange()) {

--- a/src/org/thoughtcrime/securesms/util/GroupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/GroupUtil.java
@@ -6,6 +6,7 @@ import android.support.annotation.Nullable;
 import android.util.Log;
 
 import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.Recipients;
 
@@ -65,21 +66,25 @@ public class GroupUtil {
       }
     }
 
-    public String toString() {
+    public String toString(Recipient sender) {
+      StringBuilder description = new StringBuilder();
+      description.append(context.getString(R.string.MessageRecord_s_updated_group, sender.toShortString()));
+
       if (groupContext == null) {
-        return "";
+        return description.toString();
       }
 
-      StringBuilder description = new StringBuilder();
-      String        title       = groupContext.getName();
+      String title = groupContext.getName();
 
       if (members != null) {
+        description.append("\n");
         description.append(context.getResources().getQuantityString(R.plurals.GroupUtil_joined_the_group,
                 members.getRecipientsList().size(), members.toShortString()));
       }
 
       if (title != null && !title.trim().isEmpty()) {
-        if (description.length() > 0) description.append(" ");
+        if (members != null) description.append(" ");
+        else                 description.append("\n");
         description.append(context.getString(R.string.GroupUtil_group_name_is_now, title));
       }
 

--- a/src/org/thoughtcrime/securesms/util/GroupUtil.java
+++ b/src/org/thoughtcrime/securesms/util/GroupUtil.java
@@ -61,13 +61,13 @@ public class GroupUtil {
       if (groupContext == null || groupContext.getMembersList().isEmpty()) {
         this.members = null;
       } else {
-        this.members = RecipientFactory.getRecipientsFromString(context, Util.join(groupContext.getMembersList(), ", "), true);
+        this.members = RecipientFactory.getRecipientsFromStrings(context, groupContext.getMembersList(), true);
       }
     }
 
     public String toString() {
       if (groupContext == null) {
-        return context.getString(R.string.GroupUtil_group_updated);
+        return "";
       }
 
       StringBuilder description = new StringBuilder();
@@ -83,11 +83,7 @@ public class GroupUtil {
         description.append(context.getString(R.string.GroupUtil_group_name_is_now, title));
       }
 
-      if (description.length() > 0) {
-        return description.toString();
-      } else {
-        return context.getString(R.string.GroupUtil_group_updated);
-      }
+      return description.toString();
     }
 
     public void addListener(Recipients.RecipientsModifiedListener listener) {


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description
- in conversation list: only show a short group update info (see #2834)
- in group conversation: indicate which member updated the group, or "You ...", see screenshots

**Before:**
![group_update_before](https://cloud.githubusercontent.com/assets/3845150/14347319/cb5a6aa2-fcb6-11e5-8b8a-cc35212fcbf5.png)

**After:**
![group_update_after](https://cloud.githubusercontent.com/assets/3845150/14347323/d132ec6a-fcb6-11e5-93a5-248b16713dc0.png)

// FREEBIE

_Outgoing group update descriptions could be more precise if they didn't contain unchanged group title, members and avatar._
