### PR TITLE
Add shadow under compose view on scroll

### DIFF
--- a/res/drawable/compose_divider_background.xml
+++ b/res/drawable/compose_divider_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:dither="true"
+        android:endColor="@android:color/transparent"
+        android:startColor="@color/conversation_compose_divider" />
+</shape>

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="fill_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical">
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="fill_parent"
+             android:layout_height="match_parent">
 
     <android.support.v7.widget.RecyclerView
             android:id="@android:id/list"
-            android:layout_width="fill_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1.0"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:scrollbars="vertical"
             android:cacheColorHint="?conversation_background" />
 
-</LinearLayout>
+
+    <!--suppress AndroidLintUnusedAttribute-->
+    <View android:id="@+id/compose_divider"
+          android:layout_width="match_parent"
+          android:layout_height="4dp"
+          android:layout_gravity="bottom"
+          android:background="@drawable/compose_divider_background"
+          android:alpha="0"/>
+
+</FrameLayout>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -25,6 +25,8 @@
 
     <color name="gray95_transparent50">#7F111111</color>
 
+    <color name="conversation_compose_divider">#44000000</color>
+
     <color name="conversation_list_item_background_read_light">@color/gray5</color>
     <color name="conversation_list_item_background_unread_light">#ffffffff</color>
     <color name="conversation_list_item_background_read_dark">#ff000000</color>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -88,6 +88,7 @@ public class ConversationFragment extends Fragment
   private Locale       locale;
   private RecyclerView list;
   private View         loadMoreView;
+  private View         composeDivider;
 
   @Override
   public void onCreate(Bundle icicle) {
@@ -103,6 +104,32 @@ public class ConversationFragment extends Fragment
     final LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, true);
     list.setHasFixedSize(false);
     list.setLayoutManager(layoutManager);
+
+    composeDivider = view.findViewById(R.id.compose_divider);
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.HONEYCOMB) {
+      composeDivider.setVisibility(View.INVISIBLE);
+    }
+
+    list.addOnScrollListener(new RecyclerView.OnScrollListener() {
+      boolean wasAtBottom = true;
+
+      @Override
+      public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+        super.onScrollStateChanged(recyclerView, newState);
+
+        if (wasAtBottom != isAtBottom()) {
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
+            composeDivider.animate().alpha(isAtBottom() ? 0 : 1);
+          } else if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB) {
+            composeDivider.setAlpha(isAtBottom() ? 0 : 1);
+          } else {
+            composeDivider.setVisibility(isAtBottom() ? View.INVISIBLE : View.VISIBLE);
+          }
+
+          wasAtBottom = isAtBottom();
+        }
+      }
+    });
 
     loadMoreView = inflater.inflate(R.layout.load_more_header, container, false);
     loadMoreView.setOnClickListener(new OnClickListener() {
@@ -225,6 +252,17 @@ public class ConversationFragment extends Fragment
         list.smoothScrollToPosition(0);
       }
     });
+  }
+
+  private boolean isAtBottom() {
+    if (list.getChildCount() == 0) return true;
+
+    final View bottomView = list.getChildAt(0);
+    int firstVisibleItem = ((LinearLayoutManager) list.getLayoutManager())
+            .findFirstVisibleItemPosition();
+
+    final boolean isAtBottom = (firstVisibleItem == 0);
+    return isAtBottom && bottomView.getBottom() <= list.getHeight();
   }
 
   private void handleCopyMessage(final Set<MessageRecord> messageRecords) {


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung Galaxy S5, Android 6.0.1 (CyanogenMod 13)
 * AVD Nexus 5X, Android 6.0.1
 * AVD Nexus One, Android 2.3
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Adds a shadow under the compose view (like the one in Google Messenger) that divides it from the conversation list when scrolling.

Fixes #5098

![screenshot_20160719-202632](https://cloud.githubusercontent.com/assets/17954071/16972213/45c872be-4def-11e6-84a7-469a8b9a5185.png)


// FREEBIE