### PR TITLE
Threshold for alarming notifications

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
+++ b/src/org/thoughtcrime/securesms/notifications/MessageNotifier.java
@@ -38,21 +38,17 @@ import android.text.TextUtils;
 import android.text.style.StyleSpan;
 import android.util.Log;
 
-import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.ConversationActivity;
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.DatabaseFactory;
-import org.thoughtcrime.securesms.database.MessagingDatabase;
 import org.thoughtcrime.securesms.database.MessagingDatabase.MarkedMessageInfo;
-import org.thoughtcrime.securesms.database.MessagingDatabase.SyncMessageId;
 import org.thoughtcrime.securesms.database.MmsSmsDatabase;
 import org.thoughtcrime.securesms.database.PushDatabase;
 import org.thoughtcrime.securesms.database.SmsDatabase;
 import org.thoughtcrime.securesms.database.ThreadDatabase;
 import org.thoughtcrime.securesms.database.model.MediaMmsMessageRecord;
 import org.thoughtcrime.securesms.database.model.MessageRecord;
-import org.thoughtcrime.securesms.jobs.MultiDeviceReadUpdateJob;
 import org.thoughtcrime.securesms.mms.SlideDeck;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientFactory;
@@ -349,7 +345,7 @@ public class MessageNotifier {
         body.setSpan(new StyleSpan(android.graphics.Typeface.ITALIC), 0, body.length(), Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
         if (!recipients.isMuted()) {
-          notificationState.addNotification(new NotificationItem(recipient, recipients, null, threadId, body, 0, null));
+          notificationState.addNotification(new NotificationItem(recipient, recipients, null, threadId, body, 0, 0, null));
         }
       }
     } finally {
@@ -377,6 +373,7 @@ public class MessageNotifier {
       Recipients   threadRecipients = null;
       SlideDeck    slideDeck        = null;
       long         timestamp        = record.getTimestamp();
+      long         received         = record.getDateReceived();
       
 
       if (threadId != -1) {
@@ -396,7 +393,7 @@ public class MessageNotifier {
       }
 
       if (threadRecipients == null || !threadRecipients.isMuted()) {
-        notificationState.addNotification(new NotificationItem(recipient, recipients, threadRecipients, threadId, body, timestamp, slideDeck));
+        notificationState.addNotification(new NotificationItem(recipient, recipients, threadRecipients, threadId, body, timestamp, received, slideDeck));
       }
     }
 

--- a/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationItem.java
@@ -21,12 +21,13 @@ public class NotificationItem {
   private final long                        threadId;
   private final @Nullable CharSequence      text;
   private final long                        timestamp;
+  private final long                        received;
   private final @Nullable SlideDeck         slideDeck;
 
   public NotificationItem(@NonNull   Recipient individualRecipient,
                           @NonNull   Recipients recipients,
                           @Nullable  Recipients threadRecipients,
-                          long threadId, @Nullable CharSequence text, long timestamp,
+                          long threadId, @Nullable CharSequence text, long timestamp, long received,
                           @Nullable SlideDeck slideDeck)
   {
     this.individualRecipient = individualRecipient;
@@ -35,6 +36,7 @@ public class NotificationItem {
     this.text                = text;
     this.threadId            = threadId;
     this.timestamp           = timestamp;
+    this.received            = received;
     this.slideDeck           = slideDeck;
   }
 
@@ -52,6 +54,10 @@ public class NotificationItem {
 
   public long getTimestamp() {
     return timestamp;
+  }
+
+  public long getReceived() {
+    return received;
   }
 
   public long getThreadId() {


### PR DESCRIPTION
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

---
### Description

With this PR a notification only has an alarm if the previously received message in that conversation was received more than 4 seconds ago.
I chose to make this a per conversation threshold to account for different notification settings per contact.

Fixes #3165

//FREBBIE
