### PR TITLE
Allow sending SMS/MMS on expired builds

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/MmsSendJob.java
@@ -229,4 +229,8 @@ public class MmsSendJob extends SendJob {
       MessageNotifier.notifyMessageDeliveryFailed(context, recipients, threadId);
     }
   }
+
+  protected boolean isSignalMessage() {
+    return false;
+  }
 }

--- a/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushSendJob.java
@@ -93,4 +93,8 @@ public abstract class PushSendJob extends SendJob {
       MessageNotifier.notifyMessageDeliveryFailed(context, recipients, threadId);
     }
   }
+
+  protected boolean isSignalMessage() {
+    return true;
+  }
 }

--- a/src/org/thoughtcrime/securesms/jobs/SendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SendJob.java
@@ -34,7 +34,7 @@ public abstract class SendJob extends MasterSecretJob {
 
   @Override
   public final void onRun(MasterSecret masterSecret) throws Exception {
-    if (Util.getDaysTillBuildExpiry() <= 0) {
+    if (Util.getDaysTillBuildExpiry() <= 0 && isSignalMessage()) {
       throw new TextSecureExpiredException(String.format("TextSecure expired (build %d, now %d)",
                                                          BuildConfig.BUILD_TIMESTAMP,
                                                          System.currentTimeMillis()));
@@ -42,6 +42,8 @@ public abstract class SendJob extends MasterSecretJob {
 
     onSend(masterSecret);
   }
+
+  protected abstract boolean isSignalMessage();
 
   protected abstract void onSend(MasterSecret masterSecret) throws Exception;
 

--- a/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/SmsSendJob.java
@@ -204,5 +204,7 @@ public class SmsSendJob extends SendJob {
     return builder.create();
   }
 
-
+  protected boolean isSignalMessage() {
+    return false;
+  }
 }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung Galaxy S5, Android 6.0.1 (CyanogenMod 13)
 * AVD Nexus 5X (x86_64)
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

There is no reason to block sending SMS/MMS messages on expired builds, since they are already completely unsecured and don't utilize the Signal protocol.

Related to #5493

// FREEBIE