### PR TITLE
Ignore fast sender clock

### DIFF
--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -119,8 +119,10 @@ public abstract class MessageRecord extends DisplayRecord {
   }
 
   public long getTimestamp() {
-    if (isPush()) return getDateSent();
-    else          return getDateReceived();
+    if (isPush() && getDateSent() < getDateReceived()) {
+      return getDateSent();
+    }
+    return getDateReceived();
   }
 
   public boolean isForcedSms() {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Steps to reproduce the issue:
- take phone A and set date/time some hours (or days) into the future
- send message to phone B
- check phone B:

1. The message from A will stay on top of the conversations list even if newer messages are received, until B replies to A, or B reaches the date/time of A.
2. In the conversation with A, the message will show a wrong relative timestamp, it will show "now" for quite a while.

This PR reduces the annoying effect of the fast sender clock by checking if the message was received before it was sent. In that case it is referencing the time the message was received, which is based on B's local clock.

// FREEBIE