### PR TITLE
Make 'Tap to scan' readable in dark theme

### DIFF
--- a/res/layout/verify_display_fragment.xml
+++ b/res/layout/verify_display_fragment.xml
@@ -29,6 +29,7 @@
                       android:layout_height="wrap_content"
                       android:layout_gravity="bottom|center_horizontal"
                       android:layout_marginBottom="35dp"
+                      android:textColor="@color/gray50"
                       android:textSize="11sp"
                       android:text="@string/verify_display_fragment__tap_to_scan"/>
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Fixes #5749
//FREEBIE

### Screenshots
![taptoscan-dark](https://cloud.githubusercontent.com/assets/16167751/19221115/04061b0e-8e3d-11e6-9943-8fdf3fa42680.gif)
![taptoscan-light](https://cloud.githubusercontent.com/assets/16167751/19221117/07e6e712-8e3d-11e6-82f5-349ee5667637.gif)