### PR TITLE
Fix the faulty tests in AttachmentDatabaseTest.java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -228,7 +228,8 @@ android {
                           'proguard-shortcutbadger.pro',
                           'proguard-retrofit.pro',
                           'proguard.cfg'
-            testProguardFiles 'proguard-automation.pro'
+            testProguardFiles 'proguard-automation.pro',
+                          'proguard.cfg'
         }
         release {
             minifyEnabled true

--- a/proguard-automation.pro
+++ b/proguard-automation.pro
@@ -9,3 +9,5 @@
 -dontwarn org.hamcrest.**
 -dontwarn org.mockito.**
 -dontwarn com.squareup.**
+
+-dontobfuscate

--- a/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/AttachmentDatabase.java
@@ -357,7 +357,7 @@ public class AttachmentDatabase extends Database {
   }
 
   @VisibleForTesting
-  @Nullable InputStream getDataStream(MasterSecret masterSecret, AttachmentId attachmentId, String dataType)
+  protected @Nullable InputStream getDataStream(MasterSecret masterSecret, AttachmentId attachmentId, String dataType)
   {
     File dataFile = getAttachmentDataFile(attachmentId, dataType);
 
@@ -491,7 +491,7 @@ public class AttachmentDatabase extends Database {
 
 
   @VisibleForTesting
-  void updateAttachmentThumbnail(MasterSecret masterSecret, AttachmentId attachmentId, InputStream in, float aspectRatio)
+  protected void updateAttachmentThumbnail(MasterSecret masterSecret, AttachmentId attachmentId, InputStream in, float aspectRatio)
       throws MmsException
   {
     Log.w(TAG, "updating part thumbnail for #" + attachmentId);

--- a/test/androidTest/java/org/thoughtcrime/securesms/database/AttachmentDatabaseTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/database/AttachmentDatabaseTest.java
@@ -6,6 +6,7 @@ import org.thoughtcrime.securesms.TextSecureTestCase;
 import org.thoughtcrime.securesms.attachments.AttachmentId;
 import org.thoughtcrime.securesms.attachments.DatabaseAttachment;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.util.BitmapDecodingException;
 
 import java.io.FileNotFoundException;
 import java.io.InputStream;
@@ -33,30 +34,36 @@ public class AttachmentDatabaseTest extends TextSecureTestCase {
     database = spy(DatabaseFactory.getAttachmentDatabase(getInstrumentation().getTargetContext()));
   }
 
-  public void testTaskNotRunWhenThumbnailExists() throws Exception {
+  public void testThumbnailGenerationTaskNotRunWhenThumbnailExists() throws Exception {
     final AttachmentId attachmentId = new AttachmentId(ROW_ID, UNIQUE_ID);
 
-    when(database.getAttachment(attachmentId)).thenReturn(getMockAttachment("x/x"));
+    DatabaseAttachment mockAttachment = getMockAttachment("x/x");
+    when(database.getAttachment(attachmentId)).thenReturn(mockAttachment);
 
-    doReturn(mock(InputStream.class)).when(database).getDataStream(any(MasterSecret.class), any(AttachmentId.class), eq("thumbnail"));
+    InputStream mockInputStream = mock(InputStream.class);
+    doReturn(mockInputStream).when(database).getDataStream(any(MasterSecret.class), any(AttachmentId.class), eq("thumbnail"));
     database.getThumbnailStream(mock(MasterSecret.class), attachmentId);
 
-    // XXX - I don't think this is testing anything? The thumbnail would be updated asynchronously.
+    // Works as the Future#get() call in AttachmentDatabase#getThumbnailStream() makes updating synchronous
     verify(database, never()).updateAttachmentThumbnail(any(MasterSecret.class), any(AttachmentId.class), any(InputStream.class), anyFloat());
   }
 
-  public void testTaskRunWhenThumbnailMissing() throws Exception {
+  public void testThumbnailGenerationTaskRunWhenThumbnailMissing() throws Exception {
     final AttachmentId attachmentId = new AttachmentId(ROW_ID, UNIQUE_ID);
 
-    when(database.getAttachment(attachmentId)).thenReturn(getMockAttachment("image/png"));
+    DatabaseAttachment mockAttachment = getMockAttachment("image/png");
+    when(database.getAttachment(attachmentId)).thenReturn(mockAttachment);
+
     doReturn(null).when(database).getDataStream(any(MasterSecret.class), any(AttachmentId.class), eq("thumbnail"));
     doNothing().when(database).updateAttachmentThumbnail(any(MasterSecret.class), any(AttachmentId.class), any(InputStream.class), anyFloat());
 
     try {
       database.new ThumbnailFetchCallable(mock(MasterSecret.class), attachmentId).call();
-      throw new AssertionError("didn't try to generate thumbnail");
-    } catch (FileNotFoundException fnfe) {
-      // success
+      throw new AssertionError("Didn't try to generate thumbnail");
+    } catch (BitmapDecodingException bde) {
+      if (!(bde.getCause() instanceof FileNotFoundException)) {
+        throw new AssertionError("Thumbnail generation failed for another reason than a FileNotFoundException: " + bde.getMessage());
+      } // else success
     }
   }
 
@@ -64,6 +71,7 @@ public class AttachmentDatabaseTest extends TextSecureTestCase {
     DatabaseAttachment attachment = mock(DatabaseAttachment.class);
     when(attachment.getContentType()).thenReturn(contentType);
     when(attachment.getDataUri()).thenReturn(Uri.EMPTY);
+    when(attachment.hasData()).thenReturn(true);
 
     return attachment;
   }


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD like Nexus 5, Android 6.0 Marshmallow
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Fix the faulty tests in AttachmentDatabaseTest.java

Fixes #5948