### PR TITLE
Fix ConversationItem recipients listener

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -38,10 +38,10 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.components.AlertView;
 import org.thoughtcrime.securesms.components.AudioView;
 import org.thoughtcrime.securesms.components.AvatarImageView;
 import org.thoughtcrime.securesms.components.DeliveryStatusView;
-import org.thoughtcrime.securesms.components.AlertView;
 import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.AttachmentDatabase;
@@ -223,16 +223,21 @@ public class ConversationItem extends LinearLayout
     if (messageRecord.isOutgoing()) {
       bodyBubble.getBackground().setColorFilter(defaultBubbleColor, PorterDuff.Mode.MULTIPLY);
       mediaThumbnail.setBackgroundColorHint(defaultBubbleColor);
-
-      if (DynamicTheme.LIGHT.equals(TextSecurePreferences.getTheme(context))) {
-        audioView.setTint(conversationRecipients.getColor().toConversationColor(context));
-      } else {
-        audioView.setTint(Color.WHITE);
-      }
+      setAudioViewTint(messageRecord, conversationRecipients);
     } else {
       int color = recipient.getColor().toConversationColor(context);
       bodyBubble.getBackground().setColorFilter(color, PorterDuff.Mode.MULTIPLY);
       mediaThumbnail.setBackgroundColorHint(color);
+    }
+  }
+
+  private void setAudioViewTint(MessageRecord messageRecord, Recipients recipients) {
+    if (messageRecord.isOutgoing()) {
+      if (DynamicTheme.LIGHT.equals(TextSecurePreferences.getTheme(context))) {
+        audioView.setTint(recipients.getColor().toConversationColor(context));
+      } else {
+        audioView.setTint(Color.WHITE);
+      }
     }
   }
 
@@ -455,8 +460,13 @@ public class ConversationItem extends LinearLayout
   }
 
   @Override
-  public void onModified(Recipients recipient) {
-    onModified(recipient.getPrimaryRecipient());
+  public void onModified(final Recipients recipients) {
+    Util.runOnMain(new Runnable() {
+      @Override
+      public void run() {
+        setAudioViewTint(messageRecord, recipients);
+      }
+    });
   }
 
   private class AttachmentDownloadClickListener implements SlideClickListener {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
Fixes #4420, which was introduced by 7838e8fbe0ad992407529be81d48cf9f686dc61d, as @jarteaga said.

The idea of that commit was to correctly color outgoing audio message controls, i.e. according to the conversation partners color.

But the `recipient` of outgoing audio messages is "Anonymous", so the `conversationRecipients` were passed in and used for that. And it is only used for that.

In group conversations, the `conversationRecipients` and its `getPrimaryRecipient()` is a group recipient (i.e. group name and photo), so it must not be used to update a single conversation items color, contact name and photo, which is exactly what is happening in the newly registered `onModified` listener (again as @jarteaga has already pointed out).

_The diff is not so nice, I have only created a new method `setAudioViewTint`._

// FREEBIE