### PR TITLE
Fix group update message notifications, mark as unread

### DIFF
--- a/src/org/thoughtcrime/securesms/database/SmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/SmsDatabase.java
@@ -490,7 +490,7 @@ public class SmsDatabase extends MessagingDatabase {
     }
 
     boolean    unread     = org.thoughtcrime.securesms.util.Util.isDefaultSmsProvider(context) ||
-                            message.isSecureMessage() || message.isPreKeyBundle();
+                            message.isSecureMessage() || message.isGroup() || message.isPreKeyBundle();
 
     long       threadId;
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Users are not notified when someone creates or updates a group. That is because group messages are usually not saved as unread. It only works if you set Signal as your default SMS app, or on Android versions before Kitkat where you can't set it as default app.

cc @2-4601 

// FREEBIE