### PR TITLE
Make 'Disappears' in message details translatable

### DIFF
--- a/res/layout/message_details_header.xml
+++ b/res/layout/message_details_header.xml
@@ -84,7 +84,8 @@
 
                 <TextView android:layout_width="wrap_content"
                           android:layout_height="wrap_content"
-                          android:text="Disappears"
+                          android:text="@string/message_details_header__disappears"
+                          android:gravity="right"
                           android:textStyle="bold"/>
 
                 <TextView android:id="@+id/expires_in"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -924,6 +924,7 @@
     <string name="message_details_header__issues_need_your_attention">Some issues need your attention.</string>
     <string name="message_details_header__sent">Sent</string>
     <string name="message_details_header__received">Received</string>
+    <string name="message_details_header__disappears">Disappears</string>
     <string name="message_details_header__via">Via</string>
     <string name="message_details_header__to">To:</string>
     <string name="message_details_header__from">From:</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #5755

This should make 'Disappears' in message_details_header.xml translatable.
I've additionally added ```android:gravity="right"```, as the other header strings in the message details have that as well.

Caveats:
I admittedly don't have a clue about Java and I even **didn't have the opportunity to test this** as my Windows installation is rather new and without Android Studio installed yet.

I'm pretty confident it is correct, though, as I've taken a look at similar examples within the code and this PR's changes are pretty tiny.

Please check the changes if you want to merge.

// FREEBIE