### PR TITLE
Simplify updateNotification variants

### DIFF
--- a/src/org/thoughtcrime/redphone/RedPhoneService.java
+++ b/src/org/thoughtcrime/redphone/RedPhoneService.java
@@ -247,7 +247,7 @@ public class RedPhoneService extends Service implements CallStateListener, CallS
   private void handleMissedCall(String remoteNumber, boolean signal) {
     Pair<Long, Long> messageAndThreadId = DatabaseFactory.getSmsDatabase(this).insertMissedCall(remoteNumber);
     MessageNotifier.updateNotification(this, KeyCachingService.getMasterSecret(this),
-                                       false, messageAndThreadId.second, signal);
+                                       messageAndThreadId.second, signal);
   }
 
   private void handleAnswerCall(Intent intent) {

--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -49,8 +49,8 @@ import org.whispersystems.libsignal.LegacyMessageException;
 import org.whispersystems.libsignal.NoSessionException;
 import org.whispersystems.libsignal.UntrustedIdentityException;
 import org.whispersystems.libsignal.protocol.PreKeySignalMessage;
-import org.whispersystems.libsignal.state.SignalProtocolStore;
 import org.whispersystems.libsignal.state.SessionStore;
+import org.whispersystems.libsignal.state.SignalProtocolStore;
 import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.crypto.SignalServiceCipher;
 import org.whispersystems.signalservice.api.messages.SignalServiceContent;
@@ -99,7 +99,7 @@ public class PushDecryptJob extends ContextJob {
 
     if (!IdentityKeyUtil.hasIdentityKey(context)) {
       Log.w(TAG, "Skipping job, waiting for migration...");
-      MessageNotifier.updateNotification(context, null, true, -2);
+      MessageNotifier.updatePushNotification(context);
       return;
     }
 

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -43,7 +43,6 @@ import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.database.MessagingDatabase;
 import org.thoughtcrime.securesms.database.MessagingDatabase.SyncMessageId;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;
@@ -112,24 +111,23 @@ public class MessageNotifier {
     updateNotification(context, masterSecret, false, false, 0);
   }
 
-  public static void updateNotification(@NonNull  Context context,
-                                        @Nullable MasterSecret masterSecret,
-                                        long threadId)
-  {
-    updateNotification(context, masterSecret, false, threadId);
+  public static void updatePushNotification(@NonNull  Context context) {
+    if (!TextSecurePreferences.isNotificationsEnabled(context)) {
+      return;
+    }
+
+    updateNotification(context, null, true, true, 0);
   }
 
   public static void updateNotification(@NonNull  Context context,
                                         @Nullable MasterSecret masterSecret,
-                                        boolean   includePushDatabase,
                                         long      threadId)
   {
-    updateNotification(context, masterSecret, includePushDatabase, threadId, true);
+    updateNotification(context, masterSecret, threadId, true);
   }
 
   public static void updateNotification(@NonNull  Context context,
                                         @Nullable MasterSecret masterSecret,
-                                        boolean   includePushDatabase,
                                         long      threadId,
                                         boolean   signal)
   {
@@ -158,7 +156,7 @@ public class MessageNotifier {
     if (isVisible) {
       sendInThreadNotification(context, threads.getRecipientsForThreadId(threadId));
     } else {
-      updateNotification(context, masterSecret, signal, includePushDatabase, 0);
+      updateNotification(context, masterSecret, signal, false, 0);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -221,11 +221,7 @@ public class DirectoryHelper {
         Pair<Long, Long>      smsAndThreadId = DatabaseFactory.getSmsDatabase(context).insertMessageInbox(message);
 
         int hour = Calendar.getInstance().get(Calendar.HOUR_OF_DAY);
-        if (hour >= 9 && hour < 23) {
-          MessageNotifier.updateNotification(context, masterSecret, false, smsAndThreadId.second, true);
-        } else {
-          MessageNotifier.updateNotification(context, masterSecret, false, smsAndThreadId.second, false);
-        }
+        MessageNotifier.updateNotification(context, masterSecret, smsAndThreadId.second, (hour >= 9 && hour < 23));
       }
     }
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Simplify the `updateNotification` variants. There is only one very special caller with `includePushDatabase = true`, so that case can be moved to a dedicated method.

It is in `PushDecryptJob`:
* `masterSecret = null`
* `includePushDatabase = true`
* `threadId = -2`, is not a valid thread
* by default `signal = true`

As a result, there are now "only" three variants of `updateNotification(...)` instead of four.

// FREEBIE