### PR TITLE
Better panorama resizing

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -26,8 +26,7 @@ public abstract class MediaConstraints {
   public static MediaConstraints MMS_CONSTRAINTS  = new MmsMediaConstraints();
   public static MediaConstraints PUSH_CONSTRAINTS = new PushMediaConstraints();
 
-  public abstract int getImageMaxWidth(Context context);
-  public abstract int getImageMaxHeight(Context context);
+  public abstract int getImageMaxPixels(Context context);
   public abstract int getImageMaxSize();
 
   public abstract int getGifMaxSize();
@@ -53,8 +52,8 @@ public abstract class MediaConstraints {
     try {
       InputStream is = PartAuthority.getAttachmentStream(context, masterSecret, uri);
       Pair<Integer, Integer> dimensions = BitmapUtil.getDimensions(is);
-      return dimensions.first  > 0 && dimensions.first  <= getImageMaxWidth(context) &&
-             dimensions.second > 0 && dimensions.second <= getImageMaxHeight(context);
+      return dimensions.first > 0 && dimensions.second > 0 &&
+             dimensions.first * dimensions.second <= getImageMaxPixels(context);
     } catch (BitmapDecodingException e) {
       throw new IOException(e);
     }

--- a/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
@@ -5,18 +5,13 @@ import android.content.Context;
 import org.thoughtcrime.securesms.util.Util;
 
 public class MmsMediaConstraints extends MediaConstraints {
-  private static final int MAX_IMAGE_DIMEN_LOWMEM = 768;
-  private static final int MAX_IMAGE_DIMEN        = 1024;
-  public  static final int MAX_MESSAGE_SIZE       = 280 * 1024;
+  private static final int MAX_IMAGE_PIXELS_LOWMEM = 768 * 768 * 3 / 4;
+  private static final int MAX_IMAGE_PIXELS        = 1024 * 1024 * 3 / 4;
+  public  static final int MAX_MESSAGE_SIZE        = 280 * 1024;
 
   @Override
-  public int getImageMaxWidth(Context context) {
-    return Util.isLowMemory(context) ? MAX_IMAGE_DIMEN_LOWMEM : MAX_IMAGE_DIMEN;
-  }
-
-  @Override
-  public int getImageMaxHeight(Context context) {
-    return getImageMaxWidth(context);
+  public int getImageMaxPixels(Context context) {
+    return Util.isLowMemory(context) ? MAX_IMAGE_PIXELS_LOWMEM : MAX_IMAGE_PIXELS;
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -5,19 +5,14 @@ import android.content.Context;
 import org.thoughtcrime.securesms.util.Util;
 
 public class PushMediaConstraints extends MediaConstraints {
-  private static final int MAX_IMAGE_DIMEN_LOWMEM = 768;
-  private static final int MAX_IMAGE_DIMEN        = 1280;
-  private static final int KB                     = 1024;
-  private static final int MB                     = 1024 * KB;
+  private static final int MAX_IMAGE_PIXELS_LOWMEM = 768 * 768 * 3 / 4;
+  private static final int MAX_IMAGE_PIXELS        = 1280 * 1280 * 3 / 4;
+  private static final int KB                      = 1024;
+  private static final int MB                      = 1024 * KB;
 
   @Override
-  public int getImageMaxWidth(Context context) {
-    return Util.isLowMemory(context) ? MAX_IMAGE_DIMEN_LOWMEM : MAX_IMAGE_DIMEN;
-  }
-
-  @Override
-  public int getImageMaxHeight(Context context) {
-    return getImageMaxWidth(context);
+  public int getImageMaxPixels(Context context) {
+    return Util.isLowMemory(context) ? MAX_IMAGE_PIXELS_LOWMEM : MAX_IMAGE_PIXELS;
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -43,13 +43,18 @@ public class BitmapUtil {
   public static <T> byte[] createScaledBytes(Context context, T model, MediaConstraints constraints)
       throws BitmapDecodingException
   {
-    int    quality  = MAX_COMPRESSION_QUALITY;
-    int    attempts = 0;
+    final Pair<Integer, Integer> dimensions = getDimensions(getInputStreamForModel(context, model));
+
+    int    quality   = MAX_COMPRESSION_QUALITY;
+    int    attempts  = 0;
+    int    maxPixels = constraints.getImageMaxPixels(context);
+    double scale     = Math.sqrt((double)maxPixels / (dimensions.first * dimensions.second));
     byte[] bytes;
+
     Bitmap scaledBitmap = createScaledBitmap(context,
                                              model,
-                                             constraints.getImageMaxWidth(context),
-                                             constraints.getImageMaxHeight(context));
+                                             (int)Math.round(dimensions.first * scale),
+                                             (int)Math.round(dimensions.second * scale));
     try {
       do {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [:camel:] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [:camel:] I have tested my contribution on these devices:
 * Emulator, Android 5.1
- [:camel:] My contribution is fully baked and ready to be merged as is
- [:camel:] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [:camel:] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

We're downscaling images to avoid OOM errors. The amount of memory needed is proportional to the amount of pixels. This PR replaces the edge length constraint with a pixel count constraint to achieve better results for exotic aspect ratios (e.g. with panoramic pictures).

To convert the existing edge length limits into pixel count limits, I (arbitrarily) chose an aspect ratio of 4:3, so the memory usage and the resulting image size for a 4:3 image should be the same before and after applying this PR (while 16:9 images should turn out a bit larger and panoramic images much larger than before).

Fixes #5574
Related #672