### PR TITLE
Workaround to add tsdevice:/? string when QR codes won't work

### DIFF
--- a/res/layout/device_add_fragment.xml
+++ b/res/layout/device_add_fragment.xml
@@ -20,6 +20,7 @@
 
         <org.thoughtcrime.securesms.components.ShapeScrim
             android:layout_weight="1"
+            android:id="@+id/camera_frame"
             android:layout_width="match_parent"
             android:layout_height="match_parent"/>
 
@@ -39,14 +40,35 @@
                        android:layout_height="wrap_content"
                        android:tint="@color/gray27"
                        android:transitionName="devices"
-                       android:layout_marginBottom="16dp"/>
+                       android:layout_marginBottom="3dp"/>
 
             <TextView android:text="@string/device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
                       android:textColor="?android:textColorSecondary"/>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center"
+                android:weightSum="1">
 
+                <EditText
+                    android:layout_width="0dp"
+                    android:layout_weight="1"
+                    android:layout_height="wrap_content"
+                    android:singleLine="true"
+                    android:hint="@string/device_link_fragment__enter_qr"
+                    android:id="@+id/qr_code_edit_text"/>
+
+                <Button
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/device_link_fragment__enter_button"
+                    android:id="@+id/qr_code_text_button"/>
+
+            </LinearLayout>
         </LinearLayout>
     </LinearLayout>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -703,6 +703,8 @@
 
     <!-- device_add_fragment -->
     <string name="device_add_fragment__scan_the_qr_code_displayed_on_the_device_to_link">Scan the QR code displayed on the device to link</string>
+    <string name="device_link_fragment__enter_qr">Not working? Enter QR text...</string>
+    <string name="device_link_fragment__enter_button">Done</string>
 
     <!-- device_link_fragment -->
     <string name="device_link_fragment__link_device">Link device</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines) (To the best of my knowledge :grimacing:)
- [x] I have tested my contribution on these devices:
 * LG Nexus 5, Android 4.4.4
 * Samsung Galaxy S3, Replicant/Android 4.2.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

So I don't know if this is mergeable for UX/philosophical reasons so Moxie you'll have to make that call, but I thought since I had already written the code as a jank hack just to get Signal-Desktop to pair with my personal device, I thought I would offer it as a potential solution to #4637. 

This commit adds an EditText and Button that will allow a user to manually type the QR code text (`tsdevice:/?blahblahblah`) into the EditText and then submit the device that way. The UX for this may not be optimal, and I ended up using an `setOnFocusChangeListener` on the EditText because it makes it a nightmare to type because the soft keyboard and screen takes too much space while you're trying to type if you don't hide the camera preview.

I have tested this on two devices with two separate phone numbers and it allowed me to pair signal-desktop to the device both times. Here is a screenshot:

![screen](https://cloud.githubusercontent.com/assets/4326714/16172492/becb6518-3558-11e6-92ef-9df44325b623.png)

Thanks!
