### PR TITLE
Use contact color in new VerifyIdentityActivity

### DIFF
--- a/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -75,7 +75,7 @@ import java.nio.charset.Charset;
  *
  * @author Moxie Marlinspike
  */
-public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity implements ScanListener, View.OnClickListener {
+public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity implements Recipient.RecipientModifiedListener, ScanListener, View.OnClickListener {
 
   private static final String TAG = VerifyIdentityActivity.class.getSimpleName();
 
@@ -100,6 +100,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
     getSupportActionBar().setTitle(R.string.AndroidManifest__verify_safety_numbers);
 
     Recipient recipient = RecipientFactory.getRecipientForId(this, getIntent().getLongExtra(RECIPIENT_ID, -1), true);
+    recipient.addListener(this);
 
     setActionBarNotificationBarColor(recipient.getColor());
 
@@ -122,6 +123,16 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
     }
 
     return false;
+  }
+
+  @Override
+  public void onModified(final Recipient recipient) {
+    Util.runOnMain(new Runnable() {
+      @Override
+      public void run() {
+        setActionBarNotificationBarColor(recipient.getColor());
+      }
+    });
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -163,7 +163,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
                .commit();
   }
 
-  public void setActionBarNotificationBarColor(MaterialColor color) {
+  private void setActionBarNotificationBarColor(MaterialColor color) {
     getSupportActionBar().setBackgroundDrawable(new ColorDrawable(color.toActionBarColor(this)));
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {

--- a/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -23,6 +23,8 @@ import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
 import android.graphics.PorterDuff;
 import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.ColorDrawable;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Vibrator;
 import android.support.annotation.DrawableRes;
@@ -42,6 +44,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.color.MaterialColor;
 import org.thoughtcrime.securesms.components.camera.CameraView;
 import org.thoughtcrime.securesms.crypto.IdentityKeyParcelable;
 import org.thoughtcrime.securesms.crypto.IdentityKeyUtil;
@@ -98,6 +101,8 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
 
     Recipient recipient = RecipientFactory.getRecipientForId(this, getIntent().getLongExtra(RECIPIENT_ID, -1), true);
 
+    setActionBarNotificationBarColor(recipient.getColor());
+
     Bundle extras = new Bundle();
     extras.putParcelable(VerifyDisplayFragment.REMOTE_IDENTITY, getIntent().getParcelableExtra(RECIPIENT_IDENTITY));
     extras.putString(VerifyDisplayFragment.REMOTE_NUMBER, recipient.getNumber());
@@ -145,6 +150,14 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
     transaction.replace(android.R.id.content, scanFragment)
                .addToBackStack(null)
                .commit();
+  }
+
+  public void setActionBarNotificationBarColor(MaterialColor color) {
+    getSupportActionBar().setBackgroundDrawable(new ColorDrawable(color.toActionBarColor(this)));
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      getWindow().setStatusBarColor(color.toStatusBarColor(this));
+    }
   }
 
   public static class VerifyDisplayFragment extends Fragment implements Recipients.RecipientsModifiedListener {


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 5.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Fixes #3630 
Replaces #5429 

### Screenshots
![bildschirmfoto von 2016-09-04 02-27-52](https://cloud.githubusercontent.com/assets/16167751/18228514/f7ca966e-7251-11e6-9108-a55ee5478970.png)
![bildschirmfoto von 2016-09-04 02-27-03](https://cloud.githubusercontent.com/assets/16167751/18228515/f9c69328-7251-11e6-8f72-b295ecb79893.png)
