### PR TITLE
Updating invite links now that Bitly supports HTTPS - Yay!

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -518,8 +518,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void handleInviteLink() {
     try {
       boolean a = SecureRandom.getInstance("SHA1PRNG").nextBoolean();
-      if (a) composeText.appendInvite(getString(R.string.ConversationActivity_lets_switch_to_signal, "http://sgnl.link/1LoIMUl"));
-      else   composeText.appendInvite(getString(R.string.ConversationActivity_lets_use_this_to_chat, "http://sgnl.link/1MF56H1"));
+      if (a) composeText.appendInvite(getString(R.string.ConversationActivity_lets_switch_to_signal, "https://sgnl.link/1LoIMUl"));
+      else   composeText.appendInvite(getString(R.string.ConversationActivity_lets_use_this_to_chat, "https://sgnl.link/1MF56H1"));
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
     }


### PR DESCRIPTION
- [x]  I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Chrome 49.0.2623.105 Android
 * Orfox Android (Redirect works to whispersystems.org, but no further because redirects blocked)
 * Chrome 50.x Mac
 * Tor Browser 5.5.4 (based on Mozilla Firefox 38.7.1)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the BitHub reward or not by omitting or adding the word FREEBIE in my commit message

// FREEBIE

----------

Invite links now work over `https` -- yes I tested  :-)

fixes #4060

* https://sgnl.link/1LoIMUl
* https://sgnl.link/1MF56H1
* And even: https://sgnl.link/1IvurmD

More info: https://github.com/EFForg/https-everywhere/pull/4505 and on [stackexchange](http://webmasters.stackexchange.com/questions/87163/do-bitly-branded-short-domains-support-https/92407#92407).