### PR TITLE
Color passphrase prompt text field blue

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -42,11 +42,13 @@
         <!--<item name="colorPrimary">@android:color/transparent</item>-->
         <item name="actionBarStyle">@style/TextSecure.IntroActionBar</item>
         <item name="android:windowContentOverlay">@null</item>
+        <item name="colorAccent">@color/signal_primary</item>
 
         <item name="android:textColorHint">#cc000000</item>
         <item name="centered_app_title_color">#55000000</item>
         <item name="ic_arrow_forward">@drawable/ic_arrow_forward_light</item>
         <item name="lockscreen_watermark">@drawable/lockscreen_watermark_light</item>
+        <item name="android:windowBackground">@color/gray5</item>
         <item name="ic_visibility">@drawable/ic_visibility_grey600_24dp</item>
         <item name="ic_visibility_off">@drawable/ic_visibility_off_grey600_24dp</item>
     </style>
@@ -54,6 +56,7 @@
     <style name="TextSecure.DarkIntroTheme" parent="@style/Theme.AppCompat">
         <item name="actionBarStyle">@style/TextSecure.IntroActionBar</item>
         <item name="android:windowContentOverlay">@null</item>
+        <item name="colorAccent">@color/signal_primary_dark</item>
 
         <item name="android:textColorHint">@color/white</item>
         <item name="centered_app_title_color">@color/gray27</item>


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Sony Xperia U, Android 4.4.4
  - AVD: Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

Colors the bar below and the cursor in the text field of the passphrase prompt blue.

// FREEBIE
