### PR TITLE
Added Timestamp to PlainTextBackup

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -9,10 +9,13 @@ import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class PlaintextBackupExporter {
 
-  private static final String FILENAME = "SignalPlaintextBackup.xml";
+  private static final String TIMESTAMP = new SimpleDateFormat("yyyyMMddhhmmss").format(new Date(System.currentTimeMillis()));
+  private static final String FILENAME = "SignalPlaintextBackup_" + TIMESTAMP + ".xml";
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 4 with Android 5.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Like requested in #5364 this patch adds a timestamp to the backup.
The file will be named like SignalPlainTextBackup_20160620201010.xml.
So yyyyMMddhhmmss as format.
To test it is just necessary to do a simple PlainTextBackup.