### PR TITLE
FREEBIE Reintroduced the encrypted backup of messages and keys. Removed the n…

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -368,6 +368,9 @@
 
     <activity android:name="com.soundcloud.android.crop.CropImageActivity" />
 
+    <activity android:name=".ExitActivity"
+              android:theme="@android:style/Theme.NoDisplay" />
+
     <service android:enabled="true" android:name="org.thoughtcrime.redphone.RedPhoneService"/>
 
     <service android:enabled="true" android:name=".service.ApplicationMigrationService"/>

--- a/res/layout/export_fragment.xml
+++ b/res/layout/export_fragment.xml
@@ -12,14 +12,14 @@
                   android:layout_gravity="center_vertical"
                   android:padding="8dip">
 
-
-        <!--LinearLayout android:id="@+id/export_encrypted_backup"
+        <LinearLayout android:id="@+id/export_encrypted_backup"
                       android:clickable="true"
                       android:layout_width="match_parent"
                       android:layout_height="wrap_content"
                       android:layout_marginTop="10dip"
                       android:background="@drawable/clickable_card_light"
-                      android:orientation="vertical">
+                      android:orientation="vertical"
+					  android:focusable="true">
 
             <LinearLayout android:orientation="horizontal"
                           android:layout_width="wrap_content"
@@ -33,7 +33,7 @@
                 <ImageView android:layout_width="wrap_content"
                            android:layout_height="wrap_content"
                            android:layout_marginRight="10dip"
-                           android:src="@drawable/encrypted_backup"/>
+                           android:src="?encrypted_backup"/>
 
                 <LinearLayout android:orientation="vertical"
                               android:layout_width="wrap_content"
@@ -51,8 +51,7 @@
 
                 </LinearLayout>
             </LinearLayout>
-        </LinearLayout-->
-
+        </LinearLayout>
 
         <LinearLayout android:id="@+id/export_plaintext_backup"
                       android:clickable="true"

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -235,6 +235,9 @@
   <string name="ExportFragment_error_unable_to_write_to_storage">Fout, kon niet naar de opslag schrijven.</string>
   <string name="ExportFragment_error_while_writing_to_storage">Fout tijdens het schrijven naar de opslag.</string>
   <string name="ExportFragment_export_successful">Export succesvol.</string>
+  <string name="ExportFragment_export_to_sd_card">Opslaan op SD-kaart?</string>
+  <string name="ExportFragment_this_will_export_your_encrypted_keys_settings_and_messages">Dit exporteert je keys, instellingen en berichten versleuteld naar de SD-kaart</string>
+  <string name="ExportFragment_exporting_keys_settings_and_messages">Keys, instellingen en berichten versleuteld naar de SD-kaart aan het exporteren...</string>
   <!--GcmRefreshJob-->
   <string name="GcmRefreshJob_Permanent_Signal_communication_failure">Permanente Signal-communicatiefout!</string>
   <string name="GcmRefreshJob_Signal_was_unable_to_register_with_Google_Play_Services">Signal was niet in staat met Google Play services te registreren. Signal berichten en oproepen zijn nu uitgeschakeld, probeer opnieuw te registreren via Instellingen &gt; Geavanceerd.</string>
@@ -667,6 +670,8 @@ Sleuteluitwisselingsbericht ontvangen voor een verkeerde protocol-versie.</strin
   <string name="import_fragment__restore_a_previously_exported_encrypted_signal_backup">Herstel een eerder geëxporteerde versleutelde back-up van Signal</string>
   <string name="import_fragment__import_plaintext_backup">Onversleutelde back-up importeren</string>
   <string name="import_fragment__import_a_plaintext_backup_file">Importeer een onversleutelde back-up. Compatibel met \'SMS Back-up &amp; Herstellen\'.</string>
+  <string name="export_fragment__export_encrypted_backup">Exporteer Versleutelde Back-up</string>
+  <string name="export_fragment__export_an_encrypted_backup_to_the_sd_card">Export een versleutelde back-up naar de SD-kaart.</string>
   <!--load_more_header-->
   <string name="load_more_header__see_full_conversation">Bekijk volledig gesprek</string>
   <!--media_overview_activity-->

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -259,6 +259,9 @@
     <string name="ExportFragment_error_unable_to_write_to_storage">Error, unable to write to storage.</string>
     <string name="ExportFragment_error_while_writing_to_storage">Error while writing to storage.</string>
     <string name="ExportFragment_export_successful">Export successful.</string>
+    <string name="ExportFragment_export_to_sd_card">Export To SD Card?</string>
+    <string name="ExportFragment_this_will_export_your_encrypted_keys_settings_and_messages">This will export your encrypted keys, settings, and messages to the SD card.</string>
+    <string name="ExportFragment_exporting_keys_settings_and_messages">Exporting encrypted keys, settings, and messages...</string>
 
     <!-- GcmRefreshJob -->
     <string name="GcmRefreshJob_Permanent_Signal_communication_failure">Permanent Signal communication failure!</string>
@@ -792,6 +795,8 @@
     <string name="import_fragment__restore_a_previously_exported_encrypted_signal_backup">Restore a previously exported encrypted Signal backup</string>
     <string name="import_fragment__import_plaintext_backup">Import plaintext backup</string>
     <string name="import_fragment__import_a_plaintext_backup_file">Import a plaintext backup file. Compatible with \'SMS Backup &amp; Restore.\'</string>
+    <string name="export_fragment__export_encrypted_backup">Export encrypted backup</string>
+    <string name="export_fragment__export_an_encrypted_backup_to_the_sd_card">Export an encrypted backup to the SD card.</string>
 
     <!-- load_more_header -->
     <string name="load_more_header__see_full_conversation">See full conversation</string>

--- a/src/org/thoughtcrime/securesms/ExportFragment.java
+++ b/src/org/thoughtcrime/securesms/ExportFragment.java
@@ -17,6 +17,7 @@ import android.widget.Toast;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.NoExternalStorageException;
 import org.thoughtcrime.securesms.database.PlaintextBackupExporter;
+import org.thoughtcrime.securesms.database.EncryptedBackupExporter;
 
 import java.io.IOException;
 
@@ -36,15 +37,15 @@ public class ExportFragment extends Fragment {
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle bundle) {
     View layout              = inflater.inflate(R.layout.export_fragment, container, false);
-//    View exportEncryptedView = layout.findViewById(R.id.export_encrypted_backup);
+    View exportEncryptedView = layout.findViewById(R.id.export_encrypted_backup);
     View exportPlaintextView = layout.findViewById(R.id.export_plaintext_backup);
 
-//    exportEncryptedView.setOnClickListener(new View.OnClickListener() {
-//      @Override
-//      public void onClick(View v) {
-//        handleExportEncryptedBackup();
-//      }
-//    });
+    exportEncryptedView.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        handleExportEncryptedBackup();
+      }
+    });
 
     exportPlaintextView.setOnClickListener(new View.OnClickListener() {
       @Override
@@ -56,20 +57,20 @@ public class ExportFragment extends Fragment {
     return layout;
   }
 
-//  private void handleExportEncryptedBackup() {
-//    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-//    builder.setIcon(Dialogs.getDrawable(getActivity(), R.attr.dialog_info_icon));
-//    builder.setTitle(getActivity().getString(R.string.ExportFragment_export_to_sd_card));
-//    builder.setMessage(getActivity().getString(R.string.ExportFragment_this_will_export_your_encrypted_keys_settings_and_messages));
-//    builder.setPositiveButton(getActivity().getString(R.string.ExportFragment_export), new Dialog.OnClickListener() {
-//      @Override
-//      public void onClick(DialogInterface dialog, int which) {
-//        new ExportEncryptedTask().execute();
-//      }
-//    });
-//    builder.setNegativeButton(getActivity().getString(R.string.ExportFragment_cancel), null);
-//    builder.show();
-//  }
+  private void handleExportEncryptedBackup() {
+    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+    builder.setIconAttribute(R.attr.dialog_info_icon);
+    builder.setTitle(getActivity().getString(R.string.ExportFragment_export_to_sd_card));
+    builder.setMessage(getActivity().getString(R.string.ExportFragment_this_will_export_your_encrypted_keys_settings_and_messages));
+    builder.setPositiveButton(getActivity().getString(R.string.ExportFragment_export), new Dialog.OnClickListener() {
+      @Override
+      public void onClick(DialogInterface dialog, int which) {
+        new ExportEncryptedTask().execute();
+      }
+    });
+    builder.setNegativeButton(getActivity().getString(R.string.ExportFragment_cancel), null);
+    builder.show();
+  }
 
   private void handleExportPlaintextBackup() {
     AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -141,56 +142,56 @@ public class ExportFragment extends Fragment {
     }
   }
 
-//  private class ExportEncryptedTask extends AsyncTask<Void, Void, Integer> {
-//    private ProgressDialog dialog;
-//
-//    @Override
-//    protected void onPreExecute() {
-//      dialog = ProgressDialog.show(getActivity(),
-//                                   getActivity().getString(R.string.ExportFragment_exporting),
-//                                   getActivity().getString(R.string.ExportFragment_exporting_keys_settings_and_messages),
-//                                   true, false);
-//    }
-//
-//    @Override
-//    protected void onPostExecute(Integer result) {
-//      Context context = getActivity();
-//
-//      if (dialog != null) dialog.dismiss();
-//
-//      if (context == null) return;
-//
-//      switch (result) {
-//        case NO_SD_CARD:
-//          Toast.makeText(context,
-//                         context.getString(R.string.ExportFragment_error_unable_to_write_to_storage),
-//                         Toast.LENGTH_LONG).show();
-//          break;
-//        case IO_ERROR:
-//          Toast.makeText(context,
-//                         context.getString(R.string.ExportFragment_error_while_writing_to_storage),
-//                         Toast.LENGTH_LONG).show();
-//          break;
-//        case SUCCESS:
-//          Toast.makeText(context,
-//                         context.getString(R.string.ExportFragment_success),
-//                         Toast.LENGTH_LONG).show();
-//          break;
-//      }
-//    }
-//
-//    @Override
-//    protected Integer doInBackground(Void... params) {
-//      try {
-//        EncryptedBackupExporter.exportToSd(getActivity());
-//        return SUCCESS;
-//      } catch (NoExternalStorageException e) {
-//        Log.w("ExportFragment", e);
-//        return NO_SD_CARD;
-//      } catch (IOException e) {
-//        Log.w("ExportFragment", e);
-//        return IO_ERROR;
-//      }
-//    }
-//  }
+private class ExportEncryptedTask extends AsyncTask<Void, Void, Integer> {
+    private ProgressDialog dialog;
+
+    @Override
+    protected void onPreExecute() {
+      dialog = ProgressDialog.show(getActivity(),
+                                   getActivity().getString(R.string.ExportFragment_exporting),
+                                   getActivity().getString(R.string.ExportFragment_exporting_keys_settings_and_messages),
+                                   true, false);
+    }
+
+    @Override
+    protected void onPostExecute(Integer result) {
+      Context context = getActivity();
+
+      if (dialog != null) dialog.dismiss();
+
+      if (context == null) return;
+
+      switch (result) {
+        case NO_SD_CARD:
+          Toast.makeText(context,
+                         context.getString(R.string.ExportFragment_error_unable_to_write_to_storage),
+                         Toast.LENGTH_LONG).show();
+          break;
+        case IO_ERROR:
+          Toast.makeText(context,
+                         context.getString(R.string.ExportFragment_error_while_writing_to_storage),
+                         Toast.LENGTH_LONG).show();
+          break;
+        case SUCCESS:
+          Toast.makeText(context,
+                         context.getString(R.string.ExportFragment_export_successful),
+                         Toast.LENGTH_LONG).show();
+          break;
+      }
+    }
+
+    @Override
+    protected Integer doInBackground(Void... params) {
+      try {
+        EncryptedBackupExporter.exportToSd(getActivity());
+        return SUCCESS;
+      } catch (NoExternalStorageException e) {
+        Log.w("ExportFragment", e);
+        return NO_SD_CARD;
+      } catch (IOException e) {
+        Log.w("ExportFragment", e);
+        return IO_ERROR;
+      }
+    }
+  }
 }

--- a/src/org/thoughtcrime/securesms/ImportFragment.java
+++ b/src/org/thoughtcrime/securesms/ImportFragment.java
@@ -217,14 +217,16 @@ public class ImportFragment extends Fragment {
                          Toast.LENGTH_LONG).show();
           break;
         case SUCCESS:
-          DatabaseFactory.getInstance(context).reset(context);
-          Intent intent = new Intent(context, KeyCachingService.class);
-          intent.setAction(KeyCachingService.CLEAR_KEY_ACTION);
-          context.startService(intent);
+          //DatabaseFactory.getInstance(context).reset(context);
+          //Intent intent = new Intent(context, KeyCachingService.class);
+          //intent.setAction(KeyCachingService.CLEAR_KEY_ACTION);
+          //context.startService(intent);
 
-          Toast.makeText(context,
-                         context.getString(R.string.ImportFragment_restore_complete),
-                         Toast.LENGTH_LONG).show();
+          //Toast.makeText(context,
+          //               context.getString(R.string.ImportFragment_restore_complete),
+          //               Toast.LENGTH_LONG).show();
+          // JW: Just restart
+          ExitActivity.exitAndRemoveFromRecentApps(getActivity());
       }
     }
 

--- a/src/org/thoughtcrime/securesms/database/EncryptedBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/EncryptedBackupExporter.java
@@ -87,7 +87,10 @@ public class EncryptedBackupExporter {
       for (int i=0;i<contents.length;i++) {
         File localFile = contents[i];
 
-        if (localFile.isFile()) {
+        if ( localFile.getAbsolutePath().contains("libcurve25519.so") ||
+             localFile.getAbsolutePath().contains("libnative-utils.so") ||
+             localFile.getAbsolutePath().contains("libredphone-audio.so") ) {
+        } else if (localFile.isFile()) {        
           File exportedFile = new File(exportDirectory.getAbsolutePath() + File.separator + localFile.getName());
           migrateFile(localFile, exportedFile);
         } else {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony XPeria Z1 Compact, Android 4.4.4
 * Acer Z205, Android 4.4.2

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Reintroduced the encrypted backup of messages and keys. I prevented the native libraries from getting backupped because they will give problems when restoring between different versions or architectures. Signal now needs a restart after restoring an encrypted backup, this was far easier to implement than figuring out which data had to be reinitialized.
-->
