### PR TITLE
Postpone URI check for recipient pref updates

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -839,8 +839,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void updateRecipientPreferences() {
-    if (recipients.getPrimaryRecipient() != null &&
-        recipients.getPrimaryRecipient().getContactUri() != null)
+    if (recipients.getPrimaryRecipient() != null)
     {
       new RecipientPreferencesTask().execute(recipients);
     }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -850,7 +850,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     if (TextSecurePreferences.isPushRegistered(this) &&
         !isSecureText                                &&
         !seenInvite                                  &&
-        recipients.isSingleRecipient())
+        recipients.isSingleRecipient()               &&
+        recipients.getPrimaryRecipient().getContactUri() != null)
     {
       InviteReminder reminder = new InviteReminder(this, recipients);
       reminder.setOkListener(new OnClickListener() {

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -839,10 +839,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void updateRecipientPreferences() {
-    if (recipients.getPrimaryRecipient() != null)
-    {
-      new RecipientPreferencesTask().execute(recipients);
-    }
+    new RecipientPreferencesTask().execute(recipients);
   }
 
   protected void updateInviteReminder(boolean seenInvite) {
@@ -851,6 +848,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
         !isSecureText                                &&
         !seenInvite                                  &&
         recipients.isSingleRecipient()               &&
+        recipients.getPrimaryRecipient() != null     &&
         recipients.getPrimaryRecipient().getContactUri() != null)
     {
       InviteReminder reminder = new InviteReminder(this, recipients);


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description
This PR postpones the check whether the recipient has a URI (is an address book contact). This reverts https://github.com/WhisperSystems/Signal-Android/commit/6da86e482da9a4451bb81875c39af1658c24e473 (ctrl+F `getContactUri`) partly, which prevents an update of the invite reminder for non-address-book contacts and thereby introduces #5637.

From the code I see no side effects arising from my changes. As author of the crucial commit, do you remember what you intended with this change, @moxie0 ?

~~If you wish to show the invite reminder for recipients that aren't in the address book, you can drop the second commit 7767738. Then the number of the recipient is shown in the reminder as there is no name saved in the address book.~~

EDIT: I only tested the steps in #5637 explicitly. Other possible edge cases?

Fixes #5637 
// FREEBIE