### PR TITLE
Fix DeviceListLoader behavior on init and restart

### DIFF
--- a/src/org/thoughtcrime/securesms/DeviceListFragment.java
+++ b/src/org/thoughtcrime/securesms/DeviceListFragment.java
@@ -77,7 +77,7 @@ public class DeviceListFragment extends ListFragment
   @Override
   public void onActivityCreated(Bundle bundle) {
     super.onActivityCreated(bundle);
-    getLoaderManager().initLoader(0, null, this).forceLoad();
+    getLoaderManager().initLoader(0, null, this);
     getListView().setOnItemClickListener(this);
   }
 
@@ -142,8 +142,7 @@ public class DeviceListFragment extends ListFragment
                               new DialogInterface.OnClickListener() {
       @Override
       public void onClick(DialogInterface dialog, int which) {
-        getLoaderManager().getLoader(0).forceLoad();
-        getLoaderManager().initLoader(0, null, DeviceListFragment.this);
+        getLoaderManager().restartLoader(0, null, DeviceListFragment.this);
       }
     });
 

--- a/src/org/thoughtcrime/securesms/database/loaders/DeviceListLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/DeviceListLoader.java
@@ -46,6 +46,11 @@ public class DeviceListLoader extends AsyncTaskLoader<List<DeviceInfo>> {
     }
   }
 
+  @Override
+  public void onStartLoading() {
+    forceLoad();
+  }
+
   private static class DeviceInfoComparator implements Comparator<DeviceInfo> {
 
     @Override

--- a/src/org/thoughtcrime/securesms/database/loaders/DeviceListLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/DeviceListLoader.java
@@ -1,9 +1,9 @@
 package org.thoughtcrime.securesms.database.loaders;
 
 import android.content.Context;
-import android.support.v4.content.AsyncTaskLoader;
 import android.util.Log;
 
+import org.thoughtcrime.securesms.util.AsyncLoader;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
 import org.whispersystems.signalservice.api.messages.multidevice.DeviceInfo;
 import org.whispersystems.signalservice.api.push.SignalServiceAddress;
@@ -14,7 +14,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
-public class DeviceListLoader extends AsyncTaskLoader<List<DeviceInfo>> {
+public class DeviceListLoader extends AsyncLoader<List<DeviceInfo>> {
 
   private static final String TAG = DeviceListLoader.class.getSimpleName();
 
@@ -44,11 +44,6 @@ public class DeviceListLoader extends AsyncTaskLoader<List<DeviceInfo>> {
       Log.w(TAG, e);
       return null;
     }
-  }
-
-  @Override
-  public void onStartLoading() {
-    forceLoad();
   }
 
   private static class DeviceInfoComparator implements Comparator<DeviceInfo> {

--- a/src/org/thoughtcrime/securesms/util/AsyncLoader.java
+++ b/src/org/thoughtcrime/securesms/util/AsyncLoader.java
@@ -1,0 +1,80 @@
+package org.thoughtcrime.securesms.util;
+
+/*
+ * Copyright (C) 2011 Alexander Blom
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.support.v4.content.AsyncTaskLoader;
+import android.content.Context;
+
+/**
+ * Loader which extends AsyncTaskLoaders and handles caveats
+ * as pointed out in http://code.google.com/p/android/issues/detail?id=14944.
+ *
+ * Based on CursorLoader.java in the Fragment compatibility package
+ *
+ * @author Alexander Blom (me@alexanderblom.se)
+ *
+ * @param <D> data type
+ */
+public abstract class AsyncLoader<D> extends AsyncTaskLoader<D> {
+  private D data;
+
+  public AsyncLoader(Context context) {
+    super(context);
+  }
+
+  @Override
+  public void deliverResult(D data) {
+    if (isReset()) {
+      // An async query came in while the loader is stopped
+      return;
+    }
+
+    this.data = data;
+
+    super.deliverResult(data);
+  }
+
+
+  @Override
+  protected void onStartLoading() {
+    if (data != null) {
+      deliverResult(data);
+    }
+
+    if (takeContentChanged() || data == null) {
+      forceLoad();
+    }
+  }
+
+  @Override
+  protected void onStopLoading() {
+    // Attempt to cancel the current load task if possible.
+    cancelLoad();
+  }
+
+  @Override
+  protected void onReset() {
+    super.onReset();
+
+    // Ensure the loader is stopped
+    onStopLoading();
+
+    data = null;
+  }
+
+
+}


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Our `DeviceListLoader` does not start a loader upon calling `initLoader(...)` or `restartLoader(...)`. It has to be forced to do this with `forceLoad()`. This is a [known issue](https://code.google.com/p/android/issues/detail?id=14944) and further discussed on [stackoverflow](http://stackoverflow.com/questions/10524667/android-asynctaskloader-doesnt-start-loadinbackground).

The reason seems to be, that a loader is created upon init and restart (I tested this), but it is not started/loaded. After creation `onStartLoading()` will be called. This is implemented without functionality in `android.support.v4.content.Loader`. We have to provide the functionality by overriding this method. That's what I do with this PR.

In my implementation simply `forceLoad()` is called inside `onStartLoading()`. In the above discussions there are some checks suggested before doing this `forceLoad()`. But I think everytime we init or restart the loader we want fresh data to be fetched. So from my standpoint the proposed checks are unnecessary in our case.

Replaces #5591
Fixes #4641
// FREEBIE