### PR TITLE
Resize fast scroller when keyboard is shown

### DIFF
--- a/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
+++ b/src/org/thoughtcrime/securesms/components/RecyclerViewFastScroller.java
@@ -74,6 +74,7 @@ public class RecyclerViewFastScroller extends LinearLayout {
     super(context, attrs);
     setOrientation(HORIZONTAL);
     setClipChildren(false);
+    setScrollContainer(true);
     inflate(context, R.layout.recycler_view_fast_scroller, this);
     bubble = ViewUtil.findById(this, R.id.fastscroller_bubble);
     handle = ViewUtil.findById(this, R.id.fastscroller_handle);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Make Android recognize `RecyclerViewFastScroller` as scrollable content, so that it does not hide list items behind the keyboard. Fixes #5487, cc @christophvarga

// FREEBIE