### PR TITLE
Refuse to send push messages with empty attachments (v2)

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushGroupSendJob.java
@@ -20,6 +20,7 @@ import org.thoughtcrime.securesms.recipients.RecipientFactory;
 import org.thoughtcrime.securesms.recipients.RecipientFormattingException;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
+import org.thoughtcrime.securesms.util.AttachmentEmptyException;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.jobqueue.requirements.NetworkRequirement;
@@ -95,7 +96,8 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
                           .getExpiringMessageManager()
                           .scheduleDeletion(messageId, true, message.getExpiresIn());
       }
-    } catch (InvalidNumberException | RecipientFormattingException | UndeliverableMessageException e) {
+    } catch (InvalidNumberException | RecipientFormattingException |
+            UndeliverableMessageException | AttachmentEmptyException e) {
       Log.w(TAG, e);
       database.markAsSentFailed(messageId);
       notifyMediaMessageDeliveryFailed(context, messageId);
@@ -140,7 +142,7 @@ public class PushGroupSendJob extends PushSendJob implements InjectableType {
 
   private void deliver(MasterSecret masterSecret, OutgoingMediaMessage message, long filterRecipientId)
       throws IOException, RecipientFormattingException, InvalidNumberException,
-      EncapsulatedExceptions, UndeliverableMessageException
+      EncapsulatedExceptions, UndeliverableMessageException, AttachmentEmptyException
   {
     SignalServiceMessageSender    messageSender     = messageSenderFactory.create();
     byte[]                        groupId           = GroupUtil.getDecodedId(message.getRecipients().getPrimaryRecipient().getNumber());

--- a/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushMediaSendJob.java
@@ -18,6 +18,7 @@ import org.thoughtcrime.securesms.service.ExpiringMessageManager;
 import org.thoughtcrime.securesms.transport.InsecureFallbackApprovalException;
 import org.thoughtcrime.securesms.transport.RetryLaterException;
 import org.thoughtcrime.securesms.transport.UndeliverableMessageException;
+import org.thoughtcrime.securesms.util.AttachmentEmptyException;
 import org.whispersystems.signalservice.api.SignalServiceMessageSender;
 import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException;
 import org.whispersystems.signalservice.api.messages.SignalServiceAttachment;
@@ -61,7 +62,7 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
   @Override
   public void onSend(MasterSecret masterSecret)
       throws RetryLaterException, MmsException, NoSuchMessageException,
-             UndeliverableMessageException
+             UndeliverableMessageException, AttachmentEmptyException
   {
     ExpiringMessageManager expirationManager = ApplicationContext.getInstance(context).getExpiringMessageManager();
     MmsDatabase            database          = DatabaseFactory.getMmsDatabase(context);
@@ -111,7 +112,7 @@ public class PushMediaSendJob extends PushSendJob implements InjectableType {
 
   private void deliver(MasterSecret masterSecret, OutgoingMediaMessage message)
       throws RetryLaterException, InsecureFallbackApprovalException, UntrustedIdentityException,
-             UndeliverableMessageException
+             UndeliverableMessageException, AttachmentEmptyException
   {
     if (message.getRecipients() == null                       ||
         message.getRecipients().getPrimaryRecipient() == null ||

--- a/src/org/thoughtcrime/securesms/util/AttachmentEmptyException.java
+++ b/src/org/thoughtcrime/securesms/util/AttachmentEmptyException.java
@@ -1,0 +1,5 @@
+package org.thoughtcrime.securesms.util;
+
+public class AttachmentEmptyException extends Exception {
+  public AttachmentEmptyException(String message) { super(message); }
+}


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
  - Samsung Galaxy S5, Android 6.0.1 (CyanogenMod 13)
- [X] My contribution is fully baked and ready to be merged as is
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in my commit message

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve. You can also use the `fixes #1234` syntax to refer to specific issues either here or in your commit message.
Also, please describe shortly how you tested that your fix actually works.
-->

Don't attempt to send push messages with empty attachments - attempting to send now immediately fails instead of crashing the app.

Fixes #5523

// FREEBIE
