### PR TITLE
Giphy: "No results found." --> "Nothing found"

### DIFF
--- a/res/layout/giphy_fragment.xml
+++ b/res/layout/giphy_fragment.xml
@@ -17,7 +17,7 @@
                  android:indeterminate="true"/>
 
     <TextView android:id="@+id/no_results"
-              android:text="@string/giphy_fragment__no_matches"
+              android:text="@string/giphy_fragment__nothing_found"
               android:gravity="center"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"

--- a/res/layout/giphy_fragment.xml
+++ b/res/layout/giphy_fragment.xml
@@ -17,7 +17,7 @@
                  android:indeterminate="true"/>
 
     <TextView android:id="@+id/no_results"
-              android:text="@string/giphy_fragment__no_matches_found"
+              android:text="@string/giphy_fragment__no_matches"
               android:gravity="center"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"

--- a/res/layout/giphy_fragment.xml
+++ b/res/layout/giphy_fragment.xml
@@ -17,7 +17,7 @@
                  android:indeterminate="true"/>
 
     <TextView android:id="@+id/no_results"
-              android:text="@string/giphy_fragment__no_results_found"
+              android:text="@string/giphy_fragment__no_matches_found"
               android:gravity="center"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -763,7 +763,7 @@
     <string name="giphy_activity_toolbar__search_gifs_and_stickers">Search GIFs and stickers</string>
 
     <!-- giphy_fragment -->
-    <string name="giphy_fragment__no_results_found">No results found.</string>
+    <string name="giphy_fragment__no_matches_found">No matches found.</string>
 
 
     <!-- log_submit_activity -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -763,7 +763,7 @@
     <string name="giphy_activity_toolbar__search_gifs_and_stickers">Search GIFs and stickers</string>
 
     <!-- giphy_fragment -->
-    <string name="giphy_fragment__no_matches_found">No matches found.</string>
+    <string name="giphy_fragment__no_matches">No matches</string>
 
 
     <!-- log_submit_activity -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -763,7 +763,7 @@
     <string name="giphy_activity_toolbar__search_gifs_and_stickers">Search GIFs and stickers</string>
 
     <!-- giphy_fragment -->
-    <string name="giphy_fragment__no_matches">No matches</string>
+    <string name="giphy_fragment__nothing_found">Nothing found</string>
 
 
     <!-- log_submit_activity -->


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)
### Contributor checklist

<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
  - Device A, Android X.Y.Z
  - Device B, Android Z.Y
  - Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

---
### Description

<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Maybe it's just me and I'm splitting hairs, but I don't think that "No results found." makes much sense.

In such a case, there is a "result" of the search, and that result is the fact that no "matches" were found.

Thus, I'm changing the string to

**"No matches found."**

Edit: Changed to **"Nothing found"**

// FREEBIE
