### PR TITLE
Make it easier to recognize group conversations

### DIFF
--- a/src/org/thoughtcrime/securesms/components/FromTextView.java
+++ b/src/org/thoughtcrime/securesms/components/FromTextView.java
@@ -3,13 +3,11 @@ package org.thoughtcrime.securesms.components;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.Typeface;
-import android.graphics.drawable.Drawable;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.AttributeSet;
-import android.util.Log;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.components.emoji.EmojiTextView;
@@ -69,9 +67,10 @@ public class FromTextView extends EmojiTextView {
 
     setText(builder);
 
-    if      (recipients.isBlocked()) setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_block_grey600_18dp, 0, 0, 0);
-    else if (recipients.isMuted())   setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_volume_off_grey600_18dp, 0, 0, 0);
-    else                             setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
+    if      (recipients.isBlocked())        setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_block_grey600_18dp, 0, 0, 0);
+    else if (recipients.isMuted())          setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_volume_off_grey600_18dp, 0, 0, 0);
+    else if (recipients.isGroupRecipient()) setCompoundDrawablesWithIntrinsicBounds(R.drawable.ic_group_grey600_24dp, 0, 0, 0);
+    else                                    setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
   }
 
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Sometimes it feels like it should be easier to find a group conversation (I can't always remember the group name). So here is an idea that came to my mind.

**Screenshot:**
![highlight_groups](https://cloud.githubusercontent.com/assets/3845150/15453231/3b03d026-200e-11e6-8af3-306876a52715.png)
