### PR TITLE
Allow swipe gestures in image preview

### DIFF
--- a/res/layout/media_preview_activity.xml
+++ b/res/layout/media_preview_activity.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
                 android:background="@color/gray95">
 
-    <android.support.v4.view.ViewPager
+    <org.thoughtcrime.securesms.MediaPreviewViewPager
         android:id="@+id/viewPager"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/res/layout/media_preview_activity.xml
+++ b/res/layout/media_preview_activity.xml
@@ -5,10 +5,10 @@
                 android:layout_height="match_parent"
                 android:background="@color/gray95">
 
-    <org.thoughtcrime.securesms.components.ZoomingImageView
-               android:id="@+id/image"
-               android:layout_width="match_parent"
-               android:layout_height="match_parent"
-               android:contentDescription="@string/media_preview_activity__image_content_description" />
+    <android.support.v4.view.ViewPager
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/media_preview_activity__image_content_description" />
 
 </RelativeLayout>

--- a/res/layout/media_preview_item.xml
+++ b/res/layout/media_preview_item.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <org.thoughtcrime.securesms.components.ZoomingImageView
+        android:id="@+id/image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/media_preview_activity__image_content_description" />
+
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1232,6 +1232,7 @@
 
     <!-- MediaPreviewActivity -->
     <string name="MediaPreviewActivity_you">You</string>
+    <string name="MediaPreviewActivity_draft">Draft</string>
     <string name="MediaPreviewActivity_cant_display">Failed to preview this image</string>
     <string name="MediaPreviewActivity_unssuported_media_type">Unsupported media type</string>
 

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -540,6 +540,7 @@ public class ConversationItem extends LinearLayout
         intent.setDataAndType(slide.getUri(), slide.getContentType());
         if (!messageRecord.isOutgoing()) intent.putExtra(MediaPreviewActivity.RECIPIENT_EXTRA, recipient.getRecipientId());
         intent.putExtra(MediaPreviewActivity.DATE_EXTRA, messageRecord.getTimestamp());
+        intent.putExtra(MediaPreviewActivity.THREAD_ID_EXTRA, messageRecord.getThreadId());
 
         context.startActivity(intent);
       } else {

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -538,8 +538,6 @@ public class ConversationItem extends LinearLayout
         Intent intent = new Intent(context, MediaPreviewActivity.class);
         intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         intent.setDataAndType(slide.getUri(), slide.getContentType());
-        if (!messageRecord.isOutgoing()) intent.putExtra(MediaPreviewActivity.RECIPIENT_EXTRA, recipient.getRecipientId());
-        intent.putExtra(MediaPreviewActivity.DATE_EXTRA, messageRecord.getTimestamp());
         intent.putExtra(MediaPreviewActivity.THREAD_ID_EXTRA, messageRecord.getThreadId());
 
         context.startActivity(intent);

--- a/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
+++ b/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
@@ -41,6 +41,7 @@ public class ImageMediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
   private static final String TAG = ImageMediaAdapter.class.getSimpleName();
 
   private final MasterSecret masterSecret;
+  private final long         threadId;
 
   public static class ViewHolder extends RecyclerView.ViewHolder {
     public ThumbnailView imageView;
@@ -51,9 +52,10 @@ public class ImageMediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
     }
   }
 
-  public ImageMediaAdapter(Context context, MasterSecret masterSecret, Cursor c) {
+  public ImageMediaAdapter(Context context, MasterSecret masterSecret, Cursor c, long threadId) {
     super(context, c);
     this.masterSecret = masterSecret;
+    this.threadId     = threadId;
   }
 
   @Override
@@ -87,6 +89,7 @@ public class ImageMediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
     public void onClick(View v) {
       Intent intent = new Intent(getContext(), MediaPreviewActivity.class);
       intent.putExtra(MediaPreviewActivity.DATE_EXTRA, imageRecord.getDate());
+      intent.putExtra(MediaPreviewActivity.THREAD_ID_EXTRA, threadId);
 
       if (!TextUtils.isEmpty(imageRecord.getAddress())) {
         Recipients recipients = RecipientFactory.getRecipientsFromString(getContext(),

--- a/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
+++ b/src/org/thoughtcrime/securesms/ImageMediaAdapter.java
@@ -88,17 +88,7 @@ public class ImageMediaAdapter extends CursorRecyclerViewAdapter<ViewHolder> {
     @Override
     public void onClick(View v) {
       Intent intent = new Intent(getContext(), MediaPreviewActivity.class);
-      intent.putExtra(MediaPreviewActivity.DATE_EXTRA, imageRecord.getDate());
       intent.putExtra(MediaPreviewActivity.THREAD_ID_EXTRA, threadId);
-
-      if (!TextUtils.isEmpty(imageRecord.getAddress())) {
-        Recipients recipients = RecipientFactory.getRecipientsFromString(getContext(),
-                                                                         imageRecord.getAddress(),
-                                                                         true);
-        if (recipients != null && recipients.getPrimaryRecipient() != null) {
-          intent.putExtra(MediaPreviewActivity.RECIPIENT_EXTRA, recipients.getPrimaryRecipient().getRecipientId());
-        }
-      }
       intent.setDataAndType(imageRecord.getAttachment().getDataUri(), imageRecord.getContentType());
       getContext().startActivity(intent);
 

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -215,7 +215,7 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity i
   @Override
   public void onLoadFinished(Loader<Cursor> cursorLoader, Cursor cursor) {
     Log.w(TAG, "onLoadFinished()");
-    gridView.setAdapter(new ImageMediaAdapter(this, masterSecret, cursor));
+    gridView.setAdapter(new ImageMediaAdapter(this, masterSecret, cursor, threadId));
     noImages.setVisibility(gridView.getAdapter().getItemCount() > 0 ? View.GONE : View.VISIBLE);
     invalidateOptionsMenu();
   }

--- a/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaOverviewActivity.java
@@ -41,10 +41,10 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.CursorRecyclerViewAdapter;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
 import org.thoughtcrime.securesms.database.ImageDatabase.ImageRecord;
+import org.thoughtcrime.securesms.database.loaders.ThreadMediaLoader;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.Recipient.RecipientModifiedListener;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
-import org.thoughtcrime.securesms.util.AbstractCursorLoader;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask;
 import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
@@ -223,19 +223,5 @@ public class MediaOverviewActivity extends PassphraseRequiredActionBarActivity i
   @Override
   public void onLoaderReset(Loader<Cursor> cursorLoader) {
     ((CursorRecyclerViewAdapter)gridView.getAdapter()).changeCursor(null);
-  }
-
-  public static class ThreadMediaLoader extends AbstractCursorLoader {
-    private final long threadId;
-
-    public ThreadMediaLoader(Context context, long threadId) {
-      super(context);
-      this.threadId = threadId;
-    }
-
-    @Override
-    public Cursor getCursor() {
-      return DatabaseFactory.getImageDatabase(getContext()).getImagesForThread(threadId);
-    }
   }
 }

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -73,7 +73,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
   private long                  date;
   private List<ImageRecord>     imageRecords;
   private List<Uri>             images;
-  private boolean               draftMode;
 
   @Override
   protected void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
@@ -106,22 +105,17 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void initializeActionBar() {
-    if (draftMode) {
-      getSupportActionBar().setTitle(getString(R.string.MediaPreviewActivity_you));
-      getSupportActionBar().setSubtitle(R.string.MediaPreviewActivity_draft);
+    final CharSequence relativeTimeSpan;
+    if (date > 0) {
+      relativeTimeSpan = DateUtils.getRelativeTimeSpanString(date,
+                                                             System.currentTimeMillis(),
+                                                             DateUtils.MINUTE_IN_MILLIS);
     } else {
-      final CharSequence relativeTimeSpan;
-      if (date > 0) {
-        relativeTimeSpan = DateUtils.getRelativeTimeSpanString(date,
-                System.currentTimeMillis(),
-                DateUtils.MINUTE_IN_MILLIS);
-      } else {
-        relativeTimeSpan = null;
-      }
-      getSupportActionBar().setTitle(recipient == null ? getString(R.string.MediaPreviewActivity_you)
-                                                       : recipient.toShortString());
-      getSupportActionBar().setSubtitle(relativeTimeSpan);
+      relativeTimeSpan = getString(R.string.MediaPreviewActivity_draft);
     }
+    getSupportActionBar().setTitle(recipient == null ? getString(R.string.MediaPreviewActivity_you)
+                                                     : recipient.toShortString());
+    getSupportActionBar().setSubtitle(relativeTimeSpan);
   }
 
   @Override
@@ -152,7 +146,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
     this.threadId  = getIntent().getLongExtra(THREAD_ID_EXTRA, -1);
     this.mediaUri  = getIntent().getData();
     this.mediaType = getIntent().getType();
-    this.draftMode = (this.threadId == -1);
   }
 
   private void initializeMedia() {
@@ -162,13 +155,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
       finish();
     }
 
-    if (draftMode) {
-      this.images = new ArrayList<>(0);
-      images.add(mediaUri);
-      initializeViewPagerAdapter();
-    } else {
-      getSupportLoaderManager().initLoader(0,null,MediaPreviewActivity.this);
-    }
+    getSupportLoaderManager().initLoader(0,null,MediaPreviewActivity.this);
   }
 
   private void initializeViewPager() {
@@ -237,7 +224,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public void onPageSelected(int position) {
-    if (!draftMode) updateResources(position);
+    updateResources(position);
     initializeActionBar();
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -24,6 +24,8 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -55,7 +57,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
   private MasterSecret masterSecret;
 
-  private ZoomingImageView  image;
+  private ViewPager         viewPager;
   private Uri               mediaUri;
   private String            mediaType;
   private Recipient         recipient;
@@ -74,8 +76,9 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     setContentView(R.layout.media_preview_activity);
 
-    initializeViews();
     initializeResources();
+    initializeMedia();
+    initializeViewPager();
     initializeActionBar();
   }
 
@@ -110,7 +113,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     super.onResume();
     dynamicLanguage.onResume(this);
     if (recipient != null) recipient.addListener(this);
-    initializeMedia();
   }
 
   @Override
@@ -127,10 +129,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     setIntent(intent);
     initializeResources();
     initializeActionBar();
-  }
-
-  private void initializeViews() {
-    image = (ZoomingImageView)findViewById(R.id.image);
   }
 
   private void initializeResources() {
@@ -154,16 +152,15 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
       Toast.makeText(getApplicationContext(), R.string.MediaPreviewActivity_unssuported_media_type, Toast.LENGTH_LONG).show();
       finish();
     }
+  }
 
-    Log.w(TAG, "Loading Part URI: " + mediaUri);
-
-    if (mediaType != null && mediaType.startsWith("image/")) {
-      image.setImageUri(masterSecret, mediaUri);
-    }
+  private void initializeViewPager() {
+    this.viewPager = (ViewPager) findViewById(R.id.viewPager);
+    viewPager.setAdapter(new MediaPreviewAdapter(MediaPreviewActivity.this,masterSecret,mediaUri));
   }
 
   private void cleanupMedia() {
-    image.setImageDrawable(null);
+    viewPager.setAdapter(null);
   }
 
   private void saveToDisk() {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -51,6 +51,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   private final static String TAG = MediaPreviewActivity.class.getSimpleName();
 
   public static final String RECIPIENT_EXTRA = "recipient";
+  public static final String THREAD_ID_EXTRA = "thread_id";
   public static final String DATE_EXTRA      = "date";
 
   private final DynamicLanguage dynamicLanguage = new DynamicLanguage();
@@ -61,6 +62,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   private Uri               mediaUri;
   private String            mediaType;
   private Recipient         recipient;
+  private long              threadId;
   private long              date;
 
   @Override
@@ -137,6 +139,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     mediaUri     = getIntent().getData();
     mediaType    = getIntent().getType();
     date         = getIntent().getLongExtra(DATE_EXTRA, System.currentTimeMillis());
+    threadId     = getIntent().getLongExtra(THREAD_ID_EXTRA, -1);
 
     if (recipientId > -1) {
       recipient = RecipientFactory.getRecipientForId(this, recipientId, true);

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -26,7 +26,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.view.ViewPager;
+import android.support.v4.view.ViewPager.OnPageChangeListener;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -53,8 +53,7 @@ import java.util.List;
  * Activity for displaying media attachments in-app
  */
 public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
-                                  implements RecipientModifiedListener,
-                                             ViewPager.OnPageChangeListener {
+                                  implements RecipientModifiedListener, OnPageChangeListener {
   private final static String TAG = MediaPreviewActivity.class.getSimpleName();
 
   public static final String THREAD_ID_EXTRA = "thread_id";
@@ -63,13 +62,13 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   private MasterSecret masterSecret;
 
-  private ViewPager         viewPager;
-  private Uri               mediaUri;
-  private String            mediaType;
-  private Recipient         recipient;
-  private long              threadId;
-  private long              date;
-  private List<ImageRecord> imageRecords;
+  private MediaPreviewViewPager viewPager;
+  private Uri                   mediaUri;
+  private String                mediaType;
+  private Recipient             recipient;
+  private long                  threadId;
+  private long                  date;
+  private List<ImageRecord>     imageRecords;
 
   @Override
   protected void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
@@ -154,9 +153,10 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   private void initializeViewPager() {
     this.imageRecords = getImageRecords(getApplicationContext(), threadId);
-    this.viewPager    = (ViewPager) findViewById(R.id.viewPager);
+    this.viewPager    = (MediaPreviewViewPager) findViewById(R.id.viewPager);
     viewPager.setAdapter(new MediaPreviewAdapter(MediaPreviewActivity.this,masterSecret,imageRecords));
     viewPager.addOnPageChangeListener(this);
+
     int startPosition = getImagePosition(mediaUri);
     viewPager.setCurrentItem(startPosition);
     if (startPosition == 0) onPageSelected(0);
@@ -207,7 +207,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   @Override
   public void onPageSelected(int position) {
-    System.out.println("onPageSelected("+position+")");
     updateResources(position);
     initializeActionBar();
   }

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -151,7 +151,11 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
       finish();
     }
 
-    getSupportLoaderManager().initLoader(0,null,MediaPreviewActivity.this);
+    if (threadId > -1) {
+      getSupportLoaderManager().initLoader(0,null,MediaPreviewActivity.this);
+    } else {
+      initializeViewPagerAdapter();
+    }
   }
 
   private void initializeViewPager() {
@@ -172,6 +176,11 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
       Toast.makeText(getApplicationContext(), R.string.MediaPreviewActivity_cant_display, Toast.LENGTH_LONG).show();
       finish();
     }
+  }
+
+  private void initializeViewPagerAdapter() {
+    viewPager.setAdapter(new MediaPreviewDraftAdapter(masterSecret,this,mediaUri,mediaType));
+    onPageSelected(0);
   }
 
   private void cleanupMedia() {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -161,9 +161,9 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void initializeViewPagerAdapter(Cursor cursor) {
-    viewPager.setAdapter(new MediaPreviewAdapter(MediaPreviewActivity.this,masterSecret,cursor));
+    viewPager.setAdapter(new MediaPreviewThreadAdapter(MediaPreviewActivity.this,masterSecret,cursor));
 
-    int startPosition = ((MediaPreviewAdapter) viewPager.getAdapter()).getImagePosition(mediaUri);
+    int startPosition = ((MediaPreviewThreadAdapter) viewPager.getAdapter()).getImagePosition(mediaUri);
     viewPager.setCurrentItem(startPosition);
     if (startPosition == 0) {
       onPageSelected(0);
@@ -247,7 +247,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void updateResources(int position) {
-    ImageRecord imageRecord = ((MediaPreviewAdapter) viewPager.getAdapter()).getImageAtPosition(position);
+    ImageRecord imageRecord = ((MediaPreviewThreadAdapter) viewPager.getAdapter()).getImageAtPosition(position);
     this.mediaUri           = imageRecord.getAttachment().getDataUri();
     this.mediaType          = imageRecord.getAttachment().getContentType();
     this.date               = imageRecord.getDate();

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -169,6 +169,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity
 
   private void initializeViewPager() {
     this.viewPager    = (MediaPreviewViewPager) findViewById(R.id.viewPager);
+    viewPager.setOffscreenPageLimit(2);
     viewPager.setAdapter(new MediaPreviewAdapter(MediaPreviewActivity.this,masterSecret,images));
     viewPager.addOnPageChangeListener(this);
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -18,16 +18,17 @@ package org.thoughtcrime.securesms;
 
 import android.app.Activity;
 import android.content.Context;
-import android.net.Uri;
 import android.support.v4.view.PagerAdapter;
-import android.support.v4.view.ViewPager;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.ImageView;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.ImageDatabase.ImageRecord;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Adapter for providing a ViewPager with all images of a thread
@@ -35,17 +36,17 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 public class MediaPreviewAdapter extends PagerAdapter {
   private final Context      context;
   private final MasterSecret masterSecret;
-  private final Uri          mediaUri;
+  private List<ImageRecord>  imageRecords;
 
-  public MediaPreviewAdapter(Context context, MasterSecret masterSecret, Uri mediaUri) {
+  public MediaPreviewAdapter(Context context, MasterSecret masterSecret, List<ImageRecord> imageRecords) {
     this.context      = context;
     this.masterSecret = masterSecret;
-    this.mediaUri     = mediaUri;
+    this.imageRecords = imageRecords;
   }
 
   @Override
   public int getCount() {
-    return 3;
+    return imageRecords.size();
   }
 
   @Override
@@ -53,7 +54,7 @@ public class MediaPreviewAdapter extends PagerAdapter {
     LayoutInflater   inflater  = ((Activity)context).getLayoutInflater();
     View             viewItem  = inflater.inflate(R.layout.media_preview_item, container, false);
     ZoomingImageView imageView = (ZoomingImageView) viewItem.findViewById(R.id.image);
-    imageView.setImageUri(masterSecret, mediaUri);
+    imageView.setImageUri(masterSecret, imageRecords.get(position).getAttachment().getDataUri());
     container.addView(viewItem);
 
     return viewItem;

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Context;
+import android.net.Uri;
+import android.support.v4.view.PagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+
+import org.thoughtcrime.securesms.components.ZoomingImageView;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+
+/**
+ * Adapter for providing a ViewPager with all images of a thread
+ */
+public class MediaPreviewAdapter extends PagerAdapter {
+  private final Context      context;
+  private final MasterSecret masterSecret;
+  private final Uri          mediaUri;
+
+  public MediaPreviewAdapter(Context context, MasterSecret masterSecret, Uri mediaUri) {
+    this.context      = context;
+    this.masterSecret = masterSecret;
+    this.mediaUri     = mediaUri;
+  }
+
+  @Override
+  public int getCount() {
+    return 3;
+  }
+
+  @Override
+  public Object instantiateItem(ViewGroup container, int position) {
+    LayoutInflater   inflater  = ((Activity)context).getLayoutInflater();
+    View             viewItem  = inflater.inflate(R.layout.media_preview_item, container, false);
+    ZoomingImageView imageView = (ZoomingImageView) viewItem.findViewById(R.id.image);
+    imageView.setImageUri(masterSecret, mediaUri);
+    container.addView(viewItem);
+
+    return viewItem;
+  }
+
+  @Override
+  public boolean isViewFromObject(View view, Object object) {
+    return view == object;
+  }
+
+  @Override
+  public void destroyItem(ViewGroup container, int position, Object object) {
+    container.removeView((View) object);
+  }
+}

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -24,19 +24,20 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView;
+import org.thoughtcrime.securesms.components.ZoomingImageView.OnScaleChangedListener;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.ImageDatabase.ImageRecord;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Adapter for providing a ViewPager with all images of a thread
  */
 public class MediaPreviewAdapter extends PagerAdapter {
-  private final Context      context;
-  private final MasterSecret masterSecret;
-  private List<ImageRecord>  imageRecords;
+  private final Context          context;
+  private final MasterSecret     masterSecret;
+  private List<ImageRecord>      imageRecords;
+  private OnScaleChangedListener scaleChangedListener;
 
   public MediaPreviewAdapter(Context context, MasterSecret masterSecret, List<ImageRecord> imageRecords) {
     this.context      = context;
@@ -54,7 +55,9 @@ public class MediaPreviewAdapter extends PagerAdapter {
     LayoutInflater   inflater  = ((Activity)context).getLayoutInflater();
     View             viewItem  = inflater.inflate(R.layout.media_preview_item, container, false);
     ZoomingImageView imageView = (ZoomingImageView) viewItem.findViewById(R.id.image);
+
     imageView.setImageUri(masterSecret, imageRecords.get(position).getAttachment().getDataUri());
+    imageView.setOnScaleChangedListener(scaleChangedListener);
     container.addView(viewItem);
 
     return viewItem;
@@ -68,5 +71,9 @@ public class MediaPreviewAdapter extends PagerAdapter {
   @Override
   public void destroyItem(ViewGroup container, int position, Object object) {
     container.removeView((View) object);
+  }
+
+  public void setOnScaleChangedListener(OnScaleChangedListener scaleChangedListener) {
+    this.scaleChangedListener = scaleChangedListener;
   }
 }

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -49,7 +49,7 @@ public class MediaPreviewAdapter extends CursorPagerAdapter {
     LayoutInflater   inflater    = ((Activity)context).getLayoutInflater();
     View             viewItem    = inflater.inflate(R.layout.media_preview_item, container, false);
     ZoomingImageView imageView   = (ZoomingImageView) viewItem.findViewById(R.id.image);
-    ImageRecord      imageRecord = ImageRecord.from(getCursorAtPositionOrThrow(position));
+    ImageRecord      imageRecord = ImageRecord.from(getCursorAtPositionOrThrow(reverse(position)));
 
     imageView.setImageUri(masterSecret, imageRecord.getAttachment().getDataUri());
     imageView.setOnScaleChangedListener(scaleChangedListener);
@@ -78,14 +78,18 @@ public class MediaPreviewAdapter extends CursorPagerAdapter {
         break;
       }
     }
-    return imagePosition;
+    return reverse(imagePosition);
   }
 
   public ImageRecord getImageAtPosition(int position) {
-    return ImageRecord.from(getCursorAtPositionOrThrow(position));
+    return ImageRecord.from(getCursorAtPositionOrThrow(reverse(position)));
   }
 
   public void setOnScaleChangedListener(OnScaleChangedListener scaleChangedListener) {
     this.scaleChangedListener = scaleChangedListener;
+  }
+
+  private int reverse(int position) {
+    return getCount()-1-position;
   }
 }

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -27,7 +27,6 @@ import android.view.ViewGroup;
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.components.ZoomingImageView.OnScaleChangedListener;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
-import org.thoughtcrime.securesms.database.ImageDatabase.ImageRecord;
 
 import java.util.List;
 
@@ -71,6 +70,7 @@ public class MediaPreviewAdapter extends PagerAdapter {
 
   @Override
   public void destroyItem(ViewGroup container, int position, Object object) {
+    ((ZoomingImageView) ((View) object).findViewById(R.id.image)).cleanupPhotoViewAttacher();
     container.removeView((View) object);
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -18,6 +18,7 @@ package org.thoughtcrime.securesms;
 
 import android.app.Activity;
 import android.content.Context;
+import android.net.Uri;
 import android.support.v4.view.PagerAdapter;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -36,18 +37,18 @@ import java.util.List;
 public class MediaPreviewAdapter extends PagerAdapter {
   private final Context          context;
   private final MasterSecret     masterSecret;
-  private List<ImageRecord>      imageRecords;
+  private List<Uri>              images;
   private OnScaleChangedListener scaleChangedListener;
 
-  public MediaPreviewAdapter(Context context, MasterSecret masterSecret, List<ImageRecord> imageRecords) {
+  public MediaPreviewAdapter(Context context, MasterSecret masterSecret, List<Uri> images) {
     this.context      = context;
     this.masterSecret = masterSecret;
-    this.imageRecords = imageRecords;
+    this.images       = images;
   }
 
   @Override
   public int getCount() {
-    return imageRecords.size();
+    return images.size();
   }
 
   @Override
@@ -56,7 +57,7 @@ public class MediaPreviewAdapter extends PagerAdapter {
     View             viewItem  = inflater.inflate(R.layout.media_preview_item, container, false);
     ZoomingImageView imageView = (ZoomingImageView) viewItem.findViewById(R.id.image);
 
-    imageView.setImageUri(masterSecret, imageRecords.get(position).getAttachment().getDataUri());
+    imageView.setImageUri(masterSecret, images.get(position));
     imageView.setOnScaleChangedListener(scaleChangedListener);
     container.addView(viewItem);
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Context;
+import android.net.Uri;
+import android.support.v4.view.PagerAdapter;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import org.thoughtcrime.securesms.MediaPreviewActivity.MediaPreviewAdapter;
+import org.thoughtcrime.securesms.MediaPreviewActivity.MediaPreviewItem;
+import org.thoughtcrime.securesms.components.ZoomingImageView;
+import org.thoughtcrime.securesms.components.ZoomingImageView.OnScaleChangedListener;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+
+/**
+ * Adapter for providing a ViewPager with a draft image
+ */
+public class MediaPreviewDraftAdapter extends PagerAdapter implements MediaPreviewAdapter {
+
+  private final MasterSecret masterSecret;
+  private final Context      context;
+  private final Uri          uri;
+  private final String       type;
+  private final long         date    = 0L;
+  private final String       address = null;
+
+  private OnScaleChangedListener scaleChangedListener;
+
+  public MediaPreviewDraftAdapter(MasterSecret masterSecret, Context context, Uri uri, String type) {
+    this.masterSecret = masterSecret;
+    this.context      = context;
+    this.uri          = uri;
+    this.type         = type;
+  }
+
+  @Override
+  public Object instantiateItem(ViewGroup container, int position) {
+    LayoutInflater   inflater  = ((Activity)context).getLayoutInflater();
+    View             viewItem  = inflater.inflate(R.layout.media_preview_item, container, false);
+    ZoomingImageView imageView = (ZoomingImageView) viewItem.findViewById(R.id.image);
+
+    imageView.setImageUri(masterSecret, uri);
+    imageView.setOnScaleChangedListener(scaleChangedListener);
+    container.addView(viewItem);
+
+    return viewItem;
+  }
+
+  @Override
+  public boolean isViewFromObject(View view, Object object) {
+    return view == object;
+  }
+
+  @Override
+  public void destroyItem(ViewGroup container, int position, Object object) {
+    ((ZoomingImageView) ((View) object).findViewById(R.id.image)).cleanupPhotoViewAttacher();
+    container.removeView((View) object);
+  }
+
+  @Override
+  public MediaPreviewItem getItem(int position) {
+    return new MediaPreviewItem(uri, type, date, address);
+  }
+
+  @Override
+  public void setOnScaleChangedListener(OnScaleChangedListener scaleChangedListener) {
+    this.scaleChangedListener = scaleChangedListener;
+  }
+
+  @Override
+  public int getMediaPosition(Uri uri) {
+    return 0;
+  }
+
+  @Override
+  public int getCount() {
+    return 1;
+  }
+}

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -29,11 +29,14 @@ import org.thoughtcrime.securesms.components.ZoomingImageView.OnScaleChangedList
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.CursorPagerAdapter;
 import org.thoughtcrime.securesms.database.ImageDatabase.ImageRecord;
+import org.thoughtcrime.securesms.MediaPreviewActivity.MediaPreviewAdapter;
+import org.thoughtcrime.securesms.MediaPreviewActivity.MediaPreviewItem;
 
 /**
  * Adapter for providing a ViewPager with all images of a thread
  */
-public class MediaPreviewThreadAdapter extends CursorPagerAdapter {
+public class MediaPreviewThreadAdapter extends    CursorPagerAdapter
+                                       implements MediaPreviewAdapter {
   private final Context          context;
   private final MasterSecret     masterSecret;
   private OnScaleChangedListener scaleChangedListener;
@@ -69,7 +72,17 @@ public class MediaPreviewThreadAdapter extends CursorPagerAdapter {
     container.removeView((View) object);
   }
 
-  public int getImagePosition(Uri uri) {
+  @Override
+  public MediaPreviewItem getItem(int position) {
+    ImageRecord imageRecord = ImageRecord.from(getCursorAtPositionOrThrow(reverse(position)));
+    return new MediaPreviewItem(imageRecord.getAttachment().getDataUri(),
+                                imageRecord.getContentType(),
+                                imageRecord.getDate(),
+                                imageRecord.getAddress());
+  }
+
+  @Override
+  public int getMediaPosition(Uri uri) {
     int imagePosition = -1;
     for (int i = 0; i < getCount(); i++) {
       Uri dataUri = ImageRecord.from(getCursorAtPositionOrThrow(i)).getAttachment().getDataUri();
@@ -81,10 +94,7 @@ public class MediaPreviewThreadAdapter extends CursorPagerAdapter {
     return reverse(imagePosition);
   }
 
-  public ImageRecord getImageAtPosition(int position) {
-    return ImageRecord.from(getCursorAtPositionOrThrow(reverse(position)));
-  }
-
+  @Override
   public void setOnScaleChangedListener(OnScaleChangedListener scaleChangedListener) {
     this.scaleChangedListener = scaleChangedListener;
   }

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -33,12 +33,12 @@ import org.thoughtcrime.securesms.database.ImageDatabase.ImageRecord;
 /**
  * Adapter for providing a ViewPager with all images of a thread
  */
-public class MediaPreviewAdapter extends CursorPagerAdapter {
+public class MediaPreviewThreadAdapter extends CursorPagerAdapter {
   private final Context          context;
   private final MasterSecret     masterSecret;
   private OnScaleChangedListener scaleChangedListener;
 
-  public MediaPreviewAdapter(Context context, MasterSecret masterSecret, Cursor cursor) {
+  public MediaPreviewThreadAdapter(Context context, MasterSecret masterSecret, Cursor cursor) {
     super(cursor);
     this.context      = context;
     this.masterSecret = masterSecret;

--- a/src/org/thoughtcrime/securesms/MediaPreviewViewPager.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewViewPager.java
@@ -51,7 +51,7 @@ public class MediaPreviewViewPager extends ViewPager {
     }
   }
 
-  public void setAdapter(MediaPreviewAdapter adapter) {
+  public void setAdapter(MediaPreviewThreadAdapter adapter) {
     if (adapter != null) adapter.setOnScaleChangedListener(new ScaleChangedListener());
     super.setAdapter(adapter);
   }

--- a/src/org/thoughtcrime/securesms/MediaPreviewViewPager.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewViewPager.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.content.Context;
+import android.support.v4.view.ViewPager;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+
+import org.thoughtcrime.securesms.components.ZoomingImageView.OnScaleChangedListener;
+
+/**
+ * ViewPager allowing to temporarily disable paging
+ */
+public class MediaPreviewViewPager extends ViewPager {
+  private boolean pagingEnabled = true;
+
+  public MediaPreviewViewPager(Context context) {
+    super(context);
+  }
+
+  public MediaPreviewViewPager(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  @Override
+  public boolean onTouchEvent(MotionEvent event) {
+    return this.pagingEnabled && super.onTouchEvent(event);
+  }
+
+  @Override
+  public boolean onInterceptTouchEvent(MotionEvent event) {
+    try {
+      return this.pagingEnabled && super.onInterceptTouchEvent(event);
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public void setAdapter(MediaPreviewAdapter adapter) {
+    if (adapter != null) adapter.setOnScaleChangedListener(new ScaleChangedListener());
+    super.setAdapter(adapter);
+  }
+
+  private class ScaleChangedListener implements OnScaleChangedListener {
+    @Override
+    public void onScaleChanged(float scale) {
+      pagingEnabled = (scale == 1.0);
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/MediaPreviewViewPager.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewViewPager.java
@@ -17,11 +17,13 @@
 package org.thoughtcrime.securesms;
 
 import android.content.Context;
+import android.support.v4.view.PagerAdapter;
 import android.support.v4.view.ViewPager;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView.OnScaleChangedListener;
+import org.thoughtcrime.securesms.MediaPreviewActivity.MediaPreviewAdapter;
 
 /**
  * ViewPager allowing to temporarily disable paging
@@ -51,8 +53,8 @@ public class MediaPreviewViewPager extends ViewPager {
     }
   }
 
-  public void setAdapter(MediaPreviewThreadAdapter adapter) {
-    if (adapter != null) adapter.setOnScaleChangedListener(new ScaleChangedListener());
+  public void setAdapter(PagerAdapter adapter) {
+    if (adapter != null) ((MediaPreviewAdapter) adapter).setOnScaleChangedListener(new ScaleChangedListener());
     super.setAdapter(adapter);
   }
 

--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.components;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.graphics.RectF;
 import android.net.Uri;
 import android.util.AttributeSet;
 import android.widget.ImageView;
@@ -16,9 +17,11 @@ import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.mms.DecryptableStreamUriLoader.DecryptableUri;
 
 import uk.co.senab.photoview.PhotoViewAttacher;
+import uk.co.senab.photoview.PhotoViewAttacher.OnMatrixChangedListener;
 
 public class ZoomingImageView extends ImageView {
-  private PhotoViewAttacher attacher = new PhotoViewAttacher(this);
+  private PhotoViewAttacher      attacher;
+  private OnScaleChangedListener scaleChangedListener;
 
   public ZoomingImageView(Context context) {
     super(context);
@@ -33,6 +36,8 @@ public class ZoomingImageView extends ImageView {
   }
 
   public void setImageUri(MasterSecret masterSecret, Uri uri) {
+    attacher = new PhotoViewAttacher(this);
+    attacher.setOnMatrixChangeListener(new MatrixChangedListener());
     Glide.with(getContext())
          .load(new DecryptableUri(masterSecret, uri))
          .diskCacheStrategy(DiskCacheStrategy.NONE)
@@ -44,5 +49,21 @@ public class ZoomingImageView extends ImageView {
              attacher.update();
            }
          });
+  }
+
+  private class MatrixChangedListener implements OnMatrixChangedListener {
+    public void onMatrixChanged(RectF rectf) {
+      if (scaleChangedListener != null) {
+        scaleChangedListener.onScaleChanged(attacher != null ? attacher.getScale() : -1);
+      }
+    }
+  }
+
+  public void setOnScaleChangedListener(OnScaleChangedListener scaleChangedListener) {
+    this.scaleChangedListener = scaleChangedListener;
+  }
+
+  public interface OnScaleChangedListener {
+    void onScaleChanged(float scale);
   }
 }

--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -20,7 +20,7 @@ import uk.co.senab.photoview.PhotoViewAttacher;
 import uk.co.senab.photoview.PhotoViewAttacher.OnMatrixChangedListener;
 
 public class ZoomingImageView extends ImageView {
-  private PhotoViewAttacher      attacher;
+  private PhotoViewAttacher      attacher = new PhotoViewAttacher(this);
   private OnScaleChangedListener scaleChangedListener;
 
   public ZoomingImageView(Context context) {
@@ -36,7 +36,6 @@ public class ZoomingImageView extends ImageView {
   }
 
   public void setImageUri(MasterSecret masterSecret, Uri uri) {
-    attacher = new PhotoViewAttacher(this);
     attacher.setOnMatrixChangeListener(new MatrixChangedListener());
     Glide.with(getContext())
          .load(new DecryptableUri(masterSecret, uri))
@@ -61,6 +60,10 @@ public class ZoomingImageView extends ImageView {
 
   public void setOnScaleChangedListener(OnScaleChangedListener scaleChangedListener) {
     this.scaleChangedListener = scaleChangedListener;
+  }
+
+  public void cleanupPhotoViewAttacher() {
+    attacher.cleanup();
   }
 
   public interface OnScaleChangedListener {

--- a/src/org/thoughtcrime/securesms/database/CursorPagerAdapter.java
+++ b/src/org/thoughtcrime/securesms/database/CursorPagerAdapter.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (C) 2016 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.database;
+
+import android.database.Cursor;
+import android.database.DataSetObserver;
+import android.support.annotation.NonNull;
+import android.support.v4.view.PagerAdapter;
+
+/**
+ * PagerAdapter that manages a Cursor, adapted from CursorRecyclerViewAdapter.
+ */
+public abstract class CursorPagerAdapter extends PagerAdapter {
+  private final DataSetObserver observer = new AdapterDataSetObserver();
+
+  private Cursor  cursor;
+  private boolean valid;
+
+  protected CursorPagerAdapter(Cursor cursor) {
+    this.cursor = cursor;
+    if (cursor != null) {
+      valid = true;
+      cursor.registerDataSetObserver(observer);
+    }
+  }
+
+  public void changeCursor(Cursor cursor) {
+    Cursor old = swapCursor(cursor);
+    if (old != null) {
+      old.close();
+    }
+  }
+
+  public Cursor swapCursor(Cursor newCursor) {
+    if (newCursor == cursor) {
+      return null;
+    }
+
+    final Cursor oldCursor = cursor;
+    if (oldCursor != null) {
+      oldCursor.unregisterDataSetObserver(observer);
+    }
+
+    cursor = newCursor;
+    if (cursor != null) {
+      cursor.registerDataSetObserver(observer);
+    }
+
+    valid = cursor != null;
+    notifyDataSetChanged();
+    return oldCursor;
+  }
+
+  @Override
+  public int getCount() {
+    if (!isActiveCursor()) return 0;
+
+    return cursor.getCount();
+  }
+
+  protected @NonNull Cursor getCursorAtPositionOrThrow(final int position) {
+    if (!isActiveCursor()) {
+      throw new IllegalStateException("this should only be called when the cursor is valid");
+    }
+    if (!cursor.moveToPosition(position)) {
+      throw new IllegalStateException("couldn't move cursor to position " + position);
+    }
+    return cursor;
+  }
+
+  private boolean isActiveCursor() {
+    return valid && cursor != null;
+  }
+
+  private class AdapterDataSetObserver extends DataSetObserver {
+    @Override
+    public void onChanged() {
+      super.onChanged();
+      valid = true;
+      notifyDataSetChanged();
+    }
+
+    @Override
+    public void onInvalidated() {
+      super.onInvalidated();
+      valid = false;
+      notifyDataSetChanged();
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/database/loaders/ThreadMediaLoader.java
+++ b/src/org/thoughtcrime/securesms/database/loaders/ThreadMediaLoader.java
@@ -1,0 +1,21 @@
+package org.thoughtcrime.securesms.database.loaders;
+
+import android.content.Context;
+import android.database.Cursor;
+
+import org.thoughtcrime.securesms.database.DatabaseFactory;
+import org.thoughtcrime.securesms.util.AbstractCursorLoader;
+
+public class ThreadMediaLoader extends AbstractCursorLoader {
+  private final long threadId;
+
+  public ThreadMediaLoader(Context context, long threadId) {
+    super(context);
+    this.threadId = threadId;
+  }
+
+  @Override
+  public Cursor getCursor() {
+    return DatabaseFactory.getImageDatabase(getContext()).getImagesForThread(threadId);
+  }
+}


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Sony Xperia U, Android 4.4.4
  - AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

---
### Description

I added a ViewPager to `MediaPreviewActivity`. It shows all images of a thread and allows swipe gestures to navigate between images. The information in the action bar (recipient & date) is updated accordingly.
I also implemented a "paging lock": when an image is zoomed in, paging is disabled.
Further image draft previews introduced in https://github.com/WhisperSystems/Signal-Android/commit/e79ee7803fea85ec999e0f6dc803fc1227096cd0 are still supported. Those are handled differently and allow no swipe gestures as there can only be one image draft per thread. And as drafts are not integrated in `MediaOverviewActivity` either, I wanted to achieve consistency by not adding them to the thread gallery in `MediaPreviewActivity`.

The appearance of `MediaPreviewActivity` did not change. Just for image draft previews the sent date is replaced by "Draft" (see screenshot)

Fixes #2355.
// FREEBIE
### Screenshots (outdated as of 2016-10-30)

![device-2016-10-23-154246](https://cloud.githubusercontent.com/assets/16167751/19626696/74caf760-9937-11e6-9eea-5c7e01caff65.png)
