### PR TITLE
Mark unread messages in conversation

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -3,8 +3,7 @@
         android:id="@+id/conversation_item"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:paddingRight="10dip"
-        android:orientation="vertical"
+        android:orientation="horizontal"
         android:background="@drawable/conversation_item_background"
         android:focusable="true"
         android:nextFocusLeft="@+id/container"
@@ -13,195 +12,210 @@
         xmlns:tools="http://schemas.android.com/tools"
         xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <TextView android:id="@+id/group_message_status"
-              android:layout_width="wrap_content"
-              android:layout_height="wrap_content"
-              android:layout_marginLeft="15dp"
-              android:layout_marginTop="5dp"
-              android:fontFamily="sans-serif-light"
-              android:textSize="13sp"
-              android:textColor="?attr/conversation_group_member_name"
-              android:visibility="gone" />
+    <LinearLayout android:orientation="vertical"
+                  android:paddingRight="5dip"
+                  android:layout_weight="1"
+                  android:layout_width="fill_parent"
+                  android:layout_height="fill_parent">
 
-    <RelativeLayout android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginTop="2dp"
-                    android:layout_marginLeft="9dp"
-                    android:layout_marginBottom="6dp"
-                    android:layout_marginRight="0dp">
-
-        <org.thoughtcrime.securesms.components.AvatarImageView
-            android:id="@+id/contact_photo"
-            android:foreground="@drawable/contact_photo_background"
-            android:layout_width="40dp"
-            android:layout_height="40dp"
-            android:layout_alignParentLeft="true"
-            android:layout_alignParentBottom="true"
-            android:cropToPadding="true"
-            android:contentDescription="@string/conversation_item_received__contact_photo_description" />
-
-        <LinearLayout android:id="@+id/body_bubble"
-                      android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      android:layout_toRightOf="@id/contact_photo"
-                      android:layout_marginRight="35dp"
-                      android:background="@drawable/received_bubble"
-                      android:orientation="vertical"
-                      tools:backgroundTint="@color/blue_900">
-
-            <org.thoughtcrime.securesms.components.ThumbnailView
-                    android:id="@+id/image_view"
-                    android:layout_width="@dimen/media_bubble_height"
-                    android:layout_height="@dimen/media_bubble_height"
-                    android:scaleType="centerCrop"
-                    android:adjustViewBounds="true"
-                    android:contentDescription="@string/conversation_item__mms_image_description"
-                    android:visibility="gone"
-                    tools:src="@drawable/ic_video_light"
-                    tools:visibility="gone" />
-
-            <org.thoughtcrime.securesms.components.AudioView
-                    android:id="@+id/audio_view"
-                    android:layout_width="210dp"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    app:tintColor="@color/white"
-                    tools:visibility="visible"/>
-
-            <org.thoughtcrime.securesms.components.emoji.EmojiTextView
-                    android:id="@+id/conversation_item_body"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingLeft="4dp"
-                    android:paddingRight="4dp"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?conversation_item_received_text_primary_color"
-                    android:textColorLink="?conversation_item_received_text_primary_color"
-                    android:textSize="@dimen/conversation_item_body_text_size"
-                    android:autoLink="all"
-                    android:linksClickable="true" />
-
-            <LinearLayout android:id="@+id/mms_download_controls"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:orientation="horizontal">
-
-                <Button android:id="@+id/mms_download_button"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center_vertical"
-                        android:text="@string/conversation_item_received__download"
-                        android:visibility="gone" />
-
-                <TextView android:id="@+id/mms_label_downloading"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:layout_marginLeft="5dp"
-                          android:layout_marginRight="5dp"
-                          android:gravity="center"
-                          android:text="@string/conversation_item_received__downloading"
-                          android:visibility="gone" />
-
-            </LinearLayout>
-
-            <LinearLayout android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:paddingTop="2dip"
-                          android:paddingLeft="4dp"
-                          android:paddingRight="4dp"
-                          android:orientation="horizontal"
-                          android:gravity="left">
-
-                <ImageView android:id="@+id/secure_indicator"
-                           android:layout_width="wrap_content"
-                           android:layout_height="wrap_content"
-                           android:layout_gravity="center_vertical"
-                           android:paddingRight="2dp"
-                           android:paddingEnd="4dp"
-                           android:src="?menu_lock_icon_small"
-                           android:contentDescription="@string/conversation_item__secure_message_description"
-                           android:visibility="gone"
-                           android:tint="?conversation_item_received_text_secondary_color"
-                           android:tintMode="multiply"
-                           tools:visibility="visible"/>
-
-                <org.thoughtcrime.securesms.components.ExpirationTimerView
-                        android:id="@+id/expiration_indicator"
-                        app:empty="@drawable/ic_hourglass_empty_white_18dp"
-                        app:full="@drawable/ic_hourglass_full_white_18dp"
-                        app:tint="?conversation_item_received_text_secondary_color"
-                        app:percentage="0"
-                        app:offset="0"
-                        android:layout_gravity="center_vertical|end"
-                        android:alpha=".65"
-                        android:layout_width="10dp"
-                        android:layout_height="11dp"
-                        android:visibility="gone"
-                        tools:visibility="visible"/>
-
-                <org.thoughtcrime.securesms.components.DeliveryStatusView
-                        android:id="@+id/delivery_status"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:visibility="gone"/>
-
-                <TextView android:id="@+id/conversation_item_date"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:layout_gravity="left"
-                          android:paddingTop="1dip"
-                          android:textAppearance="?android:attr/textAppearanceSmall"
-                          android:textColor="?conversation_item_received_text_secondary_color"
-                          android:textSize="@dimen/conversation_item_date_text_size"
-                          android:fontFamily="sans-serif-light"
-                          android:autoLink="none"
-                          android:linksClickable="false"
-                          tools:text="Now"
-                          tools:visibility="visible"/>
-
-                <TextView android:id="@+id/sim_info"
-                          android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:layout_gravity="left"
-                          android:paddingTop="1dip"
-                          android:paddingLeft="4dp"
-                          android:paddingStart="4dp"
-                          android:textAppearance="?android:attr/textAppearanceSmall"
-                          android:textColor="?conversation_item_received_text_secondary_color"
-                          android:textSize="@dimen/conversation_item_date_text_size"
-                          android:fontFamily="sans-serif-light"
-                          android:autoLink="none"
-                          android:linksClickable="false"
-                          android:visibility="gone"
-                          tools:visibility="visible"
-                          tools:text="from SIM1"/>
-            </LinearLayout>
-        </LinearLayout>
-
-        <org.thoughtcrime.securesms.components.AlertView
-                android:id="@+id/indicators_parent"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:orientation="vertical"
-                android:gravity="center_vertical"/>
-
-        <TextView android:id="@+id/indicator_text"
+        <TextView android:id="@+id/group_message_status"
                   android:layout_width="wrap_content"
                   android:layout_height="wrap_content"
-                  android:layout_below="@id/body_bubble"
-                  android:layout_alignParentRight="true"
-                  android:paddingRight="5dip"
-                  android:paddingLeft="5dip"
-                  android:paddingTop="3dp"
-                  android:paddingBottom="3dp"
-                  android:layout_marginLeft="50dp"
-                  android:layout_marginRight="22dp"
-                  android:layout_marginTop="-2dp"
-                  android:textSize="12sp"
-                  android:textColor="?conversation_item_sent_text_indicator_tab_color"
-                  android:background="?conversation_item_sent_indicator_text_background"
+                  android:layout_marginLeft="15dp"
+                  android:layout_marginTop="5dp"
+                  android:fontFamily="sans-serif-light"
+                  android:textSize="13sp"
+                  android:textColor="?attr/conversation_group_member_name"
                   android:visibility="gone" />
 
-    </RelativeLayout>
+        <RelativeLayout android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="2dp"
+                        android:layout_marginLeft="9dp"
+                        android:layout_marginBottom="6dp"
+                        android:layout_marginRight="0dp">
+
+            <org.thoughtcrime.securesms.components.AvatarImageView
+                    android:id="@+id/contact_photo"
+                    android:foreground="@drawable/contact_photo_background"
+                    android:layout_width="40dp"
+                    android:layout_height="40dp"
+                    android:layout_alignParentLeft="true"
+                    android:layout_alignParentBottom="true"
+                    android:cropToPadding="true"
+                    android:contentDescription="@string/conversation_item_received__contact_photo_description" />
+
+            <LinearLayout android:id="@+id/body_bubble"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content"
+                          android:layout_toRightOf="@id/contact_photo"
+                          android:layout_marginRight="35dp"
+                          android:background="@drawable/received_bubble"
+                          android:orientation="vertical"
+                          tools:backgroundTint="@color/blue_900">
+
+                <org.thoughtcrime.securesms.components.ThumbnailView
+                        android:id="@+id/image_view"
+                        android:layout_width="@dimen/media_bubble_height"
+                        android:layout_height="@dimen/media_bubble_height"
+                        android:scaleType="centerCrop"
+                        android:adjustViewBounds="true"
+                        android:contentDescription="@string/conversation_item__mms_image_description"
+                        android:visibility="gone"
+                        tools:src="@drawable/ic_video_light"
+                        tools:visibility="gone" />
+
+                <org.thoughtcrime.securesms.components.AudioView
+                        android:id="@+id/audio_view"
+                        android:layout_width="210dp"
+                        android:layout_height="wrap_content"
+                        android:visibility="gone"
+                        app:tintColor="@color/white"
+                        tools:visibility="visible"/>
+
+                <org.thoughtcrime.securesms.components.emoji.EmojiTextView
+                        android:id="@+id/conversation_item_body"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:paddingLeft="4dp"
+                        android:paddingRight="4dp"
+                        android:textAppearance="?android:attr/textAppearanceSmall"
+                        android:textColor="?conversation_item_received_text_primary_color"
+                        android:textColorLink="?conversation_item_received_text_primary_color"
+                        android:textSize="@dimen/conversation_item_body_text_size"
+                        android:autoLink="all"
+                        android:linksClickable="true" />
+
+                <LinearLayout android:id="@+id/mms_download_controls"
+                              android:layout_width="wrap_content"
+                              android:layout_height="wrap_content"
+                              android:orientation="horizontal">
+
+                    <Button android:id="@+id/mms_download_button"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center_vertical"
+                            android:text="@string/conversation_item_received__download"
+                            android:visibility="gone" />
+
+                    <TextView android:id="@+id/mms_label_downloading"
+                              android:layout_width="wrap_content"
+                              android:layout_height="wrap_content"
+                              android:layout_marginLeft="5dp"
+                              android:layout_marginRight="5dp"
+                              android:gravity="center"
+                              android:text="@string/conversation_item_received__downloading"
+                              android:visibility="gone" />
+
+                </LinearLayout>
+
+                <LinearLayout android:layout_width="wrap_content"
+                              android:layout_height="wrap_content"
+                              android:paddingTop="2dip"
+                              android:paddingLeft="4dp"
+                              android:paddingRight="4dp"
+                              android:orientation="horizontal"
+                              android:gravity="left">
+
+                    <ImageView android:id="@+id/secure_indicator"
+                               android:layout_width="wrap_content"
+                               android:layout_height="wrap_content"
+                               android:layout_gravity="center_vertical"
+                               android:paddingRight="2dp"
+                               android:paddingEnd="4dp"
+                               android:src="?menu_lock_icon_small"
+                               android:contentDescription="@string/conversation_item__secure_message_description"
+                               android:visibility="gone"
+                               android:tint="?conversation_item_received_text_secondary_color"
+                               android:tintMode="multiply"
+                               tools:visibility="visible"/>
+
+                    <org.thoughtcrime.securesms.components.ExpirationTimerView
+                            android:id="@+id/expiration_indicator"
+                            app:empty="@drawable/ic_hourglass_empty_white_18dp"
+                            app:full="@drawable/ic_hourglass_full_white_18dp"
+                            app:tint="?conversation_item_received_text_secondary_color"
+                            app:percentage="0"
+                            app:offset="0"
+                            android:layout_gravity="center_vertical|end"
+                            android:alpha=".65"
+                            android:layout_width="10dp"
+                            android:layout_height="11dp"
+                            android:visibility="gone"
+                            tools:visibility="visible"/>
+
+                    <org.thoughtcrime.securesms.components.DeliveryStatusView
+                            android:id="@+id/delivery_status"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:visibility="gone"/>
+
+                    <TextView android:id="@+id/conversation_item_date"
+                              android:layout_width="wrap_content"
+                              android:layout_height="wrap_content"
+                              android:layout_gravity="left"
+                              android:paddingTop="1dip"
+                              android:textAppearance="?android:attr/textAppearanceSmall"
+                              android:textColor="?conversation_item_received_text_secondary_color"
+                              android:textSize="@dimen/conversation_item_date_text_size"
+                              android:fontFamily="sans-serif-light"
+                              android:autoLink="none"
+                              android:linksClickable="false"
+                              tools:text="Now"
+                              tools:visibility="visible"/>
+
+                    <TextView android:id="@+id/sim_info"
+                              android:layout_width="wrap_content"
+                              android:layout_height="wrap_content"
+                              android:layout_gravity="left"
+                              android:paddingTop="1dip"
+                              android:paddingLeft="4dp"
+                              android:paddingStart="4dp"
+                              android:textAppearance="?android:attr/textAppearanceSmall"
+                              android:textColor="?conversation_item_received_text_secondary_color"
+                              android:textSize="@dimen/conversation_item_date_text_size"
+                              android:fontFamily="sans-serif-light"
+                              android:autoLink="none"
+                              android:linksClickable="false"
+                              android:visibility="gone"
+                              tools:visibility="visible"
+                              tools:text="from SIM1"/>
+                </LinearLayout>
+            </LinearLayout>
+
+            <org.thoughtcrime.securesms.components.AlertView
+                    android:id="@+id/indicators_parent"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_alignParentRight="true"
+                    android:orientation="vertical"
+                    android:gravity="center_vertical"/>
+
+            <TextView android:id="@+id/indicator_text"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:layout_below="@id/body_bubble"
+                      android:layout_alignParentRight="true"
+                      android:paddingRight="5dip"
+                      android:paddingLeft="5dip"
+                      android:paddingTop="3dp"
+                      android:paddingBottom="3dp"
+                      android:layout_marginLeft="50dp"
+                      android:layout_marginRight="22dp"
+                      android:layout_marginTop="-2dp"
+                      android:textSize="12sp"
+                      android:textColor="?conversation_item_sent_text_indicator_tab_color"
+                      android:background="?conversation_item_sent_indicator_text_background"
+                      android:visibility="gone" />
+
+        </RelativeLayout>
+    </LinearLayout>
+
+    <View android:id="@+id/read_status"
+          android:layout_weight="0"
+          android:layout_height="match_parent"
+          android:layout_width="6dp"
+          android:background="@color/white"
+          tools:backgroundTint="@color/blue_900" />
+
 </org.thoughtcrime.securesms.ConversationItem>

--- a/res/layout/conversation_item_update.xml
+++ b/res/layout/conversation_item_update.xml
@@ -7,47 +7,60 @@
         android:layout_height="wrap_content"
         android:focusable="true"
         android:background="@drawable/conversation_item_background"
-        android:orientation="horizontal"
-        android:gravity="center"
-        android:padding="20dp">
+        android:orientation="horizontal">
 
-    <ImageView android:id="@+id/conversation_update_icon"
-               android:layout_marginRight="7dp"
-               android:layout_width="wrap_content"
-               android:layout_height="wrap_content"
-               android:layout_gravity="center_vertical"
-               android:src="@drawable/ic_call_received_grey600_24dp" />
+    <LinearLayout android:orientation="horizontal"
+                  android:layout_weight="1"
+                  android:layout_width="fill_parent"
+                  android:layout_height="fill_parent"
+                  android:gravity="center"
+                  android:padding="20dp">
 
-    <LinearLayout android:orientation="vertical"
-                  android:layout_width="wrap_content"
-                  android:layout_height="wrap_content">
+        <ImageView android:id="@+id/conversation_update_icon"
+                   android:layout_marginRight="7dp"
+                   android:layout_width="wrap_content"
+                   android:layout_height="wrap_content"
+                   android:layout_gravity="center_vertical"
+                   android:src="@drawable/ic_call_received_grey600_24dp" />
 
-        <TextView android:id="@+id/conversation_update_body"
-                  android:autoLink="all"
-                  android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  android:linksClickable="true"
-                  android:textAppearance="?android:attr/textAppearanceSmall"
-                  android:textStyle="italic"
-                  android:textColor="?attr/conversation_group_member_name"
-                  tools:text="Sasha called you"/>
+        <LinearLayout android:orientation="vertical"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content">
 
-        <TextView android:id="@+id/conversation_update_date"
-                  android:autoLink="none"
-                  android:layout_width="wrap_content"
-                  android:layout_height="wrap_content"
-                  android:minWidth="15sp"
-                  android:linksClickable="false"
-                  android:textAppearance="?android:attr/textAppearanceSmall"
-                  android:layout_gravity="center"
-                  android:fontFamily="sans-serif-light"
-                  android:textColor="?conversation_item_sent_text_secondary_color"
-                  android:textSize="@dimen/conversation_item_date_text_size"
-                  android:paddingTop="1dip"
-                  android:paddingBottom="2dp"
-                  tools:text="30 min ago" />
+            <TextView android:id="@+id/conversation_update_body"
+                      android:autoLink="all"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:linksClickable="true"
+                      android:textAppearance="?android:attr/textAppearanceSmall"
+                      android:textStyle="italic"
+                      android:textColor="?attr/conversation_group_member_name"
+                      tools:text="Sasha called you"/>
+
+            <TextView android:id="@+id/conversation_update_date"
+                      android:autoLink="none"
+                      android:layout_width="wrap_content"
+                      android:layout_height="wrap_content"
+                      android:minWidth="15sp"
+                      android:linksClickable="false"
+                      android:textAppearance="?android:attr/textAppearanceSmall"
+                      android:layout_gravity="center"
+                      android:fontFamily="sans-serif-light"
+                      android:textColor="?conversation_item_sent_text_secondary_color"
+                      android:textSize="@dimen/conversation_item_date_text_size"
+                      android:paddingTop="1dip"
+                      android:paddingBottom="2dp"
+                      tools:text="30 min ago" />
+
+        </LinearLayout>
 
     </LinearLayout>
 
+    <View android:id="@+id/read_status"
+          android:layout_weight="0"
+          android:layout_height="match_parent"
+          android:layout_width="6dp"
+          android:background="@color/white"
+          tools:backgroundTint="@color/blue_900"/>
 
 </org.thoughtcrime.securesms.ConversationUpdateItem>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -297,7 +297,6 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     calculateCharactersRemaining();
 
     MessageNotifier.setVisibleThread(threadId);
-    markThreadAsRead();
   }
 
   @Override
@@ -323,6 +322,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   @Override
   protected void onDestroy() {
     saveDraft();
+    markThreadAsRead();
     if (recipients != null)              recipients.removeListener(this);
     if (securityUpdateReceiver != null)  unregisterReceiver(securityUpdateReceiver);
     if (recipientsStaleReceiver != null) unregisterReceiver(recipientsStaleReceiver);
@@ -356,6 +356,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       titleView.setTitle(recipients);
       setBlockedUserState(recipients);
       supportInvalidateOptionsMenu();
+      markThreadAsRead();
       break;
     case TAKE_PHOTO:
       if (attachmentManager.getCaptureUri() != null) {
@@ -714,6 +715,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   private void handleDial(final Recipient recipient) {
     if (recipient == null) return;
+
+    markThreadAsRead();
 
     if (isSecureVoice) {
       Intent intent = new Intent(this, RedPhoneService.class);
@@ -1334,6 +1337,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
     fragment.scrollToBottom();
     attachmentManager.cleanup();
+    markThreadAsRead();
   }
 
   private void sendMessage() {
@@ -1675,6 +1679,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void setThreadId(long threadId) {
     this.threadId = threadId;
+  }
+
+  @Override
+  public void scrolledToBottom() {
+    markThreadAsRead();
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -44,6 +44,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
+import android.widget.AbsListView;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.ConversationAdapter.ItemClickListener;
@@ -166,6 +167,19 @@ public class ConversationFragment extends Fragment
       list.setAdapter(new ConversationAdapter(getActivity(), masterSecret, locale, selectionClickListener, null, this.recipients));
       getLoaderManager().restartLoader(0, Bundle.EMPTY, this);
       list.getItemAnimator().setMoveDuration(120);
+      list.addOnScrollListener(new RecyclerView.OnScrollListener() {
+        @Override
+        public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+          super.onScrollStateChanged(recyclerView, newState);
+          if (newState == AbsListView.OnScrollListener.SCROLL_STATE_IDLE) {
+            final LinearLayoutManager lm   = (LinearLayoutManager) recyclerView.getLayoutManager();
+            final View                item = lm.findViewByPosition(lm.findFirstVisibleItemPosition());
+            if (item != null && item.getBottom() == recyclerView.getHeight()) {
+              listener.scrolledToBottom();
+            }
+          }
+        }
+      });
     }
   }
 
@@ -393,6 +407,7 @@ public class ConversationFragment extends Fragment
 
   public interface ConversationFragmentListener {
     void setThreadId(long threadId);
+    void scrolledToBottom();
   }
 
   private class ConversationFragmentItemClickListener implements ItemClickListener {

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -106,6 +106,7 @@ public class ConversationItem extends LinearLayout
   private AvatarImageView    contactPhoto;
   private DeliveryStatusView deliveryStatusIndicator;
   private AlertView          alertView;
+  private View               readStatus;
 
   private @NonNull  Set<MessageRecord>  batchSelected = new HashSet<>();
   private @Nullable Recipients          conversationRecipients;
@@ -155,6 +156,7 @@ public class ConversationItem extends LinearLayout
     this.bodyBubble              =                      findViewById(R.id.body_bubble);
     this.mediaThumbnail          = (ThumbnailView)      findViewById(R.id.image_view);
     this.audioView               = (AudioView)          findViewById(R.id.audio_view);
+    this.readStatus              =                      findViewById(R.id.read_status);
     this.expirationTimer         = (ExpirationTimerView) findViewById(R.id.expiration_indicator);
 
     setOnClickListener(new ClickListener(null));
@@ -193,7 +195,7 @@ public class ConversationItem extends LinearLayout
     setInteractionState(messageRecord);
     setBodyText(messageRecord);
     setBubbleState(messageRecord, recipient);
-    setStatusIcons(messageRecord);
+    setStatusIcons(messageRecord, recipient);
     setContactPhoto(recipient);
     setGroupMessageStatus(messageRecord, recipient);
     setMinimumWidth();
@@ -323,7 +325,7 @@ public class ConversationItem extends LinearLayout
     }
   }
 
-  private void setStatusIcons(MessageRecord messageRecord) {
+  private void setStatusIcons(MessageRecord messageRecord, Recipient recipient) {
     mmsDownloadButton.setVisibility(View.GONE);
     mmsDownloadingLabel.setVisibility(View.GONE);
     indicatorText.setVisibility(View.GONE);
@@ -343,6 +345,16 @@ public class ConversationItem extends LinearLayout
       else if (messageRecord.isPending())   deliveryStatusIndicator.setPending();
       else if (messageRecord.isDelivered()) deliveryStatusIndicator.setDelivered();
       else                                  deliveryStatusIndicator.setSent();
+    }
+
+    if (readStatus != null) {
+      if (!messageRecord.isRead()) {
+        final int color = recipient.getColor().toConversationColor(context);
+        readStatus.getBackground().setColorFilter(color, PorterDuff.Mode.MULTIPLY);
+        readStatus.setVisibility(View.VISIBLE);
+      } else {
+        readStatus.setVisibility(View.INVISIBLE);
+      }
     }
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -23,7 +23,9 @@ import android.content.Intent;
 import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
+import android.graphics.drawable.ShapeDrawable;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
@@ -352,6 +354,13 @@ public class ConversationItem extends LinearLayout
         final int color = recipient.getColor().toConversationColor(context);
         readStatus.getBackground().setColorFilter(color, PorterDuff.Mode.MULTIPLY);
         readStatus.setVisibility(View.VISIBLE);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+          ShapeDrawable unread = new ShapeDrawable();
+          unread.getPaint().setColor(getResources().getColor(R.color.white));
+          unread.setColorFilter(color, PorterDuff.Mode.MULTIPLY);
+          readStatus.setBackgroundDrawable(unread);
+        }
       } else {
         readStatus.setVisibility(View.INVISIBLE);
       }

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -42,6 +42,7 @@ public class ConversationUpdateItem extends LinearLayout
   private ImageView     icon;
   private TextView      body;
   private TextView      date;
+  private View          readStatus;
   private Recipient     sender;
   private MessageRecord messageRecord;
   private Locale        locale;
@@ -58,9 +59,10 @@ public class ConversationUpdateItem extends LinearLayout
   public void onFinishInflate() {
     super.onFinishInflate();
 
-    this.icon = (ImageView)findViewById(R.id.conversation_update_icon);
-    this.body = (TextView)findViewById(R.id.conversation_update_body);
-    this.date = (TextView)findViewById(R.id.conversation_update_date);
+    this.icon       = (ImageView) findViewById(R.id.conversation_update_icon);
+    this.body       = (TextView)  findViewById(R.id.conversation_update_body);
+    this.date       = (TextView)  findViewById(R.id.conversation_update_date);
+    this.readStatus =             findViewById(R.id.read_status);
 
     this.setOnClickListener(new InternalClickListener(null));
   }
@@ -100,6 +102,14 @@ public class ConversationUpdateItem extends LinearLayout
 
     if (batchSelected.contains(messageRecord)) setSelected(true);
     else                                       setSelected(false);
+
+    if (!messageRecord.isRead()) {
+      final int color = sender.getColor().toConversationColor(getContext());
+      readStatus.getBackground().setColorFilter(color, PorterDuff.Mode.MULTIPLY);
+      readStatus.setVisibility(View.VISIBLE);
+    } else {
+      readStatus.setVisibility(View.INVISIBLE);
+    }
   }
 
   private void setCallRecord(MessageRecord messageRecord) {

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -5,6 +5,8 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.PorterDuff;
 import android.graphics.PorterDuffColorFilter;
+import android.graphics.drawable.ShapeDrawable;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
@@ -107,6 +109,13 @@ public class ConversationUpdateItem extends LinearLayout
       final int color = sender.getColor().toConversationColor(getContext());
       readStatus.getBackground().setColorFilter(color, PorterDuff.Mode.MULTIPLY);
       readStatus.setVisibility(View.VISIBLE);
+
+      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+        ShapeDrawable unread = new ShapeDrawable();
+        unread.getPaint().setColor(getResources().getColor(R.color.white));
+        unread.setColorFilter(color, PorterDuff.Mode.MULTIPLY);
+        readStatus.setBackgroundDrawable(unread);
+      }
     } else {
       readStatus.setVisibility(View.INVISIBLE);
     }

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -1143,6 +1143,7 @@ public class MmsDatabase extends MessagingDatabase {
       long messageSize           = cursor.getLong(cursor.getColumnIndexOrThrow(MmsDatabase.MESSAGE_SIZE));
       long expiry                = cursor.getLong(cursor.getColumnIndexOrThrow(MmsDatabase.EXPIRY));
       int status                 = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.STATUS));
+      int read                   = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.READ));
       int receiptCount           = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.RECEIPT_COUNT));
       int subscriptionId         = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.SUBSCRIPTION_ID));
 
@@ -1158,7 +1159,7 @@ public class MmsDatabase extends MessagingDatabase {
 
       return new NotificationMmsMessageRecord(context, id, recipients, recipients.getPrimaryRecipient(),
                                               addressDeviceId, dateSent, dateReceived, receiptCount, threadId,
-                                              contentLocationBytes, messageSize, expiry, status,
+                                              contentLocationBytes, messageSize, expiry, status, (read == 1),
                                               transactionIdBytes, mailbox, subscriptionId);
     }
 
@@ -1171,6 +1172,7 @@ public class MmsDatabase extends MessagingDatabase {
       String address          = cursor.getString(cursor.getColumnIndexOrThrow(MmsDatabase.ADDRESS));
       int addressDeviceId     = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.ADDRESS_DEVICE_ID));
       int receiptCount        = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.RECEIPT_COUNT));
+      int read                = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.READ));
       DisplayRecord.Body body = getBody(cursor);
       int partCount           = cursor.getInt(cursor.getColumnIndexOrThrow(MmsDatabase.PART_COUNT));
       String mismatchDocument = cursor.getString(cursor.getColumnIndexOrThrow(MmsDatabase.MISMATCHED_IDENTITIES));
@@ -1185,7 +1187,7 @@ public class MmsDatabase extends MessagingDatabase {
       SlideDeck                 slideDeck       = getSlideDeck(cursor);
 
       return new MediaMmsMessageRecord(context, id, recipients, recipients.getPrimaryRecipient(),
-                                       addressDeviceId, dateSent, dateReceived, receiptCount,
+                                       addressDeviceId, dateSent, dateReceived, receiptCount, (read == 1),
                                        threadId, body, slideDeck, partCount, box, mismatches,
                                        networkFailures, subscriptionId, expiresIn, expireStarted);
     }

--- a/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsSmsDatabase.java
@@ -47,6 +47,7 @@ public class MmsSmsDatabase extends Database {
                                               SmsDatabase.ADDRESS, SmsDatabase.ADDRESS_DEVICE_ID, SmsDatabase.SUBJECT,
                                               MmsSmsColumns.NORMALIZED_DATE_SENT,
                                               MmsSmsColumns.NORMALIZED_DATE_RECEIVED,
+                                              MmsSmsColumns.READ,
                                               MmsDatabase.MESSAGE_TYPE, MmsDatabase.MESSAGE_BOX,
                                               SmsDatabase.STATUS, MmsDatabase.PART_COUNT,
                                               MmsDatabase.CONTENT_LOCATION, MmsDatabase.TRANSACTION_ID,
@@ -265,7 +266,7 @@ public class MmsSmsDatabase extends Database {
     @SuppressWarnings("deprecation")
     String query      = outerQueryBuilder.buildQuery(projection, null, null, null, null, null, null);
 
-    Log.w("MmsSmsDatabase", "Executing query: " + query);
+    Log.w(TAG, "Executing query: " + query);
     SQLiteDatabase db = databaseHelper.getReadableDatabase();
     return db.rawQuery(query, null);
   }

--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -761,6 +761,7 @@ public class SmsDatabase extends MessagingDatabase {
       long dateSent           = cursor.getLong(cursor.getColumnIndexOrThrow(SmsDatabase.NORMALIZED_DATE_SENT));
       long threadId           = cursor.getLong(cursor.getColumnIndexOrThrow(SmsDatabase.THREAD_ID));
       int status              = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.STATUS));
+      int read                = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.READ));
       int receiptCount        = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.RECEIPT_COUNT));
       String mismatchDocument = cursor.getString(cursor.getColumnIndexOrThrow(SmsDatabase.MISMATCHED_IDENTITIES));
       int subscriptionId      = cursor.getInt(cursor.getColumnIndexOrThrow(SmsDatabase.SUBSCRIPTION_ID));
@@ -774,7 +775,7 @@ public class SmsDatabase extends MessagingDatabase {
       return new SmsMessageRecord(context, messageId, body, recipients,
                                   recipients.getPrimaryRecipient(),
                                   addressDeviceId,
-                                  dateSent, dateReceived, receiptCount, type,
+                                  dateSent, dateReceived, (read == 1), receiptCount, type,
                                   threadId, status, mismatches, subscriptionId,
                                   expiresIn, expireStarted);
     }

--- a/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/ThreadDatabase.java
@@ -272,6 +272,7 @@ public class ThreadDatabase extends Database {
     final List<MarkedMessageInfo> smsRecords = DatabaseFactory.getSmsDatabase(context).setMessagesRead(threadId);
     final List<MarkedMessageInfo> mmsRecords = DatabaseFactory.getMmsDatabase(context).setMessagesRead(threadId);
 
+    notifyConversationListeners(threadId);
     notifyConversationListListeners();
 
     return new LinkedList<MarkedMessageInfo>() {{

--- a/src/org/thoughtcrime/securesms/database/model/DisplayRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/DisplayRecord.java
@@ -43,9 +43,10 @@ public abstract class DisplayRecord {
   private final Body       body;
   private final int        deliveryStatus;
   private final int        receiptCount;
+  private final boolean    read;
 
   public DisplayRecord(Context context, Body body, Recipients recipients, long dateSent,
-                       long dateReceived, long threadId, int deliveryStatus, int receiptCount, long type)
+                       long dateReceived, long threadId, int deliveryStatus, int receiptCount, long type, boolean read)
   {
     this.context              = context.getApplicationContext();
     this.threadId             = threadId;
@@ -56,6 +57,7 @@ public abstract class DisplayRecord {
     this.body                 = body;
     this.receiptCount         = receiptCount;
     this.deliveryStatus       = deliveryStatus;
+    this.read                 = read;
   }
 
   public Body getBody() {
@@ -154,6 +156,10 @@ public abstract class DisplayRecord {
 
   public boolean isPendingInsecureSmsFallback() {
     return SmsDatabase.Types.isPendingInsecureSmsFallbackType(type);
+  }
+
+  public boolean isRead() {
+    return read;
   }
 
   public static class Body {

--- a/src/org/thoughtcrime/securesms/database/model/MediaMmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MediaMmsMessageRecord.java
@@ -50,7 +50,7 @@ public class MediaMmsMessageRecord extends MessageRecord {
   public MediaMmsMessageRecord(Context context, long id, Recipients recipients,
                                Recipient individualRecipient, int recipientDeviceId,
                                long dateSent, long dateReceived, int receiptCount,
-                               long threadId, Body body,
+                               boolean read, long threadId, Body body,
                                @NonNull SlideDeck slideDeck,
                                int partCount, long mailbox,
                                List<IdentityKeyMismatch> mismatches,
@@ -58,7 +58,7 @@ public class MediaMmsMessageRecord extends MessageRecord {
                                long expiresIn, long expireStarted)
   {
     super(context, id, body, recipients, individualRecipient, recipientDeviceId, dateSent,
-          dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox, mismatches, failures,
+          dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox, read, mismatches, failures,
           subscriptionId, expiresIn, expireStarted);
 
     this.context   = context.getApplicationContext();

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -25,8 +25,8 @@ import android.text.style.StyleSpan;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.MmsSmsColumns;
 import org.thoughtcrime.securesms.database.SmsDatabase;
-import org.thoughtcrime.securesms.database.documents.NetworkFailure;
 import org.thoughtcrime.securesms.database.documents.IdentityKeyMismatch;
+import org.thoughtcrime.securesms.database.documents.NetworkFailure;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.ExpirationUtil;
@@ -59,12 +59,12 @@ public abstract class MessageRecord extends DisplayRecord {
                 Recipient individualRecipient, int recipientDeviceId,
                 long dateSent, long dateReceived, long threadId,
                 int deliveryStatus, int receiptCount, long type,
-                List<IdentityKeyMismatch> mismatches,
+                boolean read, List<IdentityKeyMismatch> mismatches,
                 List<NetworkFailure> networkFailures,
                 int subscriptionId, long expiresIn, long expireStarted)
   {
     super(context, body, recipients, dateSent, dateReceived, threadId, deliveryStatus, receiptCount,
-          type);
+          type, read);
     this.id                  = id;
     this.individualRecipient = individualRecipient;
     this.recipientDeviceId   = recipientDeviceId;

--- a/src/org/thoughtcrime/securesms/database/model/NotificationMmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/NotificationMmsMessageRecord.java
@@ -20,10 +20,10 @@ import android.content.Context;
 import android.text.SpannableString;
 
 import org.thoughtcrime.securesms.R;
-import org.thoughtcrime.securesms.database.SmsDatabase.Status;
 import org.thoughtcrime.securesms.database.MmsDatabase;
-import org.thoughtcrime.securesms.database.documents.NetworkFailure;
+import org.thoughtcrime.securesms.database.SmsDatabase.Status;
 import org.thoughtcrime.securesms.database.documents.IdentityKeyMismatch;
+import org.thoughtcrime.securesms.database.documents.NetworkFailure;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 
@@ -49,11 +49,11 @@ public class NotificationMmsMessageRecord extends MessageRecord {
                                       Recipient individualRecipient, int recipientDeviceId,
                                       long dateSent, long dateReceived, int receiptCount,
                                       long threadId, byte[] contentLocation, long messageSize,
-                                      long expiry, int status, byte[] transactionId, long mailbox,
+                                      long expiry, int status, boolean read, byte[] transactionId, long mailbox,
                                       int subscriptionId)
   {
     super(context, id, new Body("", true), recipients, individualRecipient, recipientDeviceId,
-          dateSent, dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox,
+          dateSent, dateReceived, threadId, Status.STATUS_NONE, receiptCount, mailbox, read,
           new LinkedList<IdentityKeyMismatch>(), new LinkedList<NetworkFailure>(), subscriptionId,
           0, 0);
 

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -45,13 +45,13 @@ public class SmsMessageRecord extends MessageRecord {
                           Recipient individualRecipient,
                           int recipientDeviceId,
                           long dateSent, long dateReceived,
-                          int receiptCount,
+                          boolean read, int receiptCount,
                           long type, long threadId,
                           int status, List<IdentityKeyMismatch> mismatches,
                           int subscriptionId, long expiresIn, long expireStarted)
   {
     super(context, id, body, recipients, individualRecipient, recipientDeviceId,
-          dateSent, dateReceived, threadId, status, receiptCount, type,
+          dateSent, dateReceived, threadId, status, receiptCount, type, read,
           mismatches, new LinkedList<NetworkFailure>(), subscriptionId,
           expiresIn, expireStarted);
   }

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -28,7 +28,6 @@ import android.text.style.StyleSpan;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.MmsSmsColumns;
 import org.thoughtcrime.securesms.database.SmsDatabase;
-import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.ExpirationUtil;
 import org.thoughtcrime.securesms.util.GroupUtil;
@@ -44,7 +43,6 @@ public class ThreadRecord extends DisplayRecord {
   private @NonNull  final Context context;
   private @Nullable final Uri     snippetUri;
   private           final long    count;
-  private           final boolean read;
   private           final int     distributionType;
   private           final boolean archived;
   private           final long    expiresIn;
@@ -54,11 +52,10 @@ public class ThreadRecord extends DisplayRecord {
                       long threadId, int receiptCount, int status, long snippetType,
                       int distributionType, boolean archived, long expiresIn)
   {
-    super(context, body, recipients, date, date, threadId, status, receiptCount, snippetType);
+    super(context, body, recipients, date, date, threadId, status, receiptCount, snippetType, read);
     this.context          = context.getApplicationContext();
     this.snippetUri       = snippetUri;
     this.count            = count;
-    this.read             = read;
     this.distributionType = distributionType;
     this.archived         = archived;
     this.expiresIn        = expiresIn;
@@ -126,10 +123,6 @@ public class ThreadRecord extends DisplayRecord {
 
   public long getCount() {
     return count;
-  }
-
-  public boolean isRead() {
-    return read;
   }
 
   public long getDate() {

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -38,21 +38,15 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.Log;
 
-import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.database.MessagingDatabase;
-import org.thoughtcrime.securesms.database.MessagingDatabase.MarkedMessageInfo;
-import org.thoughtcrime.securesms.database.MessagingDatabase.SyncMessageId;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;
 import org.thoughtcrime.securesms.database.SmsDatabase;
-import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
-import org.thoughtcrime.securesms.jobs.MultiDeviceReadUpdateJob;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
@@ -137,14 +131,8 @@ public class MessageNotifier {
   {
     boolean    isVisible  = visibleThread == threadId;
 
-    ThreadDatabase threads    = DatabaseFactory.getThreadDatabase(context);
     Recipients     recipients = DatabaseFactory.getThreadDatabase(context)
                                                .getRecipientsForThreadId(threadId);
-
-    if (isVisible) {
-      List<MarkedMessageInfo> messageIds = threads.setRead(threadId);
-      MarkReadReceiver.process(context, messageIds);
-    }
 
     if (!TextSecurePreferences.isNotificationsEnabled(context) ||
         (recipients != null && recipients.isMuted()))
@@ -153,10 +141,10 @@ public class MessageNotifier {
     }
 
     if (isVisible) {
-      sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
-    } else {
-      updateNotification(context, masterSecret, signal, includePushDatabase, 0);
+      sendInThreadNotification(context, recipients);
     }
+
+    updateNotification(context, masterSecret, signal && !isVisible, includePushDatabase, 0);
   }
 
   private static void updateNotification(@NonNull  Context context,


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

Indicator for unread messages, see #965.

A bar on the right side of the conversation indicates unread messages. The bar covers the full  message height and uses the senders color.

Messages are marked as read when the conversation is left, a message is sent by the user, or when the conversation is scrolled to the bottom.

**Screenshot:**
![unread_new](https://cloud.githubusercontent.com/assets/3845150/15991430/9912f2dc-30b2-11e6-9703-14ef6ec9c6ca.png)
