### PR TITLE
Prevent contact number NPE

### DIFF
--- a/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
+++ b/src/org/thoughtcrime/securesms/recipients/RecipientProvider.java
@@ -138,13 +138,18 @@ public class RecipientProvider {
 
     try {
       if (cursor != null && cursor.moveToFirst()) {
-        Uri          contactUri   = Contacts.getLookupUri(cursor.getLong(2), cursor.getString(1));
-        String       name         = cursor.getString(3).equals(cursor.getString(0)) ? null : cursor.getString(0);
-        ContactPhoto contactPhoto = ContactPhotoFactory.getContactPhoto(context,
-                                                                        Uri.withAppendedPath(Contacts.CONTENT_URI, cursor.getLong(2) + ""),
-                                                                        name);
+        final String resultNumber = cursor.getString(3);
+        if (resultNumber != null) {
+          Uri          contactUri   = Contacts.getLookupUri(cursor.getLong(2), cursor.getString(1));
+          String       name         = resultNumber.equals(cursor.getString(0)) ? null : cursor.getString(0);
+          ContactPhoto contactPhoto = ContactPhotoFactory.getContactPhoto(context,
+                                                                          Uri.withAppendedPath(Contacts.CONTENT_URI, cursor.getLong(2) + ""),
+                                                                          name);
 
-        return new RecipientDetails(cursor.getString(0), cursor.getString(3), contactUri, contactPhoto, color);
+          return new RecipientDetails(cursor.getString(0), resultNumber, contactUri, contactPhoto, color);
+        } else {
+          Log.w(TAG, "resultNumber is null");
+        }
       }
     } finally {
       if (cursor != null)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
I can't reproduce the crash in #5454, but this should fix it: if the returned contact phone number is `null`, fall through to return default `RecipientDetails`.
It's still not clear to me which result is actually returned.
I have some "numberless" SMS in my stock messaging app, and there I can't even add the sender to my contacts.

//FREEBIE