### PR TITLE
Catch ActivityNotFoundException when opening links

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -76,9 +76,7 @@
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="?conversation_item_received_text_primary_color"
                     android:textColorLink="?conversation_item_received_text_primary_color"
-                    android:textSize="@dimen/conversation_item_body_text_size"
-                    android:autoLink="all"
-                    android:linksClickable="true" />
+                    android:textSize="@dimen/conversation_item_body_text_size" />
 
             <LinearLayout android:id="@+id/mms_download_controls"
                           android:layout_width="wrap_content"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -60,12 +60,10 @@
 
             <org.thoughtcrime.securesms.components.emoji.EmojiTextView
                     android:id="@+id/conversation_item_body"
-                    android:autoLink="all"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:paddingLeft="4dp"
                     android:paddingRight="4dp"
-                    android:linksClickable="true"
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="?conversation_item_sent_text_primary_color"
                     android:textColorLink="?conversation_item_sent_text_primary_color"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="ConversationFragment_deleting_messages">Deleting messages...</string>
 
     <!-- ConversationListActivity -->
+    <string name="ConversationListActivity_help_no_browser">You have no browser installed. Get a browser to access help.</string>
     <string name="ConversationListActivity_search">Search...</string>
 
     <!-- ConversationListFragment -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -511,6 +511,9 @@
     <string name="RegistrationService_registration_error">Registration error</string>
     <string name="RegistrationService_signal_registration_has_encountered_a_problem">Signal registration has encountered a problem.</string>
 
+    <!-- SafeLinkMovementMethod -->
+    <string name="SafeLinkMovementMethod_no_handler_app">You have no app installed to open this link.</string>
+
     <!-- Slide -->
     <string name="Slide_image">Image</string>
     <string name="Slide_audio">Audio</string>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -26,6 +26,7 @@ import android.graphics.PorterDuff;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
+import android.text.SpannableString;
 import android.text.TextUtils;
 import android.text.util.Linkify;
 import android.util.AttributeSet;
@@ -38,10 +39,10 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.components.AlertView;
 import org.thoughtcrime.securesms.components.AudioView;
 import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.components.DeliveryStatusView;
-import org.thoughtcrime.securesms.components.AlertView;
 import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
@@ -63,6 +64,7 @@ import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.DynamicTheme;
+import org.thoughtcrime.securesms.util.SafeLinkMovementMethod;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.dualsim.SubscriptionInfoCompat;
@@ -241,7 +243,15 @@ public class ConversationItem extends LinearLayout
     mediaThumbnail.setFocusable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
     mediaThumbnail.setClickable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
     mediaThumbnail.setLongClickable(batchSelected.isEmpty());
-    bodyText.setAutoLinkMask(batchSelected.isEmpty() ? Linkify.ALL : 0);
+
+    if (batchSelected.isEmpty()) {
+      SpannableString body = messageRecord.getDisplayBody();
+      Linkify.addLinks(body,Linkify.ALL);
+      bodyText.setMovementMethod(SafeLinkMovementMethod.getInstance());
+      bodyText.setText(body);
+    } else {
+      bodyText.setText(messageRecord.getDisplayBody());
+    }
   }
 
   private boolean isCaptionlessMms(MessageRecord messageRecord) {
@@ -267,7 +277,6 @@ public class ConversationItem extends LinearLayout
     if (isCaptionlessMms(messageRecord)) {
       bodyText.setVisibility(View.GONE);
     } else {
-      bodyText.setText(messageRecord.getDisplayBody());
       bodyText.setVisibility(View.VISIBLE);
     }
   }

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -16,6 +16,7 @@
  */
 package org.thoughtcrime.securesms;
 
+import android.content.ActivityNotFoundException;
 import android.content.Intent;
 import android.database.ContentObserver;
 import android.net.Uri;
@@ -30,6 +31,7 @@ import android.support.v7.widget.SearchView;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.RatingManager;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -212,7 +214,11 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
   }
 
   private void handleHelp() {
-    startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("http://support.whispersystems.org")));
+    try {
+      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("http://support.whispersystems.org")));
+    } catch (ActivityNotFoundException e) {
+      Toast.makeText(this, R.string.ConversationListActivity_help_no_browser, Toast.LENGTH_LONG).show();
+    }
   }
 
   private void initializeContactUpdatesReceiver() {

--- a/src/org/thoughtcrime/securesms/util/SafeLinkMovementMethod.java
+++ b/src/org/thoughtcrime/securesms/util/SafeLinkMovementMethod.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms.util;
+
+import android.content.ActivityNotFoundException;
+import android.text.Spannable;
+import android.text.method.LinkMovementMethod;
+import android.text.method.MovementMethod;
+import android.util.Log;
+import android.view.MotionEvent;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import org.thoughtcrime.securesms.R;
+
+public class SafeLinkMovementMethod extends LinkMovementMethod {
+  private static SafeLinkMovementMethod sInstance;
+  private static final String TAG = SafeLinkMovementMethod.class.getSimpleName();
+
+  public static MovementMethod getInstance() {
+    if (sInstance == null)
+      sInstance = new SafeLinkMovementMethod();
+      return sInstance;
+  }
+
+  @Override
+  public boolean onTouchEvent(TextView widget, Spannable buffer, MotionEvent event) {
+    try {
+      return super.onTouchEvent(widget,buffer,event);
+    } catch (ActivityNotFoundException e) {
+      Toast.makeText(widget.getContext(), R.string.SafeLinkMovementMethod_no_handler_app, Toast.LENGTH_LONG).show();
+      return false;
+    }
+  }
+}


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Fixes #3726 

EDIT: Please tell me, if there are other links placed in the app, that could cause an `ActivityNotFoundException`. I already know about the link you get, when you submit a log. But this link has to be fixed in libpastelog.