### PR TITLE
Enable hiding the recipients number on the actionbar in conversations

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -962,6 +962,8 @@
     <string name="preferences__lock_signal_and_message_notifications_with_a_passphrase">Lock Signal and message notifications with a passphrase</string>
     <string name="preferences__screen_security">Screen security</string>
     <string name="preferences__disable_screen_security_to_allow_screen_shots">Block screenshots in the recents list and inside the app</string>
+    <string name="preferences__hide_number_on_actionbar">Hide number on ActionBar</string>
+    <string name="preferences__hide_the_recipients_number_on_the_actionbar">Hide the recipient\'s number on the actionbar in a conversation</string>
     <string name="preferences__auto_lock_signal_after_a_specified_time_interval_of_inactivity">Auto-lock Signal after a specified time interval of inactivity</string>
     <string name="preferences__inactivity_timeout_passphrase">Inactivity timeout passphrase</string>
     <string name="preferences__inactivity_timeout_interval">Inactivity timeout interval</string>

--- a/res/xml/preferences_app_protection.xml
+++ b/res/xml/preferences_app_protection.xml
@@ -28,6 +28,13 @@
                         android:title="@string/preferences__screen_security"
                         android:summary="@string/preferences__disable_screen_security_to_allow_screen_shots" />
 
+    <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                        android:defaultValue="false"
+                        android:key="pref_hide_number"
+                        android:title="@string/preferences__hide_number_on_actionbar"
+                        android:summary="@string/preferences__hide_the_recipients_number_on_the_actionbar" />
+
+
     <Preference android:key="preference_category_blocked"
                 android:title="@string/preferences_app_protection__blocked_contacts" />
 </PreferenceScreen>

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
 public class ConversationTitleView extends LinearLayout {
@@ -67,8 +68,13 @@ public class ConversationTitleView extends LinearLayout {
         this.subtitle.setVisibility(View.GONE);
       } else {
         this.title.setText(recipient.getName());
-        this.subtitle.setText(recipient.getNumber());
-        this.subtitle.setVisibility(View.VISIBLE);
+        if(TextSecurePreferences.isHideNumberInActionBarEnabled(getContext())){
+          this.subtitle.setText(null);
+          this.subtitle.setVisibility(View.GONE);
+        }else {
+          this.subtitle.setText(recipient.getNumber());
+          this.subtitle.setVisibility(View.VISIBLE);
+        }
       }
     } else {
       String groupName = (!TextUtils.isEmpty(recipient.getName())) ?

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -57,6 +57,7 @@ public class TextSecurePreferences {
   public  static final String PASSPHRASE_TIMEOUT_INTERVAL_PREF = "pref_timeout_interval";
   private static final String PASSPHRASE_TIMEOUT_PREF          = "pref_timeout_passphrase";
   public  static final String SCREEN_SECURITY_PREF             = "pref_screen_security";
+  public  static final String HIDE_NUMBER_IN_ACTIONBAR         = "pref_hide_number";
   private static final String ENTER_SENDS_PREF                 = "pref_enter_sends";
   private static final String ENTER_PRESENT_PREF               = "pref_enter_key";
   private static final String SMS_DELIVERY_REPORT_PREF         = "pref_delivery_report_sms";
@@ -355,6 +356,10 @@ public class TextSecurePreferences {
 
   public static boolean isScreenSecurityEnabled(Context context) {
     return getBooleanPreference(context, SCREEN_SECURITY_PREF, true);
+  }
+
+  public static boolean isHideNumberInActionBarEnabled(Context context){
+    return getBooleanPreference(context, HIDE_NUMBER_IN_ACTIONBAR, false);
   }
 
   public static boolean isLegacyUseLocalApnsEnabled(Context context) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola Moto G 3rd Gen. Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

This adds a preference that enables hiding the recipients number on the actionbar in conversations. I understand that i might be in violation of rule#1 "The answer is not more options" but i think this should have been the default behavior. It's especially important when you're in public and there are lots of prying eyes, and also screenshots

//FREEBIE