### PR TITLE
Lower memory consumption of Giphy browser

### DIFF
--- a/src/org/thoughtcrime/securesms/giph/ui/GiphyAdapter.java
+++ b/src/org/thoughtcrime/securesms/giph/ui/GiphyAdapter.java
@@ -46,7 +46,6 @@ public class GiphyAdapter extends RecyclerView.Adapter<GiphyAdapter.GiphyViewHol
 
     GiphyViewHolder(View view) {
       super(view);
-      super.setIsRecyclable(false);
       thumbnail   = ViewUtil.findById(view, R.id.thumbnail);
       gifProgress = ViewUtil.findById(view, R.id.gif_progress);
       thumbnail.setOnClickListener(this);
@@ -155,6 +154,12 @@ public class GiphyAdapter extends RecyclerView.Adapter<GiphyAdapter.GiphyViewHol
            .listener(holder)
            .into(holder.thumbnail);
     }
+  }
+
+  @Override
+  public void onViewRecycled(GiphyViewHolder holder) {
+    super.onViewRecycled(holder);
+    Glide.clear(holder.thumbnail);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/giph/ui/GiphyAdapter.java
+++ b/src/org/thoughtcrime/securesms/giph/ui/GiphyAdapter.java
@@ -46,6 +46,7 @@ public class GiphyAdapter extends RecyclerView.Adapter<GiphyAdapter.GiphyViewHol
 
     GiphyViewHolder(View view) {
       super(view);
+      super.setIsRecyclable(false);
       thumbnail   = ViewUtil.findById(view, R.id.thumbnail);
       gifProgress = ViewUtil.findById(view, R.id.gif_progress);
       thumbnail.setOnClickListener(this);


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 6.0
 * AVD Nexus 5X, Android 5.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
First of all: showing multiple GIFs is very memory consuming. On Android they are loaded into memory as bitmap and this needs much memory (and causes e.g. this oblong discussion #672).

Nevertheless we want to do some caching and keep GIFs we once downloaded for a while. RecyclerView attempts to accomplish caching for us. It holds views to be reused later (scroll upwards). Then the view showing the GIF can be recycled (loaded from memory cache). But doing this in memory with the bitmaps is not a good idea as they are rather large. We should perform another way of caching.

There is also Glide which we use to load the GIFs into the RecyclerView. It also offers to cache images (the GIFs itself, I assume, not the large bitmaps). Glide offers to do this caching on disk instead of in memory. This alone should be sufficient for our purpose.

tl;dr
So **this PR marks the GIF views as not recyclable**. So RecyclerView doesn't cache them in memory for later reuse. But the GIFs are still on disk so that they don't have to be downloaded every time we scroll by them. This caching was already implemented before.

Memory consumption (with all GIFs loaded/animated):

- before: 95-150MB
- after: 70-100MB, sometimes up to 110MB because of a lazy GC, I suppose

Fixes #5831