### PR TITLE
Show all phone numbers of Signal contacts on search

### DIFF
--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -164,8 +164,9 @@ public class ContactsDatabase {
       put(LABEL_COLUMN, ContactsContract.CommonDataKinds.Phone.LABEL);
     }};
 
-    String excludeSelection = ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " NOT IN (" +
-        "SELECT data.contact_id FROM raw_contacts, view_data data WHERE raw_contacts._id = data.raw_contact_id AND " +
+    String excludeSelection = ContactsContract.CommonDataKinds.Phone.NUMBER + " NOT IN (" +
+        "SELECT data." + ContactsContract.CommonDataKinds.Phone.NUMBER +
+        " FROM raw_contacts, view_data data WHERE raw_contacts._id = data.raw_contact_id AND " +
         "data.mimetype = '" + CONTACT_MIMETYPE + "')";
 
     String fallbackSelection = ContactsContract.Data.SYNC2 + " IS NULL OR " + ContactsContract.Data.SYNC2 + " != '" + SYNC + "'";

--- a/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsDatabase.java
@@ -135,7 +135,7 @@ public class ContactsDatabase {
     return addedNumbers;
   }
 
-  @NonNull Cursor querySystemContacts(String filter) {
+  @NonNull Cursor querySystemContacts(String filter, boolean filterNonPushContacts) {
     Uri uri;
 
     if (!TextUtils.isEmpty(filter)) {
@@ -164,10 +164,17 @@ public class ContactsDatabase {
       put(LABEL_COLUMN, ContactsContract.CommonDataKinds.Phone.LABEL);
     }};
 
-    String excludeSelection = ContactsContract.CommonDataKinds.Phone.NUMBER + " NOT IN (" +
-        "SELECT data." + ContactsContract.CommonDataKinds.Phone.NUMBER +
-        " FROM raw_contacts, view_data data WHERE raw_contacts._id = data.raw_contact_id AND " +
-        "data.mimetype = '" + CONTACT_MIMETYPE + "')";
+    String excludeSelection;
+    if (filterNonPushContacts) {
+      excludeSelection = ContactsContract.CommonDataKinds.Phone.CONTACT_ID + " NOT IN (" +
+                         "SELECT data.contact_id FROM raw_contacts, view_data data WHERE raw_contacts._id = data.raw_contact_id AND " +
+                         "data.mimetype = '" + CONTACT_MIMETYPE + "')";
+    } else {
+      excludeSelection = ContactsContract.CommonDataKinds.Phone.NUMBER + " NOT IN (" +
+                         "SELECT data." + ContactsContract.CommonDataKinds.Phone.NUMBER +
+                         " FROM raw_contacts, view_data data WHERE raw_contacts._id = data.raw_contact_id AND " +
+                         "data.mimetype = '" + CONTACT_MIMETYPE + "')";
+    }
 
     String fallbackSelection = ContactsContract.Data.SYNC2 + " IS NULL OR " + ContactsContract.Data.SYNC2 + " != '" + SYNC + "'";
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 6.0 (EDIT 2016-11-14)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This PR makes secondary phone numbers of Signal contacts visible in contact search. Contact search is accessed at several places inside the app. These are:

- `NewConversationActivity`: conversation list -> hit pencil button
- `GroupCreateActivity`: group conversation -> menu -> update group -> "+"
conversation list -> menu -> create group -> "+"
- `InviteActivity`: conversation list -> menu -> invite friends -> choose contacts

There are several types of contacts that have to be distinguished:

- Signal contacts, which only have Signal registered numbers associated (primary numbers)
- semi-Signal contacts, which have Signal registered numbers and ones that are not registered (secondary numbers)
- non-Signal contacts

This PR affects the visibility of those secondary numbers in `NewConversationActivity` and `GroupCreateActivity`. It doesn't affect `InviteActivity` (see screenshots).

number | NewConversation | GroupCreateActivity | Invite
-----------|------------------------|---------------------------|-----------
Signal reg. primary | x | x | o
Signal reg. secondary | x (before: o) | x (before: o) | o
non-Signal contact no. | x | x | x

Fixes #5311 
// FREEBIE

### Commit description
The first commit fixes the contact list in `NewConversationActivity`. But it also has the effect that the secondary numbers of Signal users are shown in `InviteActivity`.
The second commit uses the old query for `InviteActivity` and the new one for `NewConversationActivity`. That means secondary numbers of Signal users are no more shown in `InviteActivity` (as before). Contact filtering is then completely moved to the database queries. The method `filterNonPushContacts(...)` was redundant before and is not useful afterwards either.

### Screenshots before
![device-2016-11-13-143633](https://cloud.githubusercontent.com/assets/16167751/20246138/f35fd878-a9b0-11e6-9db2-0476837b4cee.png)
![device-2016-11-13-143653](https://cloud.githubusercontent.com/assets/16167751/20246139/f3612642-a9b0-11e6-8569-12984fb7d27f.png)
### Screenshots after
![device-2016-11-13-143148](https://cloud.githubusercontent.com/assets/16167751/20246141/f36102de-a9b0-11e6-8a0d-94184cccb5c6.png)
![device-2016-11-13-143218](https://cloud.githubusercontent.com/assets/16167751/20246140/f3612c78-a9b0-11e6-8404-c9f8dc5a1145.png)
