### PR TITLE
Let LogSubmitActivity adapt to theme

### DIFF
--- a/src/org/thoughtcrime/securesms/LogSubmitActivity.java
+++ b/src/org/thoughtcrime/securesms/LogSubmitActivity.java
@@ -9,16 +9,20 @@ import android.util.Log;
 import android.view.MenuItem;
 import android.widget.Toast;
 
+import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.whispersystems.libpastelog.SubmitLogFragment;
 
 /**
  * Activity for submitting logcat logs to a pastebin service.
  */
 public class LogSubmitActivity extends BaseActionBarActivity implements SubmitLogFragment.OnLogSubmittedListener {
+
   private static final String TAG = LogSubmitActivity.class.getSimpleName();
+  private DynamicTheme dynamicTheme = new DynamicTheme();
 
   @Override
   protected void onCreate(Bundle icicle) {
+    dynamicTheme.onCreate(this);
     super.onCreate(icicle);
     setContentView(R.layout.log_submit_activity);
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -30,6 +34,7 @@ public class LogSubmitActivity extends BaseActionBarActivity implements SubmitLo
 
   @Override
   protected void onResume() {
+    dynamicTheme.onResume(this);
     super.onResume();
   }
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD: Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Addresses #2625
// FREEBIE

### Screenshots
![device-2016-09-04-145741](https://cloud.githubusercontent.com/assets/16167751/18231176/a2483204-72b1-11e6-8998-da1c84e9d938.png)
![device-2016-09-04-145825](https://cloud.githubusercontent.com/assets/16167751/18231177/a6cc6516-72b1-11e6-8882-380d55386fd6.png)
![device-2016-09-04-145805](https://cloud.githubusercontent.com/assets/16167751/18231180/ad42372c-72b1-11e6-9551-3bef0f270cfe.png)
