### PR TITLE
Harmonize ticker text of new message notifications

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -621,6 +621,9 @@
     <string name="QuickResponseService_quick_response_unavailable_when_Signal_is_locked">Quick response unavailable when Signal is locked!</string>
     <string name="QuickResponseService_problem_sending_message">Problem sending message!</string>
 
+    <!-- AbstractNotificationBuilder -->
+    <string name="AbstractNotificationBuilder_new_message">New message</string>
+
     <!-- SingleRecipientNotificationBuilder -->
     <string name="SingleRecipientNotificationBuilder_signal">Signal</string>
     <string name="SingleRecipientNotificationBuilder_new_message">New message</string>

--- a/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -10,6 +10,7 @@ import android.support.v4.app.NotificationCompat;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
 
+import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.database.RecipientPreferenceDatabase;
 import org.thoughtcrime.securesms.preferences.NotificationPrivacyPreference;
 import org.thoughtcrime.securesms.recipients.Recipient;
@@ -58,6 +59,16 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
       setLights(Color.parseColor(ledColor),
                 Integer.parseInt(blinkPatternArray[0]),
                 Integer.parseInt(blinkPatternArray[1]));
+    }
+  }
+
+  public void setTicker(@NonNull Recipient recipient, @Nullable CharSequence message) {
+    if (privacy.isDisplayMessage()) {
+      setTicker(getStyledMessage(recipient, message));
+    } else if (privacy.isDisplayContact()) {
+      setTicker(getStyledMessage(recipient, context.getString(R.string.SingleRecipientNotificationBuilder_new_message)));
+    } else {
+      setTicker(context.getString(R.string.SingleRecipientNotificationBuilder_new_message));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -66,9 +66,9 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     if (privacy.isDisplayMessage()) {
       setTicker(getStyledMessage(recipient, message));
     } else if (privacy.isDisplayContact()) {
-      setTicker(getStyledMessage(recipient, context.getString(R.string.SingleRecipientNotificationBuilder_new_message)));
+      setTicker(getStyledMessage(recipient, context.getString(R.string.AbstractNotificationBuilder_new_message)));
     } else {
-      setTicker(context.getString(R.string.SingleRecipientNotificationBuilder_new_message));
+      setTicker(context.getString(R.string.AbstractNotificationBuilder_new_message));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -278,7 +278,8 @@ public class MessageNotifier {
 
     if (signal) {
       builder.setAlarms(notificationState.getRingtone(), notificationState.getVibrate());
-      builder.setTicker(notifications.get(0).getText());
+      builder.setTicker(notifications.get(0).getIndividualRecipient(),
+                        notifications.get(0).getText());
     }
 
     ((NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE))

--- a/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/SingleRecipientNotificationBuilder.java
@@ -150,16 +150,6 @@ public class SingleRecipientNotificationBuilder extends AbstractNotificationBuil
     }
   }
 
-  public void setTicker(@NonNull Recipient recipient, @Nullable CharSequence message) {
-    if (privacy.isDisplayMessage()) {
-      setTicker(getStyledMessage(recipient, message));
-    } else if (privacy.isDisplayContact()) {
-      setTicker(getStyledMessage(recipient, context.getString(R.string.SingleRecipientNotificationBuilder_new_message)));
-    } else {
-      setTicker(context.getString(R.string.SingleRecipientNotificationBuilder_new_message));
-    }
-  }
-
   @Override
   public Notification build() {
     if (privacy.isDisplayMessage()) {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Fixes #5517

As stated in the issue, this bug only occurs in Android versions that show messages directly in the status bar (so called "ticker" texts). So Android 5 & 6 are not affected by this issue and its fix. 

// FREEBIE