### PR TITLE
Add forward button to MediaPreview

### DIFF
--- a/res/menu/media_preview.xml
+++ b/res/menu/media_preview.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item android:id="@+id/media_preview__forward"
+          android:title="@string/media_preview__forward_title"
+          android:icon="@drawable/ic_forward_white_24dp"
+          app:showAsAction="always"/>
     <item android:id="@+id/save"
           android:title="@string/media_preview__save_title"
           android:icon="@drawable/ic_save_white_24dp"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1237,6 +1237,7 @@
 
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>
+    <string name="media_preview__forward_title">Forward</string>
 
     <!-- media_overview -->
     <string name="media_overview__save_all">Save all</string>

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -166,6 +166,13 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     image.setImageDrawable(null);
   }
 
+  private void forward() {
+    Intent composeIntent = new Intent(this, ShareActivity.class);
+    composeIntent.putExtra(Intent.EXTRA_STREAM, mediaUri);
+    composeIntent.setType(mediaType);
+    startActivity(composeIntent);
+  }
+
   private void saveToDisk() {
     SaveAttachmentTask.showWarningDialog(this, new DialogInterface.OnClickListener() {
       @Override
@@ -192,8 +199,9 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     super.onOptionsItemSelected(item);
 
     switch (item.getItemId()) {
-    case R.id.save:         saveToDisk(); return true;
-    case android.R.id.home: finish();     return true;
+      case R.id.media_preview__forward: forward();    return true;
+      case R.id.save:                   saveToDisk(); return true;
+      case android.R.id.home:           finish();     return true;
     }
 
     return false;


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This PR adds a forward button to the media preview. The code for the action is adapted from `ConversationFragment`'s [`handleForwardMessage()`](https://github.com/WhisperSystems/Signal-Android/blob/b54a271a753fd31dcea77e258e5df5188f1da156/src/org/thoughtcrime/securesms/ConversationFragment.java#L332).

This PR is slightly related to #4906.

// FREEBIE

### Screenshots
![device-2016-11-03-000406](https://cloud.githubusercontent.com/assets/16167751/19950874/a76e4a8e-a15a-11e6-9a52-5d6d95f897a9.png)
![device-2016-11-03-000433](https://cloud.githubusercontent.com/assets/16167751/19950873/a76a3ee4-a15a-11e6-86e3-7583143c6c30.png)