### PR TITLE
Hide linked devices preference for unregistered users

### DIFF
--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -149,6 +149,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
       super.onResume();
       ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.text_secure_normal__menu_settings);
       setCategorySummaries();
+      setCategoryVisibility();
     }
 
     private void setCategorySummaries() {
@@ -162,6 +163,13 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
           .setSummary(AppearancePreferenceFragment.getSummary(getActivity()));
       this.findPreference(PREFERENCE_CATEGORY_CHATS)
           .setSummary(ChatsPreferenceFragment.getSummary(getActivity()));
+    }
+
+    private void setCategoryVisibility() {
+      Preference devicePreference = this.findPreference(PREFERENCE_CATEGORY_DEVICES);
+      if (devicePreference != null && !TextSecurePreferences.isPushRegistered(getActivity())) {
+        getPreferenceScreen().removePreference(devicePreference);
+      }
     }
 
     private class CategoryClickListener implements Preference.OnPreferenceClickListener {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
If a user of the Signal app is not a push user, the "Linked devices" preference will be hidden. It won't be just disabled (which means greyed out), but the menu entry won't exist at all.

Fixes #4860
// FREEBIE