### PR TITLE
Always set LED notification

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -27,6 +27,8 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
 
     this.context = context;
     this.privacy = privacy;
+
+    setLed();
   }
 
   protected CharSequence getStyledMessage(@NonNull Recipient recipient, @Nullable CharSequence message) {
@@ -39,12 +41,8 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
   }
 
   public void setAlarms(@Nullable Uri ringtone, RecipientPreferenceDatabase.VibrateState vibrate) {
-    String defaultRingtoneName   = TextSecurePreferences.getNotificationRingtone(context);
-    boolean defaultVibrate       = TextSecurePreferences.isNotificationVibrateEnabled(context);
-    String ledColor              = TextSecurePreferences.getNotificationLedColor(context);
-    String ledBlinkPattern       = TextSecurePreferences.getNotificationLedPattern(context);
-    String ledBlinkPatternCustom = TextSecurePreferences.getNotificationLedPatternCustom(context);
-    String[] blinkPatternArray   = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
+    String  defaultRingtoneName = TextSecurePreferences.getNotificationRingtone(context);
+    boolean defaultVibrate      = TextSecurePreferences.isNotificationVibrateEnabled(context);
 
     if      (ringtone != null)                        setSound(ringtone);
     else if (!TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
@@ -54,8 +52,16 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     {
       setDefaults(Notification.DEFAULT_VIBRATE);
     }
+  }
+
+  private void setLed() {
+    String ledColor              = TextSecurePreferences.getNotificationLedColor(context);
+    String ledBlinkPattern       = TextSecurePreferences.getNotificationLedPattern(context);
+    String ledBlinkPatternCustom = TextSecurePreferences.getNotificationLedPatternCustom(context);
 
     if (!ledColor.equals("none")) {
+      String[] blinkPatternArray = parseBlinkPattern(ledBlinkPattern, ledBlinkPatternCustom);
+
       setLights(Color.parseColor(ledColor),
                 Integer.parseInt(blinkPatternArray[0]),
                 Integer.parseInt(blinkPatternArray[1]));


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Fixes that missed call notifications do not enable LED. Might also help with #1036.
Without this, every silent notification update (!signal / updateNotification(context, masterSecret)) will turn off the LED.

Minimal version of #5466.

// FREEBIE