### PR TITLE
Added Timestamp to PlainTextBackup

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -9,10 +9,13 @@ import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class PlaintextBackupExporter {
 
-  private static final String FILENAME = "SignalPlaintextBackup.xml";
+  private static final String TIMESTAMP = new SimpleDateFormat("yyyyMMddHHmmss").format(new Date(System.currentTimeMillis()));
+  private static final String FILENAME = "SignalPlaintextBackup_" + TIMESTAMP + ".xml";
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -16,6 +16,9 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
+import java.io.FilenameFilter;
+import java.util.Arrays;
+import java.util.Collections;
 
 
 public class PlaintextBackupImporter {
@@ -35,13 +38,39 @@ public class PlaintextBackupImporter {
 
   private static File getPlaintextExportFile() {
     File backup    = PlaintextBackupExporter.getPlaintextExportFile();
-    File oldBackup = new File(Environment.getExternalStorageDirectory(), "TextSecurePlaintextBackup.xml");
+    FilenameFilter backupFilesFilter = new FilenameFilter() {
+        public boolean accept(File file, String name) {
+            if (name.startsWith("SignalPlaintextBackup_")) {
+                return true;
+            } else {
+                return false; } }
+    };
+
+    File dir = Environment.getExternalStorageDirectory();
+    File[] allBackupFiles;
+    if( dir.exists() ) {
+        allBackupFiles = dir.listFiles(backupFilesFilter);
+        Arrays.sort(allBackupFiles, Collections.reverseOrder());
+    }
+    else 
+        allBackupFiles = new File[0];
+
+    File oldBackup;
+    if(allBackupFiles.length > 0)
+        oldBackup = allBackupFiles[0];
+    else
+    {
+        oldBackup = new File(Environment.getExternalStorageDirectory(), "SignalPlaintextBackup.xml");
+        if(!oldBackup.exists())
+            oldBackup = new File(Environment.getExternalStorageDirectory(), "TextSecurePlaintextBackup.xml");
+    }
+        
 
     if (!backup.exists() && oldBackup.exists()) {
       return oldBackup;
     }
     return backup;
-  }
+}
 
   private static void importPlaintext(Context context, MasterSecret masterSecret)
       throws IOException


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Nexus 4 (Android 5.1.1)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Like requested in #5364 this patch adds a timestamp to the backup.
The file will be named like SignalPlainTextBackup_20160620201010.xml.
So yyyyMMddHHmmss as format.
To test it is just necessary to do a simple PlainTextBackup.

The import was adjusted too.
It behaves like this:
- take backup-filename stored in environment
- if not, search dynamically for the latest timestamp (based on filename) and use that backup
- if not, search for the old filenmae SignalPlainTextBackup.xml (for backwards compatibility)