### PR TITLE
Get the automated tests up and running again

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,7 @@ dependencies {
     androidTestCompile ('org.assertj:assertj-core:1.7.1') {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'
     }
-    androidTestCompile ('com.squareup.assertj:assertj-android:1.0.0') {
+    androidTestCompile ('com.squareup.assertj:assertj-android:1.1.1') {
         exclude group: 'org.hamcrest',        module: 'hamcrest-core'
         exclude group: 'com.android.support', module: 'support-annotations'
     }
@@ -215,6 +215,7 @@ android {
                           'proguard-shortcutbadger.pro',
                           'proguard-retrofit.pro',
                           'proguard.cfg'
+            testProguardFiles 'proguard-automation.pro'
         }
         release {
             minifyEnabled true

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -21,6 +21,7 @@ import android.database.Cursor;
 import android.support.annotation.LayoutRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -39,7 +40,6 @@ import org.thoughtcrime.securesms.database.model.MessageRecord;
 import org.thoughtcrime.securesms.recipients.Recipients;
 import org.thoughtcrime.securesms.util.LRUCache;
 import org.thoughtcrime.securesms.util.ViewUtil;
-import org.thoughtcrime.securesms.util.VisibleForTesting;
 
 import java.lang.ref.SoftReference;
 import java.security.MessageDigest;

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -24,6 +24,7 @@ import android.database.sqlite.SQLiteOpenHelper;
 import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.Pair;
@@ -41,7 +42,6 @@ import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.util.MediaUtil;
 import org.thoughtcrime.securesms.util.MediaUtil.ThumbnailData;
 import org.thoughtcrime.securesms.util.Util;
-import org.thoughtcrime.securesms.util.VisibleForTesting;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -151,6 +151,7 @@ public class AttachmentDatabase extends Database {
     notifyConversationListeners(DatabaseFactory.getMmsDatabase(context).getThreadIdForMessage(mmsId));
   }
 
+  @VisibleForTesting
   public @Nullable DatabaseAttachment getAttachment(AttachmentId attachmentId) {
     SQLiteDatabase database = databaseHelper.getReadableDatabase();
     Cursor cursor           = null;

--- a/src/org/thoughtcrime/securesms/database/CanonicalAddressDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/CanonicalAddressDatabase.java
@@ -23,6 +23,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteDatabase.CursorFactory;
 import android.database.sqlite.SQLiteOpenHelper;
 import android.support.annotation.NonNull;
+import android.support.annotation.VisibleForTesting;
 import android.telephony.PhoneNumberUtils;
 import android.text.TextUtils;
 import android.util.Log;
@@ -35,7 +36,6 @@ import com.google.i18n.phonenumbers.ShortNumberInfo;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.thoughtcrime.securesms.util.ShortCodeUtil;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
-import org.thoughtcrime.securesms.util.VisibleForTesting;
 import org.whispersystems.signalservice.api.util.InvalidNumberException;
 import org.whispersystems.signalservice.api.util.PhoneNumberFormatter;
 

--- a/src/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
+++ b/src/org/thoughtcrime/securesms/database/CursorRecyclerViewAdapter.java
@@ -21,12 +21,11 @@ import android.database.Cursor;
 import android.database.DataSetObserver;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.RecyclerView.ViewHolder;
 import android.view.View;
 import android.view.ViewGroup;
-
-import org.thoughtcrime.securesms.util.VisibleForTesting;
 
 /**
  * RecyclerView.Adapter that manages a Cursor, comparable to the CursorAdapter usable in ListView/GridView.

--- a/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/AttachmentDownloadJob.java
@@ -1,6 +1,7 @@
 package org.thoughtcrime.securesms.jobs;
 
 import android.content.Context;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -17,7 +18,6 @@ import org.thoughtcrime.securesms.events.PartProgressEvent;
 import org.thoughtcrime.securesms.jobs.requirements.MasterSecretRequirement;
 import org.thoughtcrime.securesms.jobs.requirements.MediaNetworkRequirement;
 import org.thoughtcrime.securesms.notifications.MessageNotifier;
-import org.thoughtcrime.securesms.util.VisibleForTesting;
 import org.whispersystems.jobqueue.JobParameters;
 import org.whispersystems.jobqueue.requirements.NetworkRequirement;
 import org.whispersystems.libsignal.InvalidMessageException;

--- a/src/org/thoughtcrime/securesms/service/SmsListener.java
+++ b/src/org/thoughtcrime/securesms/service/SmsListener.java
@@ -24,6 +24,7 @@ import android.os.Bundle;
 import android.provider.Telephony;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.telephony.SmsMessage;
 import android.util.Log;
 
@@ -31,7 +32,6 @@ import org.thoughtcrime.securesms.ApplicationContext;
 import org.thoughtcrime.securesms.jobs.SmsReceiveJob;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
-import org.thoughtcrime.securesms.util.VisibleForTesting;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/src/org/thoughtcrime/securesms/util/VisibleForTesting.java
+++ b/src/org/thoughtcrime/securesms/util/VisibleForTesting.java
@@ -1,4 +1,0 @@
-package org.thoughtcrime.securesms.util;
-
-public @interface VisibleForTesting {
-}

--- a/test/androidTest/java/org/thoughtcrime/securesms/TextSecureTestCase.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/TextSecureTestCase.java
@@ -6,7 +6,7 @@ import android.test.InstrumentationTestCase;
 public class TextSecureTestCase extends InstrumentationTestCase {
 
   @Override
-  public void setUp() throws Exception {
+  public void setUp() {
     System.setProperty("dexmaker.dexcache", getInstrumentation().getTargetContext().getCacheDir().getPath());
   }
 

--- a/test/androidTest/java/org/thoughtcrime/securesms/database/AttachmentDatabaseTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/database/AttachmentDatabaseTest.java
@@ -29,6 +29,7 @@ public class AttachmentDatabaseTest extends TextSecureTestCase {
 
   @Override
   public void setUp() {
+    super.setUp();
     database = spy(DatabaseFactory.getAttachmentDatabase(getInstrumentation().getTargetContext()));
   }
 

--- a/test/androidTest/java/org/thoughtcrime/securesms/database/CanonicalAddressDatabaseTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/database/CanonicalAddressDatabaseTest.java
@@ -16,7 +16,8 @@ public class CanonicalAddressDatabaseTest extends TextSecureTestCase {
 
   private CanonicalAddressDatabase db;
 
-  public void setUp() throws Exception {
+  @Override
+  public void setUp() {
     super.setUp();
     this.db = CanonicalAddressDatabase.getInstance(getInstrumentation().getTargetContext());
   }

--- a/test/unitTest/java/org/thoughtcrime/securesms/jobs/DeliveryReceiptJobTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/jobs/DeliveryReceiptJobTest.java
@@ -45,6 +45,7 @@ public class DeliveryReceiptJobTest extends BaseUnitTest {
     assertTrue(captor.getValue().getNumber().equals("+14152222222"));
   }
 
+  @Test
   public void testNetworkError() throws IOException {
     SignalServiceMessageSender textSecureMessageSender = mock(SignalServiceMessageSender.class);
     long                    timestamp               = System.currentTimeMillis();


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Virtual device, Android 6.0 (Emulator only, since it's just automated tests)
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

* Fix the build.gradle file
* Use the correct VisibleForTesting class
* Fix the Android test setUp() logic
* Enable a test in DeliveryReceiptJobTest.java where the @Test anotation was missing

It should be noted that the tests in AttachmentDatabaseTest.java fail.

Fixes #3474


Thanks to @haffenloher for pointing out an issue with an earlier version of the commit. :smile: 