### PR TITLE
Fix unlink device endless spinning wheel

### DIFF
--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -182,7 +182,7 @@ public class DeviceListFragment extends ListFragment
       @Override
       protected void onPostExecute(Void result) {
         super.onPostExecute(result);
-        getLoaderManager().restartLoader(0, null, DeviceListFragment.this);
+        getLoaderManager().restartLoader(0, null, DeviceListFragment.this).forceLoad();
       }
     }.execute();
   }


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Fixes #4641

Tested with one and two linked devices (in the latter case both devices were unlinked successively). After each unlink the device list is shown again and the wheel of confusion does not spin forever.

//FREEBIE