### PR TITLE
Accessible content labels for attachment icons

### DIFF
--- a/res/layout/attachment_type_selector.xml
+++ b/res/layout/attachment_type_selector.xml
@@ -34,6 +34,7 @@
                     android:src="@drawable/ic_image_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__image_description"
                     app:circleColor="@color/purple_400"/>
 
             <TextView android:layout_marginTop="10dp"
@@ -57,6 +58,7 @@
                     android:src="@drawable/ic_headset_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__audio_description"
                     app:circleColor="@color/orange_400"/>
 
             <TextView android:layout_marginTop="10dp"
@@ -80,7 +82,7 @@
                     android:src="@drawable/ic_local_movies_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
-
+                    android:contentDescription="@string/attachment_type_selector__video_description"
                     app:circleColor="@color/red_400"/>
 
             <TextView android:layout_marginTop="10dp"
@@ -104,6 +106,7 @@
                     android:src="@drawable/ic_person_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__contact_description"
                     app:circleColor="@color/blue_400"/>
 
             <TextView android:layout_marginTop="10dp"
@@ -138,6 +141,7 @@
                     android:src="@drawable/ic_camera_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__camera_description"
                     app:circleColor="@color/green_400"/>
 
             <TextView android:layout_marginTop="10dp"
@@ -163,6 +167,7 @@
                     android:src="@drawable/ic_location_on_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__location_description"
                     app:circleColor="@color/blue_grey_400"/>
 
             <TextView android:layout_marginTop="10dp"
@@ -187,13 +192,14 @@
                     android:src="@drawable/ic_gif_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__gif_description"
                     app:circleColor="@color/cyan_400"/>
 
             <TextView android:layout_marginTop="10dp"
                       android:layout_width="wrap_content"
                       android:layout_height="wrap_content"
                       style="@style/AttachmentTypeLabel"
-                      android:text="GIF"/>
+                      android:text="@string/attachment_type_selector__gif"/>
 
         </LinearLayout>
 
@@ -210,6 +216,7 @@
                     android:src="@drawable/ic_keyboard_arrow_down_white_36dp"
                     android:scaleType="center"
                     android:elevation="4dp"
+                    android:contentDescription="@string/attachment_type_selector__drawer_description"
                     app:circleColor="@color/gray50"/>
 
             <TextView android:layout_marginTop="10dp"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -632,11 +632,20 @@
 
     <!-- attachment_type_selector -->
     <string name="attachment_type_selector__image">Image</string>
+    <string name="attachment_type_selector__image_description">Image</string>
     <string name="attachment_type_selector__audio">Audio</string>
+    <string name="attachment_type_selector__audio_description">Audio</string>
     <string name="attachment_type_selector__video">Video</string>
+    <string name="attachment_type_selector__video_description">Video</string>
     <string name="attachment_type_selector__contact">Contact</string>
+    <string name="attachment_type_selector__contact_description">Contact</string>
     <string name="attachment_type_selector__camera">Camera</string>
+    <string name="attachment_type_selector__camera_description">Camera</string>
     <string name="attachment_type_selector__location">Location</string>
+    <string name="attachment_type_selector__location_description">Location</string>
+    <string name="attachment_type_selector__gif">GIF</string>
+    <string name="attachment_type_selector__gif_description">Gif</string>
+    <string name="attachment_type_selector__drawer_description">Toggle attachment drawer</string>
 
     <!-- change_passphrase_activity -->
     <string name="change_passphrase_activity__old_passphrase">Old passphrase</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Adds content description labels for all the buttons in the insert attachment toggle drawer.

Fixes #5908
// FREEBIE