### PR TITLE
Text now wraps when "Enter is send" is enabled

### DIFF
--- a/src/org/thoughtcrime/securesms/components/ComposeText.java
+++ b/src/org/thoughtcrime/securesms/components/ComposeText.java
@@ -13,6 +13,7 @@ import android.text.TextUtils.TruncateAt;
 import android.text.style.RelativeSizeSpan;
 import android.util.AttributeSet;
 import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.InputConnection;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.TransportOption;
@@ -92,7 +93,6 @@ public class ComposeText extends EmojiEditText {
   }
 
   public void setTransport(TransportOption transport) {
-    final boolean enterSends     = TextSecurePreferences.isEnterSendsEnabled(getContext());
     final boolean useSystemEmoji = TextSecurePreferences.isSystemEmojiPreferred(getContext());
 
     int imeOptions = (getImeOptions() & ~EditorInfo.IME_MASK_ACTION) | EditorInfo.IME_ACTION_SEND;
@@ -105,19 +105,20 @@ public class ComposeText extends EmojiEditText {
       inputType = (inputType & ~InputType.TYPE_MASK_VARIATION) | InputType.TYPE_TEXT_VARIATION_SHORT_MESSAGE;
     }
 
-    inputType  = !isLandscape() && enterSends
-               ? inputType & ~InputType.TYPE_TEXT_FLAG_MULTI_LINE
-               : inputType | InputType.TYPE_TEXT_FLAG_MULTI_LINE;
-
-    imeOptions = enterSends
-               ? imeOptions & ~EditorInfo.IME_FLAG_NO_ENTER_ACTION
-               : imeOptions | EditorInfo.IME_FLAG_NO_ENTER_ACTION;
-
     setInputType(inputType);
     setImeOptions(imeOptions);
     setHint(transport.getComposeHint(),
             transport.getSimName().isPresent()
                 ? getContext().getString(R.string.conversation_activity__from_sim_name, transport.getSimName().get())
                 : null);
+  }
+
+  @Override
+  public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+    InputConnection conn = super.onCreateInputConnection(outAttrs);
+    if(TextSecurePreferences.isEnterSendsEnabled(getContext())) {
+      outAttrs.imeOptions &= ~EditorInfo.IME_FLAG_NO_ENTER_ACTION;
+    }
+    return conn;
   }
 }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - LG G4, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Fixes #5264. Also referencing #5614.

Text wrap is now used in all cases, regardless of whether "Enter Key Sends" is enabled.
