### PR TITLE
Make accessibility strings in audio_view.xml translatable

### DIFF
--- a/res/layout/audio_view.xml
+++ b/res/layout/audio_view.xml
@@ -42,7 +42,7 @@
                            android:src="@drawable/ic_play_circle_fill_white_48dp"
                            android:scaleType="centerInside"
                            tools:visibility="gone"
-                           android:contentDescription="Play"/>
+                           android:contentDescription="@string/audio_view__play_accessibility_description"/>
 
                 <ImageView android:id="@+id/pause"
                            android:layout_width="wrap_content"
@@ -54,7 +54,7 @@
                            android:background="@drawable/circle_touch_highlight_background"
                            android:src="@drawable/ic_pause_circle_fill_white_48dp"
                            android:scaleType="centerInside"
-                           android:contentDescription="Pause"/>
+                           android:contentDescription="@string/audio_view__pause_accessibility_description"/>
 
                 <ImageView android:id="@+id/download"
                            android:layout_width="wrap_content"
@@ -64,7 +64,7 @@
                            android:visibility="gone"
                            android:background="@drawable/circle_touch_highlight_background"
                            android:src="@drawable/ic_download_circle_fill_white_48dp"
-                           android:contentDescription="Download"/>
+                           android:contentDescription="@string/audio_view__download_accessibility_description"/>
 
             </org.thoughtcrime.securesms.components.AnimatingToggle>
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -709,6 +709,11 @@
     <string name="conversation_item_received__contact_photo_description">Contact photo</string>
     <string name="conversation_item_received__downloading">Downloading</string>
 
+    <!-- audio_view -->
+    <string name="audio_view__play_accessibility_description">Play</string>
+    <string name="audio_view__pause_accessibility_description">Pause</string>
+    <string name="audio_view__download_accessibility_description">Download</string>
+
     <!-- conversation_fragment_cab -->
     <string name="conversation_fragment_cab__batch_selection_mode">Batch selection mode</string>
     <string name="conversation_fragment_cab__batch_selection_amount">%s selected</string>


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 7.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Related to (but doesn't entirely fix) #5908 

// FREEBIE