### PR TITLE
Fixes messages sent to self (attempt 3)

### DIFF
--- a/src/org/thoughtcrime/securesms/sms/MessageSender.java
+++ b/src/org/thoughtcrime/securesms/sms/MessageSender.java
@@ -286,6 +286,10 @@ public class MessageSender {
       return false;
     }
 
+    if (TextSecurePreferences.isMultiDevice(context)) {
+      return false;
+    }
+
     return Util.isOwnNumber(context, recipients.getPrimaryRecipient().getNumber());
   }
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 4, Android 6.0.1
 * Motorola whatever, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Messages sent to self are now sent to all linked devices. Credits to gulp21 and effigies.
Fixes: #4844

Third time's a charm! Since i cannot reopen the old PR because reasons, so i open this one and go more into detail on why it works. @moxie0's objection was that this would cause Signal-Android to attempt to create sessions with itself.

However, when creating the `OutgoingPushMessageList` the messagesender [does the following](https://github.com/WhisperSystems/libsignal-service-java/blob/master/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java#L402):
```
List<OutgoingPushMessage> messages = new LinkedList<>();

if (!recipient.equals(localAddress)) {
  messages.add(getEncryptedMessage(socket, recipient, SignalServiceAddress.DEFAULT_DEVICE_ID, plaintext, legacy, silent));
}

for (int deviceId : store.getSubDeviceSessions(recipient.getNumber())) {
  messages.add(getEncryptedMessage(socket, recipient, deviceId, plaintext, legacy, silent));
}

return new OutgoingPushMessageList(recipient.getNumber(), timestamp, recipient.getRelay().orNull(), messages);
```

Currently, Signal-Android always is the master device which always has the default device-id (1).
As you see, libsignal adds messages to all slave devices (since they are in the store's subdevicesessions).
A message to the master device is added if **and only if** `!recipient.equals(localAddress)` is true, which is obviously not true if we send a message to ourself. So if we do that, only messages to our slaves are added, and we never attempt to create a session with ourselves.

I have tested this commit on my own and on several of my friends' phones, and it is working fine.
If you are worried that in the future Signal-Android's device-id may not be 1, do not worry, [here ](https://github.com/Turasa/libsignal-service-java/blob/a8a61996627b0fcebd881d189dc4da83a64d4ef2/java/src/main/java/org/whispersystems/signalservice/api/SignalServiceMessageSender.java#L434)is a fix for that which you could merge or incorporate.