### PR TITLE
Disable verify button if no message was exchanged

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -448,6 +448,7 @@
     <string name="RecipientPreferenceActivity_unblock">Unblock</string>
     <string name="RecipientPreferenceActivity_enabled">Enabled</string>
     <string name="RecipientPreferenceActivity_disabled">Disabled</string>
+    <string name="RecipientPreferenceActivity_you_will_have_to_exchange_a_message_first">You will have to exchange a message first.</string>
 
     <!-- RedPhone -->
     <string name="RedPhone_answering">Answering</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -448,7 +448,7 @@
     <string name="RecipientPreferenceActivity_unblock">Unblock</string>
     <string name="RecipientPreferenceActivity_enabled">Enabled</string>
     <string name="RecipientPreferenceActivity_disabled">Disabled</string>
-    <string name="RecipientPreferenceActivity_you_will_have_to_exchange_a_message_first">You will have to exchange a message first.</string>
+    <string name="RecipientPreferenceActivity_available_once_a_message_has_been_sent_or_received">Available once a message has been sent or received.</string>
 
     <!-- RedPhone -->
     <string name="RedPhone_answering">Answering</string>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1018,7 +1018,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onClick(View v) {
         Intent intent = new Intent(ConversationActivity.this, RecipientPreferenceActivity.class);
         intent.putExtra(RecipientPreferenceActivity.RECIPIENTS_EXTRA, recipients.getIds());
-        intent.putExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBERS_EXTRA,
+        intent.putExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBER_EXTRA,
                         isSecureText && !isSelfConversation());
 
         startActivitySceneTransition(intent, titleView.findViewById(R.id.title), "recipient_name");

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1018,6 +1018,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       public void onClick(View v) {
         Intent intent = new Intent(ConversationActivity.this, RecipientPreferenceActivity.class);
         intent.putExtra(RecipientPreferenceActivity.RECIPIENTS_EXTRA, recipients.getIds());
+        intent.putExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBERS_EXTRA,
+                        isSecureText && !isSelfConversation());
 
         startActivitySceneTransition(intent, titleView.findViewById(R.id.title), "recipient_name");
       }

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -55,7 +55,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 {
   private static final String TAG = RecipientPreferenceActivity.class.getSimpleName();
 
-  public static final String RECIPIENTS_EXTRA = "recipient_ids";
+  public static final String RECIPIENTS_EXTRA              = "recipient_ids";
+  public static final String CAN_HAVE_SAFETY_NUMBERS_EXTRA = "can_have_safety_numbers";
 
   private static final String PREFERENCE_MUTED    = "pref_key_recipient_mute";
   private static final String PREFERENCE_TONE     = "pref_key_recipient_ringtone";
@@ -192,6 +193,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     private Recipients        recipients;
     private BroadcastReceiver staleReceiver;
     private MasterSecret      masterSecret;
+    private boolean           canHaveSafetyNumbers;
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -200,7 +202,9 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
       addPreferencesFromResource(R.xml.recipient_preferences);
       initializeRecipients();
 
-      this.masterSecret = getArguments().getParcelable("master_secret");
+      this.masterSecret         = getArguments().getParcelable("master_secret");
+      this.canHaveSafetyNumbers = getActivity().getIntent()
+                                  .getBooleanExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBERS_EXTRA, false);
 
       this.findPreference(PREFERENCE_TONE)
           .setOnPreferenceChangeListener(new RingtoneChangeListener());
@@ -299,6 +303,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
             if (result.isPresent()) {
               if (identityPreference != null) identityPreference.setOnPreferenceClickListener(new IdentityClickedListener(result.get()));
               if (identityPreference != null) identityPreference.setEnabled(true);
+            } else if (canHaveSafetyNumbers) {
+              if (identityPreference != null) identityPreference.setSummary(R.string.RecipientPreferenceActivity_you_will_have_to_exchange_a_message_first);
             } else {
               if (identityPreference != null) getPreferenceScreen().removePreference(identityPreference);
             }

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -193,7 +193,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     private Recipients        recipients;
     private BroadcastReceiver staleReceiver;
     private MasterSecret      masterSecret;
-    private boolean           canHaveSafetyNumbers;
+    private boolean           canHaveSafetyNumber;
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -202,9 +202,9 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
       addPreferencesFromResource(R.xml.recipient_preferences);
       initializeRecipients();
 
-      this.masterSecret         = getArguments().getParcelable("master_secret");
-      this.canHaveSafetyNumbers = getActivity().getIntent()
-                                  .getBooleanExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBER_EXTRA, false);
+      this.masterSecret        = getArguments().getParcelable("master_secret");
+      this.canHaveSafetyNumber = getActivity().getIntent()
+                                 .getBooleanExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBER_EXTRA, false);
 
       this.findPreference(PREFERENCE_TONE)
           .setOnPreferenceChangeListener(new RingtoneChangeListener());
@@ -303,7 +303,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
             if (result.isPresent()) {
               if (identityPreference != null) identityPreference.setOnPreferenceClickListener(new IdentityClickedListener(result.get()));
               if (identityPreference != null) identityPreference.setEnabled(true);
-            } else if (canHaveSafetyNumbers) {
+            } else if (canHaveSafetyNumber) {
               if (identityPreference != null) identityPreference.setSummary(R.string.RecipientPreferenceActivity_you_will_have_to_exchange_a_message_first);
             } else {
               if (identityPreference != null) getPreferenceScreen().removePreference(identityPreference);

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -55,8 +55,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 {
   private static final String TAG = RecipientPreferenceActivity.class.getSimpleName();
 
-  public static final String RECIPIENTS_EXTRA              = "recipient_ids";
-  public static final String CAN_HAVE_SAFETY_NUMBERS_EXTRA = "can_have_safety_numbers";
+  public static final String RECIPIENTS_EXTRA             = "recipient_ids";
+  public static final String CAN_HAVE_SAFETY_NUMBER_EXTRA = "can_have_safety_number";
 
   private static final String PREFERENCE_MUTED    = "pref_key_recipient_mute";
   private static final String PREFERENCE_TONE     = "pref_key_recipient_ringtone";
@@ -204,7 +204,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
 
       this.masterSecret         = getArguments().getParcelable("master_secret");
       this.canHaveSafetyNumbers = getActivity().getIntent()
-                                  .getBooleanExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBERS_EXTRA, false);
+                                  .getBooleanExtra(RecipientPreferenceActivity.CAN_HAVE_SAFETY_NUMBER_EXTRA, false);
 
       this.findPreference(PREFERENCE_TONE)
           .setOnPreferenceChangeListener(new RingtoneChangeListener());

--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -304,7 +304,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
               if (identityPreference != null) identityPreference.setOnPreferenceClickListener(new IdentityClickedListener(result.get()));
               if (identityPreference != null) identityPreference.setEnabled(true);
             } else if (canHaveSafetyNumber) {
-              if (identityPreference != null) identityPreference.setSummary(R.string.RecipientPreferenceActivity_you_will_have_to_exchange_a_message_first);
+              if (identityPreference != null) identityPreference.setSummary(R.string.RecipientPreferenceActivity_available_once_a_message_has_been_sent_or_received);
             } else {
               if (identityPreference != null) getPreferenceScreen().removePreference(identityPreference);
             }


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * ~Sony Xperia U, Android 4.4~ (I did not test the latest changes)
 * AVD Nexus 5X, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
If there's no safety number found but it is a push conversation, the verify button won't be completely hidden (which is the current behaviour). Instead it will stay disabled and a hint is displayed.

This state can occur after a secure session was reset or if not a single message was exchanged with the recipient.

Fixes #5878
// FREEBIE

### Screenshot (outdated)
![device-2016-12-12-004429](https://cloud.githubusercontent.com/assets/16167751/21084558/89480364-c005-11e6-917a-f4e8863ce36b.png)
