### PR TITLE
Increase JPEG quality & slow down quality decrease

### DIFF
--- a/src/org/thoughtcrime/securesms/util/BitmapUtil.java
+++ b/src/org/thoughtcrime/securesms/util/BitmapUtil.java
@@ -36,9 +36,10 @@ public class BitmapUtil {
 
   private static final String TAG = BitmapUtil.class.getSimpleName();
 
-  private static final int MAX_COMPRESSION_QUALITY  = 80;
-  private static final int MIN_COMPRESSION_QUALITY  = 45;
-  private static final int MAX_COMPRESSION_ATTEMPTS = 4;
+  private static final int MAX_COMPRESSION_QUALITY          = 90;
+  private static final int MIN_COMPRESSION_QUALITY          = 45;
+  private static final int MAX_COMPRESSION_ATTEMPTS         = 5;
+  private static final int MIN_COMPRESSION_QUALITY_DECREASE = 5;
 
   public static <T> byte[] createScaledBytes(Context context, T model, MediaConstraints constraints)
       throws BitmapDecodingException
@@ -58,7 +59,12 @@ public class BitmapUtil {
 
         Log.w(TAG, "iteration with quality " + quality + " size " + (bytes.length / 1024) + "kb");
         if (quality == MIN_COMPRESSION_QUALITY) break;
-        quality = Math.max((quality * constraints.getImageMaxSize()) / bytes.length, MIN_COMPRESSION_QUALITY);
+
+        int nextQuality = (int)Math.floor(quality * Math.sqrt((double)constraints.getImageMaxSize() / bytes.length));
+        if (quality - nextQuality < MIN_COMPRESSION_QUALITY_DECREASE) {
+          nextQuality = quality - MIN_COMPRESSION_QUALITY_DECREASE;
+        }
+        quality = Math.max(nextQuality, MIN_COMPRESSION_QUALITY);
       }
       while (bytes.length > constraints.getImageMaxSize() && attempts++ < MAX_COMPRESSION_ATTEMPTS);
       if (bytes.length > constraints.getImageMaxSize()) {


### PR DESCRIPTION
### Contributor checklist
- [:chicken:] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [:chicken:] I have tested my contribution on these devices:
 * Emulator, Android 5.1
- [:chicken:] My contribution is fully baked and ready to be merged as is
- [:chicken:] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [:chicken:] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

While fooling around with some test images, I noticed that the compressed files would usually be much smaller than the file size limits.

**First change**: increase the maximum JPEG quality from 80 to 90.

However, for many images, this still didn't solve the problem: the algorithm would start at quality=90 and jump to a quality much lower than necessary in the second iteration.

**Second change**: slow down the quality decrease between iterations by adding a `Math.sqrt()` call around `constraints.getImageMaxSize() / bytes.length`.

Example image 1 via push (limit: 420 KB) - before the second change:
```
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 90 size 582kb
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 64 size 326kb
```
After:
```
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 90 size 582kb
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 76 size 393kb
```

Example image 2 via MMS (limit: 280 KB) - before the second change:
```
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 90 size 324kb
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 77 size 207kb
```
After:
```
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 90 size 324kb
org.thoughtcrime.securesms W/BitmapUtil: iteration with quality 83 size 246kb
```

To account for the increase of `MAX_COMPRESSION_QUALITY` and the reduced step size, I also upped the max. number of compression attempts by one and added a minimum step size of 5.

I hope this makes sense? If not, feel free to ask! And: please test and report back :)

Related #672

//FREEBIE