### PR TITLE
Use singular form for per-conversation safety numbers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.2.2'
         classpath files('libs/gradle-witness.jar')
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.1.3'
         classpath files('libs/gradle-witness.jar')
     }
 }

--- a/res/menu/verify_identity.xml
+++ b/res/menu/verify_identity.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
       xmlns:app="http://schemas.android.com/apk/res-auto" >
     <item android:id="@+id/verify_identity__share"
-          android:title="@string/verify_identity__share_safety_numbers"
+          android:title="@string/verify_identity__share_safety_number"
           android:icon="@drawable/ic_share_white_24dp"
           app:showAsAction="ifRoom" />
 </menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -74,13 +74,8 @@
     <string name="CallScreen_Incoming_call">Incoming call</string>
 
     <!-- ConfirmIdentityDialog -->
-    <string name="ConfirmIdentityDialog_the_signature_on_this_key_exchange_is_different">The
-        safety numbers for %1$s have changed. This could either mean that someone is trying to
-        intercept your communication, or that %2$s simply re-installed Signal.
-    </string>
-    <string name="ConfirmIdentityDialog_you_may_wish_to_verify_this_contact">You may wish to verify
-        safety numbers for this contact.
-    </string>
+    <string name="ConfirmIdentityDialog_your_safety_numbers_with_s_have_changed">Your safety numbers with %1$s have changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply reinstalled Signal.</string>
+    <string name="ConfirmIdentityDialog_you_may_wish_to_verify_your_safety_numbers_with_this_contact">You may wish to verify your safety numbers with this contact.</string>
     <string name="ConfirmIdentityDialog_accept">Accept</string>
 
     <!-- ContactsDatabase -->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -74,8 +74,8 @@
     <string name="CallScreen_Incoming_call">Incoming call</string>
 
     <!-- ConfirmIdentityDialog -->
-    <string name="ConfirmIdentityDialog_your_safety_numbers_with_s_have_changed">Your safety numbers with %1$s have changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply reinstalled Signal.</string>
-    <string name="ConfirmIdentityDialog_you_may_wish_to_verify_your_safety_numbers_with_this_contact">You may wish to verify your safety numbers with this contact.</string>
+    <string name="ConfirmIdentityDialog_your_safety_number_with_s_has_changed">Your safety number with %1$s has changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply reinstalled Signal.</string>
+    <string name="ConfirmIdentityDialog_you_may_wish_to_verify_your_safety_number_with_this_contact">You may wish to verify your safety number with this contact.</string>
     <string name="ConfirmIdentityDialog_accept">Accept</string>
 
     <!-- ContactsDatabase -->
@@ -357,7 +357,7 @@
 
     <!-- MessageDetailsRecipient -->
     <string name="MessageDetailsRecipient_failed_to_send">Failed to send</string>
-    <string name="MessageDetailsRecipient_new_safety_numbers">New safety numbers</string>
+    <string name="MessageDetailsRecipient_new_safety_number">New safety number</string>
 
     <!-- MmsDownloader -->
     <string name="MmsDownloader_error_storing_mms">Error storing MMS!</string>
@@ -388,7 +388,7 @@
     <string name="MessageRecord_s_is_on_signal_say_hey">%s is on Signal, say hey!</string>
     <string name="MessageRecord_you_set_disappearing_message_time_to_s">You set disappearing message time to %1$s.</string>
     <string name="MessageRecord_s_set_disappearing_message_time_to_s">%1$s set disappearing message time to %2$s.</string>
-    <string name="MessageRecord_your_safety_numbers_with_s_have_changed">Your safety numbers with %s have changed</string>
+    <string name="MessageRecord_your_safety_number_with_s_has_changed">Your safety number with %s has changed.</string>
 
 
     <!-- PassphraseChangeActivity -->
@@ -539,7 +539,7 @@
     <string name="SmsMessageRecord_received_key_exchange_message_for_invalid_protocol_version">
         Received key exchange message for invalid protocol version.
     </string>
-    <string name="SmsMessageRecord_received_message_with_new_safety_numbers_tap_to_process">Received message with new safety numbers. Tap to process and display.</string>
+    <string name="SmsMessageRecord_received_message_with_new_safety_number_tap_to_process">Received message with new safety number. Tap to process and display.</string>
     <string name="SmsMessageRecord_secure_session_reset">You reset the secure session.</string>
     <string name="SmsMessageRecord_secure_session_reset_s">%s reset the secure session.</string>
     <string name="SmsMessageRecord_duplicate_message">Duplicate message.</string>
@@ -554,17 +554,16 @@
     <string name="ThreadRecord_media_message">Media message</string>
     <string name="ThreadRecord_s_is_on_signal_say_hey">%s is on Signal, say hey!</string>
     <string name="ThreadRecord_disappearing_message_time_updated_to_s">Disappearing message time set to %s</string>
-    <string name="ThreadRecord_your_safety_numbers_with_s_have_changed">Your safety numbers with %s have changed</string>
+    <string name="ThreadRecord_your_safety_number_with_s_has_changed">Your safety number with %s has changed.</string>
 
     <!-- VerifyIdentityActivity -->
-    <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">Your contact is running an old version of Signal, please ask them to update before verifying safety numbers.</string>
+    <string name="VerifyIdentityActivity_your_contact_is_running_an_old_version_of_signal">Your contact is running an old version of Signal, please ask them to update before verifying your safety number.</string>
     <string name="VerifyIdentityActivity_your_contact_is_running_a_newer_version_of_Signal">Your contact is running a newer version of Signal with an incompatible QR code format. Please update to compare.</string>
-    <string name="VerifyIdentityActivity_you_re_attempting_to_verify_safety_numbers_with">You\'re attempting to verify safety numbers with %1$s, but scanned %2$s instead.</string>
-    <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">The scanned QR code is not a correctly formatted safety number verification code.  Please try scanning again.</string>
-    <string name="VerifyIdentityActivity_share_safety_numbers_via">Share safety numbers via...</string>
-    <string name="VerifyIdentityActivity_our_signal_safety_numbers">Our Signal safety numbers:</string>
+    <string name="VerifyIdentityActivity_the_scanned_qr_code_is_not_a_correctly_formatted_safety_number">The scanned QR code is not a correctly formatted safety number verification code. Please try scanning again.</string>
+    <string name="VerifyIdentityActivity_share_safety_number_via">Share safety number via...</string>
+    <string name="VerifyIdentityActivity_our_signal_safety_number">Our Signal safety number:</string>
     <string name="VerifyIdentityActivity_no_app_to_share_to">It looks like you don\'t have any apps to share to.</string>
-    <string name="VerifyIdentityActivity_no_safety_numbers_to_compare_were_found_in_the_clipboard">No safety numbers to compare were found in the clipboard</string>
+    <string name="VerifyIdentityActivity_no_safety_number_to_compare_was_found_in_the_clipboard">No safety number to compare was found in the clipboard</string>
 
     <!-- KeyExchangeInitiator -->
     <string name="KeyExchangeInitiator_initiate_despite_existing_request_question">Initiate despite existing request?</string>
@@ -838,7 +837,7 @@
     <string name="recipient_preferences__block">Block</string>
     <string name="recipient_preferences__color">Color</string>
     <string name="recipient_preferences__color_for_this_contact">Color for this contact</string>
-    <string name="recipient_preferences__verify_safety_numbers">Verify safety numbers</string>
+    <string name="recipient_preferences__verify_safety_number">Verify safety number</string>
 
     <!--- redphone_call_controls -->
     <string name="redphone_call_card__signal_call">Signal Call</string>
@@ -935,11 +934,11 @@
     <string name="recipients_panel__add_members">Add members</string>
 
     <!-- verify_display_fragment -->
-    <string name="verify_display_fragment__scan_the_code_on_your_contact_s_phone_or_ask_them_to_scan_your_code_to_verify_that_your_messages_are_end_to_end_encrypted_you_can_alternately_compare_the_number_above"><![CDATA[If you wish to verify the security of your end-to-end encryption with %s, compare the numbers above with the numbers on their device. Alternately, you can scan the code on their phone, or ask them to scan your code. <a href="https://whispersystems.org/redirect/safety-numbers">Learn more about verifying safety numbers</a>.]]></string>
+    <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[If you wish to verify the security of your end-to-end encryption with %s, compare the number above with the number on their device. Alternately, you can scan the code on their phone, or ask them to scan your code. <a href="https://whispersystems.org/redirect/safety-numbers">Learn more about verifying safety numbers</a>.]]></string>
     <string name="verify_display_fragment__tap_to_scan">Tap to scan</string>
 
     <!-- verify_identity -->
-    <string name="verify_identity__share_safety_numbers">Share safety numbers</string>
+    <string name="verify_identity__share_safety_number">Share safety number</string>
     
     <!-- message_details_header -->
     <string name="message_details_header__issues_need_your_attention">Some issues need your attention.</string>
@@ -957,7 +956,7 @@
     <string name="AndroidManifest__select_contacts">Select contacts</string>
     <string name="AndroidManifest__signal_detected">Signal detected</string>
     <string name="AndroidManifest__change_passphrase">Change passphrase</string>
-    <string name="AndroidManifest__verify_safety_numbers">Verify safety numbers</string>
+    <string name="AndroidManifest__verify_safety_number">Verify safety number</string>
     <string name="AndroidManifest__log_submit">Submit debug log</string>
     <string name="AndroidManifest__media_preview">Media preview</string>
     <string name="AndroidManifest__media_overview">All images</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -934,7 +934,7 @@
     <string name="recipients_panel__add_members">Add members</string>
 
     <!-- verify_display_fragment -->
-    <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[If you wish to verify the security of your end-to-end encryption with %s, compare the number above with the number on their device. Alternately, you can scan the code on their phone, or ask them to scan your code. <a href="https://whispersystems.org/redirect/safety-numbers">Learn more about verifying safety numbers</a>.]]></string>
+    <string name="verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s"><![CDATA[If you wish to verify the security of your end-to-end encryption with %s, compare the number above with the number on their device. Alternatively, you can scan the code on their phone, or ask them to scan your code. <a href="https://whispersystems.org/redirect/safety-numbers">Learn more about verifying safety numbers</a>]]></string>
     <string name="verify_display_fragment__tap_to_scan">Tap to scan</string>
 
     <!-- verify_identity -->

--- a/res/xml/recipient_preferences.xml
+++ b/res/xml/recipient_preferences.xml
@@ -37,7 +37,7 @@
             app:numColumns="5" />
 
     <Preference android:key="pref_key_recipient_identity"
-                android:title="@string/recipient_preferences__verify_safety_numbers"
+                android:title="@string/recipient_preferences__verify_safety_number"
                 android:persistent="false"
                 android:enabled="false"/>
 

--- a/src/org/thoughtcrime/securesms/ConfirmIdentityDialog.java
+++ b/src/org/thoughtcrime/securesms/ConfirmIdentityDialog.java
@@ -50,9 +50,9 @@ public class ConfirmIdentityDialog extends AlertDialog {
     super(context);
     Recipient       recipient       = RecipientFactory.getRecipientForId(context, mismatch.getRecipientId(), false);
     String          name            = recipient.toShortString();
-    String          introduction    = String.format(context.getString(R.string.ConfirmIdentityDialog_your_safety_numbers_with_s_have_changed), name, name);
+    String          introduction    = String.format(context.getString(R.string.ConfirmIdentityDialog_your_safety_number_with_s_has_changed), name, name);
     SpannableString spannableString = new SpannableString(introduction + " " +
-                                                          context.getString(R.string.ConfirmIdentityDialog_you_may_wish_to_verify_your_safety_numbers_with_this_contact));
+                                                          context.getString(R.string.ConfirmIdentityDialog_you_may_wish_to_verify_your_safety_number_with_this_contact));
 
     spannableString.setSpan(new VerifySpan(context, mismatch),
                             introduction.length()+1, spannableString.length(),

--- a/src/org/thoughtcrime/securesms/ConfirmIdentityDialog.java
+++ b/src/org/thoughtcrime/securesms/ConfirmIdentityDialog.java
@@ -50,9 +50,9 @@ public class ConfirmIdentityDialog extends AlertDialog {
     super(context);
     Recipient       recipient       = RecipientFactory.getRecipientForId(context, mismatch.getRecipientId(), false);
     String          name            = recipient.toShortString();
-    String          introduction    = String.format(context.getString(R.string.ConfirmIdentityDialog_the_signature_on_this_key_exchange_is_different), name, name);
+    String          introduction    = String.format(context.getString(R.string.ConfirmIdentityDialog_your_safety_numbers_with_s_have_changed), name, name);
     SpannableString spannableString = new SpannableString(introduction + " " +
-                                                          context.getString(R.string.ConfirmIdentityDialog_you_may_wish_to_verify_this_contact));
+                                                          context.getString(R.string.ConfirmIdentityDialog_you_may_wish_to_verify_your_safety_numbers_with_this_contact));
 
     spannableString.setSpan(new VerifySpan(context, mismatch),
                             introduction.length()+1, spannableString.length(),

--- a/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
+++ b/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
@@ -99,7 +99,7 @@ public class MessageRecipientListItem extends RelativeLayout
       resendButton.setVisibility(View.GONE);
       conflictButton.setVisibility(View.VISIBLE);
 
-      errorText = getContext().getString(R.string.MessageDetailsRecipient_new_safety_numbers);
+      errorText = getContext().getString(R.string.MessageDetailsRecipient_new_safety_number);
       conflictButton.setOnClickListener(new OnClickListener() {
         @Override
         public void onClick(View v) {

--- a/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
+++ b/src/org/thoughtcrime/securesms/VerifyIdentityActivity.java
@@ -108,7 +108,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
   protected void onCreate(Bundle state, @NonNull MasterSecret masterSecret) {
     try {
       getSupportActionBar().setDisplayHomeAsUpEnabled(true);
-      getSupportActionBar().setTitle(R.string.AndroidManifest__verify_safety_numbers);
+      getSupportActionBar().setTitle(R.string.AndroidManifest__verify_safety_number);
 
       Recipient recipient = RecipientFactory.getRecipientForId(this, getIntent().getLongExtra(RECIPIENT_ID, -1), true);
       recipient.addListener(this);
@@ -196,17 +196,17 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
 
   private void handleShare() {
     String shareString =
-        getString(R.string.VerifyIdentityActivity_our_signal_safety_numbers) + "\n" +
+        getString(R.string.VerifyIdentityActivity_our_signal_safety_number) + "\n" +
         displayFragment.getFormattedSafetyNumbers() + "\n";
 
     Intent intent = new Intent();
     intent.setAction(Intent.ACTION_SEND);
-    intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.VerifyIdentityActivity_our_signal_safety_numbers));
+    intent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.VerifyIdentityActivity_our_signal_safety_number));
     intent.putExtra(Intent.EXTRA_TEXT, shareString);
     intent.setType("text/plain");
 
     try {
-      startActivity(Intent.createChooser(intent, getString(R.string.VerifyIdentityActivity_share_safety_numbers_via)));
+      startActivity(Intent.createChooser(intent, getString(R.string.VerifyIdentityActivity_share_safety_number_via)));
     } catch (ActivityNotFoundException e) {
       Toast.makeText(VerifyIdentityActivity.this, R.string.VerifyIdentityActivity_no_app_to_share_to, Toast.LENGTH_LONG).show();
     }
@@ -381,14 +381,14 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
       String clipboardData = Util.readTextFromClipboard(getActivity());
 
       if (clipboardData == null) {
-        Toast.makeText(getActivity(), R.string.VerifyIdentityActivity_no_safety_numbers_to_compare_were_found_in_the_clipboard, Toast.LENGTH_LONG).show();
+        Toast.makeText(getActivity(), R.string.VerifyIdentityActivity_no_safety_number_to_compare_was_found_in_the_clipboard, Toast.LENGTH_LONG).show();
         return;
       }
 
       String numericClipboardData = clipboardData.replaceAll("\\D", "");
 
       if (TextUtils.isEmpty(numericClipboardData) || numericClipboardData.length() != 60) {
-        Toast.makeText(getActivity(), R.string.VerifyIdentityActivity_no_safety_numbers_to_compare_were_found_in_the_clipboard, Toast.LENGTH_LONG).show();
+        Toast.makeText(getActivity(), R.string.VerifyIdentityActivity_no_safety_number_to_compare_was_found_in_the_clipboard, Toast.LENGTH_LONG).show();
         return;
       }
 
@@ -412,7 +412,7 @@ public class VerifyIdentityActivity extends PassphraseRequiredActionBarActivity 
       Bitmap qrCodeBitmap = QrCode.create(qrCodeString);
 
       qrCode.setImageBitmap(qrCodeBitmap);
-      description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__scan_the_code_on_your_contact_s_phone_or_ask_them_to_scan_your_code_to_verify_that_your_messages_are_end_to_end_encrypted_you_can_alternately_compare_the_number_above), recipient.toShortString())));
+      description.setText(Html.fromHtml(String.format(getActivity().getString(R.string.verify_display_fragment__if_you_wish_to_verify_the_security_of_your_end_to_end_encryption_with_s), recipient.toShortString())));
       description.setMovementMethod(LinkMovementMethod.getInstance());
     }
 

--- a/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/MessageRecord.java
@@ -113,7 +113,7 @@ public abstract class MessageRecord extends DisplayRecord {
       return isOutgoing() ? emphasisAdded(context.getString(R.string.MessageRecord_you_set_disappearing_message_time_to_s, time))
                           : emphasisAdded(context.getString(R.string.MessageRecord_s_set_disappearing_message_time_to_s, getIndividualRecipient().toShortString(), time));
     } else if (isIdentityUpdate()) {
-      return emphasisAdded(context.getString(R.string.MessageRecord_your_safety_numbers_with_s_have_changed, getIndividualRecipient().toShortString()));
+      return emphasisAdded(context.getString(R.string.MessageRecord_your_safety_number_with_s_has_changed, getIndividualRecipient().toShortString()));
     } else if (getBody().getBody().length() > MAX_DISPLAY_LENGTH) {
       return new SpannableString(getBody().getBody().substring(0, MAX_DISPLAY_LENGTH));
     }

--- a/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/SmsMessageRecord.java
@@ -75,7 +75,7 @@ public class SmsMessageRecord extends MessageRecord {
     } else if (MmsSmsColumns.Types.isLegacyType(type)) {
       return emphasisAdded(context.getString(R.string.MessageRecord_message_encrypted_with_a_legacy_protocol_version_that_is_no_longer_supported));
     } else if (isBundleKeyExchange()) {
-      return emphasisAdded(context.getString(R.string.SmsMessageRecord_received_message_with_new_safety_numbers_tap_to_process));
+      return emphasisAdded(context.getString(R.string.SmsMessageRecord_received_message_with_new_safety_number_tap_to_process));
     } else if (isKeyExchange() && isOutgoing()) {
       return new SpannableString("");
     } else if (isKeyExchange() && !isOutgoing()) {

--- a/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
+++ b/src/org/thoughtcrime/securesms/database/model/ThreadRecord.java
@@ -103,7 +103,7 @@ public class ThreadRecord extends DisplayRecord {
       String time = ExpirationUtil.getExpirationDisplayValue(context, (int) (getExpiresIn() / 1000));
       return emphasisAdded(context.getString(R.string.ThreadRecord_disappearing_message_time_updated_to_s, time));
     } else if (SmsDatabase.Types.isIdentityUpdate(type)) {
-      return emphasisAdded(context.getString(R.string.ThreadRecord_your_safety_numbers_with_s_have_changed, getRecipients().getPrimaryRecipient().toShortString()));
+      return emphasisAdded(context.getString(R.string.ThreadRecord_your_safety_number_with_s_has_changed, getRecipients().getPrimaryRecipient().toShortString()));
     } else {
       if (TextUtils.isEmpty(getBody().getBody())) {
         return new SpannableString(emphasisAdded(context.getString(R.string.ThreadRecord_media_message)));


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 7.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
- This corrects the remaining strings affected by the transition from per-user fingerprints to per-conversation Safety Numbers (as both participants of a conversation now share the same Safety Number).

- Furthermore, me and some other community members are wondering why "safety numbers" is used in its plural form ("safety numbers" vs. "safety number") in that context, as there is only 1 common Safety Number for both participants (which contains 2 encoded fingerprints/identity keys). **I'm offering to change the plural form to singular for all affected strings in an additional commit if this is desired. Please advise.**

// FREEBIE