### PR TITLE
Always enable LED notification

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -40,10 +40,6 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
   public void setAlarms(@Nullable Uri ringtone, RecipientPreferenceDatabase.VibrateState vibrate) {
     String defaultRingtoneName   = TextSecurePreferences.getNotificationRingtone(context);
     boolean defaultVibrate       = TextSecurePreferences.isNotificationVibrateEnabled(context);
-    String ledColor              = TextSecurePreferences.getNotificationLedColor(context);
-    String ledBlinkPattern       = TextSecurePreferences.getNotificationLedPattern(context);
-    String ledBlinkPatternCustom = TextSecurePreferences.getNotificationLedPatternCustom(context);
-    String[] blinkPatternArray   = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
 
     if      (ringtone != null)                        setSound(ringtone);
     else if (!TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
@@ -53,17 +49,25 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     {
       setDefaults(Notification.DEFAULT_VIBRATE);
     }
+  }
+
+  public void setLed() {
+    String ledColor = TextSecurePreferences.getNotificationLedColor(context);
 
     if (!ledColor.equals("none")) {
+      String[] blinkPatternArray = getBlinkPattern();
+
       setLights(Color.parseColor(ledColor),
                 Integer.parseInt(blinkPatternArray[0]),
                 Integer.parseInt(blinkPatternArray[1]));
     }
   }
 
-  private String[] parseBlinkPattern(String blinkPattern, String blinkPatternCustom) {
+  private String[] getBlinkPattern() {
+    String blinkPattern = TextSecurePreferences.getNotificationLedPattern(context);
+
     if (blinkPattern.equals("custom"))
-      blinkPattern = blinkPatternCustom;
+      blinkPattern = TextSecurePreferences.getNotificationLedPatternCustom(context);
 
     return blinkPattern.split(",");
   }

--- a/src/org/thoughtcrime/securesms/notifications/FailedNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/FailedNotificationBuilder.java
@@ -23,6 +23,7 @@ public class FailedNotificationBuilder extends AbstractNotificationBuilder {
     setContentIntent(PendingIntent.getActivity(context, 0, intent, 0));
     setAutoCancel(true);
     setAlarms(null, RecipientPreferenceDatabase.VibrateState.DEFAULT);
+    setLed();
   }
 
 

--- a/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/MarkReadReceiver.java
@@ -1,6 +1,5 @@
 package org.thoughtcrime.securesms.notifications;
 
-import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
 import android.os.AsyncTask;
@@ -34,8 +33,7 @@ public class MarkReadReceiver extends MasterSecretBroadcastReceiver {
     if (threadIds != null) {
       Log.w("TAG", "threadIds length: " + threadIds.length);
 
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-                                   .cancel(MessageNotifier.NOTIFICATION_ID);
+      MessageNotifier.cancelNotification(context);
 
       new AsyncTask<Void, Void, Void>() {
         @Override

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -43,7 +43,6 @@ import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.database.MessagingDatabase;
 import org.thoughtcrime.securesms.database.MessagingDatabase.SyncMessageId;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;
@@ -79,7 +78,7 @@ public class MessageNotifier {
 
   private static final String TAG = MessageNotifier.class.getSimpleName();
 
-  public static final int NOTIFICATION_ID = 1338;
+  private static final int NOTIFICATION_ID = 1338;
 
   private volatile static long visibleThread = -1;
 
@@ -136,8 +135,7 @@ public class MessageNotifier {
     boolean    isVisible  = visibleThread == threadId;
 
     ThreadDatabase threads    = DatabaseFactory.getThreadDatabase(context);
-    Recipients     recipients = DatabaseFactory.getThreadDatabase(context)
-                                               .getRecipientsForThreadId(threadId);
+    Recipients     recipients = threads.getRecipientsForThreadId(threadId);
 
     if (isVisible) {
       List<SyncMessageId> messageIds = threads.setRead(threadId);
@@ -156,7 +154,7 @@ public class MessageNotifier {
     }
 
     if (isVisible) {
-      sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
+      sendInThreadNotification(context, recipients);
     } else {
       updateNotification(context, masterSecret, signal, includePushDatabase, 0);
     }
@@ -178,8 +176,7 @@ public class MessageNotifier {
       if ((telcoCursor == null || telcoCursor.isAfterLast()) &&
           (pushCursor == null || pushCursor.isAfterLast()))
       {
-        ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+        cancelNotification(context);
         updateBadge(context, 0);
         clearReminder(context);
         return;
@@ -214,28 +211,28 @@ public class MessageNotifier {
                                                    boolean signal)
   {
     if (notificationState.getNotifications().isEmpty()) {
-      ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
-          .cancel(NOTIFICATION_ID);
+      cancelNotification(context);
       return;
     }
 
     SingleRecipientNotificationBuilder builder       = new SingleRecipientNotificationBuilder(context, masterSecret, TextSecurePreferences.getNotificationPrivacy(context));
     List<NotificationItem>             notifications = notificationState.getNotifications();
-    Recipients                         recipients    = notifications.get(0).getRecipients();
+    NotificationItem                   notification  = notifications.get(0);
+    Recipients                         recipients    = notification.getRecipients();
 
-    builder.setThread(notifications.get(0).getRecipients());
+    builder.setThread(recipients);
     builder.setMessageCount(notificationState.getMessageCount());
-    builder.setPrimaryMessageBody(recipients, notifications.get(0).getIndividualRecipient(),
-                                  notifications.get(0).getText(), notifications.get(0).getSlideDeck());
-    builder.setContentIntent(notifications.get(0).getPendingIntent(context));
+    builder.setPrimaryMessageBody(recipients, notification.getIndividualRecipient(),
+                                  notification.getText(), notification.getSlideDeck());
+    builder.setContentIntent(notification.getPendingIntent(context));
 
-    long timestamp = notifications.get(0).getTimestamp();
+    long timestamp = notification.getTimestamp();
     if (timestamp != 0) builder.setWhen(timestamp);
 
     builder.addActions(masterSecret,
                        notificationState.getMarkAsReadIntent(context),
-                       notificationState.getQuickReplyIntent(context, notifications.get(0).getRecipients()),
-                       notificationState.getWearableReplyIntent(context, notifications.get(0).getRecipients()));
+                       notificationState.getQuickReplyIntent(context, recipients),
+                       notificationState.getWearableReplyIntent(context, recipients));
 
     ListIterator<NotificationItem> iterator = notifications.listIterator(notifications.size());
 
@@ -246,8 +243,8 @@ public class MessageNotifier {
 
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
-      builder.setTicker(notifications.get(0).getIndividualRecipient(),
-                        notifications.get(0).getText());
+      builder.setTicker(notification.getIndividualRecipient(),
+                        notification.getText());
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
@@ -434,6 +431,10 @@ public class MessageNotifier {
     PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, alarmIntent, PendingIntent.FLAG_CANCEL_CURRENT);
     AlarmManager  alarmManager  = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
     alarmManager.cancel(pendingIntent);
+  }
+
+  public static void cancelNotification(Context context) {
+    ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE)).cancel(NOTIFICATION_ID);
   }
 
   public static class ReminderReceiver extends BroadcastReceiver {

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -246,6 +246,7 @@ public class MessageNotifier {
       builder.setTicker(notification.getIndividualRecipient(),
                         notification.getText());
     }
+    builder.setLed();
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
       .notify(NOTIFICATION_ID, builder.build());
@@ -277,6 +278,7 @@ public class MessageNotifier {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
       builder.setTicker(notifications.get(0).getText());
     }
+    builder.setLed();
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))
       .notify(NOTIFICATION_ID, builder.build());


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Fixes that missed call notifications do not enable LED. Might also help with #1036.
Without this, every silent notification update (`!signal` / `updateNotification(context, masterSecret)`) will turn off the LED.

// FREEBIE