### PR TITLE
respond to generic panic trigger Intent by locking

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -497,5 +497,13 @@
         </intent-filter>
     </receiver>
 
+    <receiver
+        android:name=".service.PanicResponderListener"
+        android:exported="true">
+        <intent-filter>
+            <action android:name="info.guardianproject.panic.action.TRIGGER" />
+        </intent-filter>
+    </receiver>
+
 </application>
 </manifest>

--- a/src/org/thoughtcrime/securesms/service/PanicResponderListener.java
+++ b/src/org/thoughtcrime/securesms/service/PanicResponderListener.java
@@ -1,0 +1,28 @@
+package org.thoughtcrime.securesms.service;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+/**
+ * Respond to a PanicKit trigger Intent by locking the app.  PanicKit provides a
+ * common framework for creating "panic button" apps that can trigger actions
+ * in "panic responder" apps.  In this case, the response is to lock the app,
+ * if it has been configured to do so via the Signal lock preference. If the
+ * user has not set a passphrase, then the panic trigger intent does nothing.
+ */
+public class PanicResponderListener extends BroadcastReceiver {
+
+  @Override
+  public void onReceive(Context context, Intent intent) {
+    if (intent != null
+        && !TextSecurePreferences.isPasswordDisabled(context)
+        && "info.guardianproject.panic.action.TRIGGER".equals(intent.getAction())) {
+      Intent lockIntent = new Intent(context, KeyCachingService.class);
+      lockIntent.setAction(KeyCachingService.CLEAR_KEY_ACTION);
+      context.startService(lockIntent);
+    }
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy Note 2, Android 4.4.4
 * Asus ZenFone2, Android 4.4.2 (x86)
 * its [included in SMSSecure](https://github.com/SMSSecure/SMSSecure/pulls?q=is%3Apr+is%3Aclosed+author%3Aeighthave) official releases, so its been tested on a bunch of devices there
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the Bithub reward or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

As discussed back in October face to face with @moxie0 and @mcginty, here is the "panic button" support.  Since Signal already includes a "lock" feature, it is a natural panic responder app.  This is a follow-up to the discussion in #5341.  The Intents are now received in a simple `BroadcastReceiver`.
