### PR TITLE
Add shadow under compose view on scroll (v2)

### DIFF
--- a/res/drawable/compose_divider_background.xml
+++ b/res/drawable/compose_divider_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="90"
+        android:dither="true"
+        android:endColor="@android:color/transparent"
+        android:startColor="@color/conversation_compose_divider" />
+</shape>

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -1,16 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="fill_parent"
-              android:layout_height="match_parent"
-              android:orientation="vertical">
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+             android:layout_width="fill_parent"
+             android:layout_height="match_parent">
 
     <android.support.v7.widget.RecyclerView
             android:id="@android:id/list"
-            android:layout_width="fill_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1.0"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:scrollbars="vertical"
             android:cacheColorHint="?conversation_background" />
 
-</LinearLayout>
+
+    <!--suppress AndroidLintUnusedAttribute-->
+    <View android:id="@+id/compose_divider"
+          android:layout_width="match_parent"
+          android:layout_height="2dp"
+          android:layout_gravity="bottom"
+          android:background="@drawable/compose_divider_background"
+          android:alpha="0"/>
+
+</FrameLayout>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -25,6 +25,8 @@
 
     <color name="gray95_transparent50">#7F111111</color>
 
+    <color name="conversation_compose_divider">#32000000</color>
+
     <color name="conversation_list_item_background_read_light">@color/gray5</color>
     <color name="conversation_list_item_background_unread_light">#ffffffff</color>
     <color name="conversation_list_item_background_read_dark">#ff000000</color>


### PR DESCRIPTION
### Contributor checklist
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Samsung Galaxy S5, Android 6.0.1 (CyanogenMod 13)
 * AVD Nexus 5X, Android 6.0
 * AVD Nexus One, Android 2.3
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

----------

### Description

Adds a shadow separating the compose view from the message list when scrolled.

Fixes #5098 

![device-2016-09-03-134758](https://cloud.githubusercontent.com/assets/17954071/18227280/c4fc48ee-71e4-11e6-921d-622a4c828865.png)

// FREEBIE