### PR TITLE
Fix the content description of the audio record button

### DIFF
--- a/res/layout/conversation_input_panel.xml
+++ b/res/layout/conversation_input_panel.xml
@@ -65,7 +65,7 @@
                         android:layout_gravity="bottom"
                         android:src="?quick_camera_icon"
                         android:background="@drawable/touch_highlight_background"
-                        android:contentDescription="@string/conversation_activity__quick_attachment_drawer_toggle_description"
+                        android:contentDescription="@string/conversation_activity__quick_attachment_drawer_toggle_camera_description"
                         android:padding="10dp"/>
 
                 <org.thoughtcrime.securesms.components.MicrophoneRecorderView
@@ -82,7 +82,7 @@
                             android:layout_gravity="bottom"
                             android:src="?quick_mic_icon"
                             android:background="@null"
-                            android:contentDescription="@string/conversation_activity__quick_attachment_drawer_toggle_description"
+                            android:contentDescription="@string/conversation_activity__quick_attachment_drawer_record_and_send_audio_description"
                             android:padding="10dp"/>
 
                     <ImageView android:id="@+id/quick_audio_fab"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -676,7 +676,8 @@
     <string name="conversation_activity__compose_description">Message composition</string>
     <string name="conversation_activity__emoji_toggle_description">Toggle emoji keyboard</string>
     <string name="conversation_activity__attachment_thumbnail">Attachment Thumbnail</string>
-    <string name="conversation_activity__quick_attachment_drawer_toggle_description">Toggle attachment drawer</string>
+    <string name="conversation_activity__quick_attachment_drawer_toggle_camera_description">Toggle quick camera attachment drawer</string>
+    <string name="conversation_activity__quick_attachment_drawer_record_and_send_audio_description">Record and send audio attachment</string>
     <string name="conversation_activity__enable_signal_for_sms">Enable Signal for SMS</string>
 
     <!-- conversation_input_panel -->


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5 Virtual device, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This commit changes the content description of the camera attachment toggle button to be less ambiguous, and fixes the incorrect content description of the audio record button.
Fixes #5910