### PR TITLE
Improve #3990

### DIFF
--- a/src/org/thoughtcrime/securesms/PassphraseActivity.java
+++ b/src/org/thoughtcrime/securesms/PassphraseActivity.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.IBinder;
+import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.service.KeyCachingService;
@@ -57,10 +58,16 @@ public abstract class PassphraseActivity extends BaseActionBarActivity {
         cleanup();
 
         Intent nextIntent = getIntent().getParcelableExtra("next_intent");
-        if (nextIntent != null) startActivity(nextIntent);
+        if (nextIntent != null) {
+            try {
+                startActivity(nextIntent);
+            } catch (java.lang.SecurityException e) {
+                Log.w("PassphraseActivity",
+                        "Access permission not passed from PassphraseActivity, retry sharing.");
+            }
+        }
         finish();
       }
-
       @Override
       public void onServiceDisconnected(ComponentName name) {
         keyCachingService = null;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
  - Virtual Device Nexus 5X, Android 7.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

By catching the crash Signal remains unlocked. The user can quickly
retry sharing from the previous app and it will work, rather than crashing again until the user returns to the home screen and unlocks Signal.

Since this issue occurs rarely (passphrase used, Signal not unlocked, media shared to Signal), I believe the simplest thing that could be called a fix might be to send a Toast informing the user that they should try sharing again.

This commit is just catching the crash, not sending a Toast. Comments appreciated, I'm interested in solving this issue and contributing more to Signal.

// FREEBIE
