### PR TITLE
fix corrupt messages crashing Signal

### DIFF
--- a/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/PushDecryptJob.java
@@ -604,6 +604,11 @@ public class PushDecryptJob extends ContextJob {
                                               @NonNull SignalServiceEnvelope envelope,
                                               @NonNull Optional<Long> smsMessageId)
   {
+    if (envelope.getLegacyMessage() == null || envelope.getLegacyMessage().length == 0) {
+      handleCorruptMessage(masterSecret, envelope, smsMessageId);
+      return;
+    }
+
     try {
       EncryptingSmsDatabase database       = DatabaseFactory.getEncryptingSmsDatabase(context);
       Recipients            recipients     = RecipientFactory.getRecipientsFromString(context, envelope.getSource(), false);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 nexus4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

libsignal throws ArrayIndexOutOfBounds exception which terminate Signal-Android, if the serialized PreKeySignalMessage has the length zero.
This is fixing the crash in #5922 (and stops this bug from being exploited by adversaries which want to disrupt Signal), but not the cause of the malformed message.

I could only test if this works with normal signal behaviour, since my device did not receive such a malformed/corrupt message.