### PR TITLE
Remove the hard dependency on Google Play Services

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -85,6 +85,9 @@
     <uses-permission android:name="android.permission.READ_LOGS"/>
     <uses-permission android:name="android.permission.WRITE_CALL_LOG"/>
 
+    <!-- Required network connection if Google Play is missing -->
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+
     <permission android:name="org.thoughtcrime.securesms.permission.C2D_MESSAGE"
                 android:protectionLevel="signature" />
     <uses-permission android:name="org.thoughtcrime.securesms.permission.C2D_MESSAGE" />

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1254,6 +1254,8 @@
     <string name="reminder_header_share_title">Invite your friends!</string>
     <string name="reminder_header_share_text">The more friends use Signal, the better it gets.</string>
     <string name="reminder_header_share_button">SHARE</string>
+    <string name="reminder_header_battery_optimisation_title">Disable battery optimisation</string>
+    <string name="reminder_header_battery_optimisation_text">Tap to disable battery optimisation for Signal.</string>
     <string name="reminder_header_close_button">CLOSE</string>
 
     <!-- MediaPreviewActivity -->

--- a/res/xml/preferences_advanced.xml
+++ b/res/xml/preferences_advanced.xml
@@ -3,7 +3,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                         android:defaultValue="false"
-                        android:key="pref_toggle_push_messaging"
+                        android:key="pref_toggle_messaging"
                         android:title="@string/preferences__signal_messages_and_calls"
                         android:summary="@string/preferences__free_private_messages_and_calls"/>
 

--- a/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
+++ b/src/org/thoughtcrime/securesms/ApplicationPreferencesActivity.java
@@ -167,7 +167,7 @@ public class ApplicationPreferencesActivity extends PassphraseRequiredActionBarA
 
     private void setCategoryVisibility() {
       Preference devicePreference = this.findPreference(PREFERENCE_CATEGORY_DEVICES);
-      if (devicePreference != null && !TextSecurePreferences.isPushRegistered(getActivity())) {
+      if (devicePreference != null && !TextSecurePreferences.isRegistered(getActivity())) {
         getPreferenceScreen().removePreference(devicePreference);
       }
     }

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -927,7 +927,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
 
   protected void updateInviteReminder(boolean seenInvite) {
     Log.w(TAG, "updateInviteReminder(" + seenInvite+")");
-    if (TextSecurePreferences.isPushRegistered(this) &&
+    if (TextSecurePreferences.isRegistered(this)     &&
         !isSecureText                                &&
         !seenInvite                                  &&
         recipients.isSingleRecipient()               &&
@@ -1307,7 +1307,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private boolean isSelfConversation() {
-    if (!TextSecurePreferences.isPushRegistered(this))       return false;
+    if (!TextSecurePreferences.isRegistered(this))           return false;
     if (!recipients.isSingleRecipient())                     return false;
     if (recipients.getPrimaryRecipient().isGroupRecipient()) return false;
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -52,6 +52,7 @@ import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 
 import org.thoughtcrime.securesms.ConversationListAdapter.ItemClickListener;
+import org.thoughtcrime.securesms.components.reminder.BatteryOptimisationReminder;
 import org.thoughtcrime.securesms.components.reminder.DefaultSmsReminder;
 import org.thoughtcrime.securesms.components.reminder.ExpiredBuildReminder;
 import org.thoughtcrime.securesms.components.reminder.OutdatedBuildReminder;
@@ -185,6 +186,8 @@ public class ConversationListFragment extends Fragment
           return Optional.of((new PushRegistrationReminder(context, masterSecret)));
         } else if (ShareReminder.isEligible(context)) {
           return Optional.of(new ShareReminder(context));
+        } else if (BatteryOptimisationReminder.isEligible(context)) {
+          return Optional.of(new BatteryOptimisationReminder(context));
         } else {
           return Optional.absent();
         }

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -139,7 +139,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
   }
 
   private boolean isSignalGroup() {
-    return TextSecurePreferences.isPushRegistered(this) && !getAdapter().hasNonPushMembers();
+    return TextSecurePreferences.isRegistered(this) && !getAdapter().hasNonPushMembers();
   }
 
   private void disableSignalGroupViews(int reasonResId) {
@@ -158,7 +158,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
 
   @SuppressWarnings("ConstantConditions")
   private void updateViewState() {
-    if (!TextSecurePreferences.isPushRegistered(this)) {
+    if (!TextSecurePreferences.isRegistered(this)) {
       disableSignalGroupViews(R.string.GroupCreateActivity_youre_not_registered_for_signal);
       getSupportActionBar().setTitle(R.string.GroupCreateActivity_actionbar_mms_title);
     } else if (getAdapter().hasNonPushMembers()) {

--- a/src/org/thoughtcrime/securesms/RegistrationActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationActivity.java
@@ -67,6 +67,16 @@ public class RegistrationActivity extends BaseActionBarActivity {
   }
 
   @Override
+  public void onResume() {
+    super.onResume();
+
+    if (!(GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) == ConnectionResult.SUCCESS)) {
+      Dialogs.showAlertDialog(this, getString(R.string.RegistrationActivity_unsupported),
+                              getString(R.string.RegistrationActivity_sorry_this_device_is_not_supported_for_data_messaging));
+    }
+  }
+
+  @Override
   protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (requestCode == PICK_COUNTRY && resultCode == RESULT_OK && data != null) {
       this.countryCode.setText(data.getIntExtra("country_code", 1)+"");
@@ -208,18 +218,6 @@ public class RegistrationActivity extends BaseActionBarActivity {
                              getString(R.string.RegistrationActivity_invalid_number),
                              String.format(getString(R.string.RegistrationActivity_the_number_you_specified_s_is_invalid),
                                            e164number));
-        return;
-      }
-
-      int gcmStatus = GooglePlayServicesUtil.isGooglePlayServicesAvailable(self);
-
-      if (gcmStatus != ConnectionResult.SUCCESS) {
-        if (GooglePlayServicesUtil.isUserRecoverableError(gcmStatus)) {
-          GooglePlayServicesUtil.getErrorDialog(gcmStatus, self, 9000).show();
-        } else {
-          Dialogs.showAlertDialog(self, getString(R.string.RegistrationActivity_unsupported),
-                                  getString(R.string.RegistrationActivity_sorry_this_device_is_not_supported_for_data_messaging));
-        }
         return;
       }
 

--- a/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
+++ b/src/org/thoughtcrime/securesms/RegistrationProgressActivity.java
@@ -30,6 +30,9 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.push.AccountManagerFactory;
 import org.thoughtcrime.securesms.service.RegistrationService;
@@ -520,8 +523,9 @@ public class RegistrationProgressActivity extends BaseActionBarActivity {
           try {
             SignalServiceAccountManager accountManager = AccountManagerFactory.createManager(context, e164number, password);
             int                         registrationId = TextSecurePreferences.getLocalRegistrationId(context);
+            boolean                     hasServices    = GooglePlayServicesUtil.isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS;
 
-            accountManager.verifyAccountWithCode(code, signalingKey, registrationId, true);
+            accountManager.verifyAccountWithCode(code, signalingKey, registrationId, hasServices, !hasServices);
 
             return SUCCESS;
           } catch (ExpectationFailedException e) {

--- a/src/org/thoughtcrime/securesms/components/reminder/BatteryOptimisationReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/BatteryOptimisationReminder.java
@@ -1,0 +1,85 @@
+/*
+ * Signal: A private messenger for Android.
+ * Copyright (C) 2016  Open Whisper Systems
+ *
+ * This file is part of Signal.
+ *
+ * Signal is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Signal is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Signal.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package org.thoughtcrime.securesms.components.reminder;
+
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.os.PowerManager;
+import android.provider.Settings;
+import android.view.View;
+import android.view.View.OnClickListener;
+
+import org.thoughtcrime.securesms.R;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
+
+/**
+ * Posts a message in the form of a {@code Reminder} that alerts the
+ * user that they are able to add Signal to the whitelist of
+ * applications that can by pass Android's doze/sleep mechanism.
+ *
+ * @author  Alex Melbourne {@literal <alex.melbourne@protonmail.com>}
+ * @version v0.1.0
+ * @see     android.provider.Settings#ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS
+ * @since   !_TODO__ : Update this value when preparing a release.
+ */
+public class BatteryOptimisationReminder extends Reminder {
+
+  public BatteryOptimisationReminder(final Context context) {
+    super(context.getString(R.string.reminder_header_battery_optimisation_title),
+          context.getString(R.string.reminder_header_battery_optimisation_text));
+
+    final OnClickListener okListener = new OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        TextSecurePreferences.setPromptedBatteryOptimisation(context, true);
+        Intent intent = new Intent();
+        intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
+        intent.setData(new Uri.Builder().scheme("package")
+                                        .opaquePart(context.getPackageName())
+                                        .build());
+        context.startActivity(intent);
+      }
+    };
+    final OnClickListener dismissListener = new OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        TextSecurePreferences.setPromptedBatteryOptimisation(context, true);
+      }
+    };
+    setOkListener(okListener);
+    setDismissListener(dismissListener);
+  }
+
+  public static boolean isEligible(Context context) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      final PowerManager powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+
+      return TextSecurePreferences.isRegistered(context)                            &&
+             !TextSecurePreferences.isPushRegistered(context)                       &&
+             !powerManager.isIgnoringBatteryOptimizations(context.getPackageName()) &&
+             !TextSecurePreferences.hasPromptedBatteryOptimisation(context);
+    } else {
+      return false;
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/components/reminder/PushRegistrationReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/PushRegistrationReminder.java
@@ -35,6 +35,6 @@ public class PushRegistrationReminder extends Reminder {
   }
 
   public static boolean isEligible(Context context) {
-    return !TextSecurePreferences.isPushRegistered(context);
+    return !TextSecurePreferences.isRegistered(context);
   }
 }

--- a/src/org/thoughtcrime/securesms/components/reminder/ShareReminder.java
+++ b/src/org/thoughtcrime/securesms/components/reminder/ShareReminder.java
@@ -33,7 +33,7 @@ public class ShareReminder extends Reminder {
   }
 
   public static boolean isEligible(final @NonNull Context context) {
-    if (!TextSecurePreferences.isPushRegistered(context) ||
+    if (!TextSecurePreferences.isRegistered(context) ||
         TextSecurePreferences.hasPromptedShare(context))
     {
       return false;

--- a/src/org/thoughtcrime/securesms/contacts/ContactsSyncAdapter.java
+++ b/src/org/thoughtcrime/securesms/contacts/ContactsSyncAdapter.java
@@ -28,7 +28,7 @@ public class ContactsSyncAdapter extends AbstractThreadedSyncAdapter {
   {
     Log.w(TAG, "onPerformSync(" + authority +")");
 
-    if (TextSecurePreferences.isPushRegistered(getContext())) {
+    if (TextSecurePreferences.isRegistered(getContext())) {
       try {
         DirectoryHelper.refreshDirectory(getContext(), KeyCachingService.getMasterSecret(getContext()));
       } catch (IOException e) {

--- a/src/org/thoughtcrime/securesms/database/CanonicalAddressDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/CanonicalAddressDatabase.java
@@ -148,7 +148,8 @@ public class CanonicalAddressDatabase {
       long   canonicalAddressId;
       String formattedAddress;
 
-      if ((formattedAddress = formattedAddressCache.get(address)) == null) {
+      if ((formattedAddress = formattedAddressCache.get(address)) == null &&
+					 TextSecurePreferences.isRegistered(context)) {
         String localNumber = TextSecurePreferences.getLocalNumber(context);
 
         if (!isNumberAddress(address)                        ||

--- a/src/org/thoughtcrime/securesms/database/MmsDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/MmsDatabase.java
@@ -279,7 +279,7 @@ public class MmsDatabase extends MessagingDatabase {
 
     group.add(retrieved.getAddresses().getFrom());
 
-    if (TextSecurePreferences.isPushRegistered(context)) {
+    if (TextSecurePreferences.isRegistered(context)) {
       localNumber = TextSecurePreferences.getLocalNumber(context);
     } else {
       localNumber = ServiceUtil.getTelephonyManager(context).getLine1Number();

--- a/src/org/thoughtcrime/securesms/jobs/CreateSignedPreKeyJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/CreateSignedPreKeyJob.java
@@ -47,7 +47,7 @@ public class CreateSignedPreKeyJob extends MasterSecretJob implements Injectable
       return;
     }
 
-    if (!TextSecurePreferences.isPushRegistered(context)) {
+    if (!TextSecurePreferences.isRegistered(context)) {
       Log.w(TAG, "Not yet registered...");
       return;
     }

--- a/src/org/thoughtcrime/securesms/jobs/RefreshAttributesJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/RefreshAttributesJob.java
@@ -3,6 +3,9 @@ package org.thoughtcrime.securesms.jobs;
 import android.content.Context;
 import android.util.Log;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
+
 import org.thoughtcrime.redphone.signaling.RedPhoneAccountAttributes;
 import org.thoughtcrime.redphone.signaling.RedPhoneAccountManager;
 import org.thoughtcrime.securesms.dependencies.InjectableType;
@@ -42,10 +45,14 @@ public class RefreshAttributesJob extends ContextJob implements InjectableType {
     String gcmRegistrationId = TextSecurePreferences.getGcmRegistrationId(context);
     int    registrationId    = TextSecurePreferences.getLocalRegistrationId(context);
 
-    String token = textSecureAccountManager.getAccountVerificationToken();
+    if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(context) == ConnectionResult.SUCCESS) {
+      String token = textSecureAccountManager.getAccountVerificationToken();
 
-    redPhoneAccountManager.createAccount(token, new RedPhoneAccountAttributes(signalingKey, gcmRegistrationId));
-    textSecureAccountManager.setAccountAttributes(signalingKey, registrationId, true);
+      redPhoneAccountManager.createAccount(token, new RedPhoneAccountAttributes(signalingKey, gcmRegistrationId));
+      textSecureAccountManager.setAccountAttributes(signalingKey, registrationId, true, false);
+    } else {
+      textSecureAccountManager.setAccountAttributes(signalingKey, registrationId, false, true);
+    }
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/jobs/RefreshPreKeysJob.java
+++ b/src/org/thoughtcrime/securesms/jobs/RefreshPreKeysJob.java
@@ -48,7 +48,7 @@ public class RefreshPreKeysJob extends MasterSecretJob implements InjectableType
 
   @Override
   public void onRun(MasterSecret masterSecret) throws IOException {
-    if (!TextSecurePreferences.isPushRegistered(context)) return;
+    if (!TextSecurePreferences.isRegistered(context)) return;
 
     int availableKeys = accountManager.getPreKeysCount();
 

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -42,7 +42,7 @@ import java.io.IOException;
 public class AdvancedPreferenceFragment extends PreferenceFragment {
   private static final String TAG = AdvancedPreferenceFragment.class.getSimpleName();
 
-  private static final String PUSH_MESSAGING_PREF   = "pref_toggle_push_messaging";
+  private static final String MESSAGING_PREF   = "pref_toggle_messaging";
   private static final String SUBMIT_DEBUG_LOG_PREF = "pref_submit_debug_logs";
 
   private static final int PICK_IDENTITY_CONTACT = 1;
@@ -67,7 +67,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
     super.onResume();
     ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.preferences__advanced);
 
-    initializePushMessagingToggle();
+    initializeMessagingToggle();
   }
 
   @Override
@@ -80,10 +80,10 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
     }
   }
 
-  private void initializePushMessagingToggle() {
-    CheckBoxPreference preference = (CheckBoxPreference)this.findPreference(PUSH_MESSAGING_PREF);
+  private void initializeMessagingToggle() {
+    CheckBoxPreference preference = (CheckBoxPreference)this.findPreference(MESSAGING_PREF);
 
-    if (TextSecurePreferences.isPushRegistered(getActivity())) {
+    if (TextSecurePreferences.isRegistered(getActivity())) {
       preference.setChecked(true);
       preference.setSummary(TextSecurePreferences.getLocalNumber(getActivity()));
     } else {
@@ -91,7 +91,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
       preference.setSummary(R.string.preferences__free_private_messages_and_calls);
     }
 
-    preference.setOnPreferenceChangeListener(new PushMessagingClickListener());
+    preference.setOnPreferenceChangeListener(new MessagingClickListener());
   }
 
   private void initializeIdentitySelection() {
@@ -156,14 +156,14 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
     }
   }
 
-  private class PushMessagingClickListener implements Preference.OnPreferenceChangeListener {
+  private class MessagingClickListener implements Preference.OnPreferenceChangeListener {
     private static final int SUCCESS       = 0;
     private static final int NETWORK_ERROR = 1;
 
-    private class DisablePushMessagesTask extends ProgressDialogAsyncTask<Void, Void, Integer> {
+    private class DisableMessagesTask extends ProgressDialogAsyncTask<Void, Void, Integer> {
       private final CheckBoxPreference checkBoxPreference;
 
-      public DisablePushMessagesTask(final CheckBoxPreference checkBoxPreference) {
+      public DisableMessagesTask(final CheckBoxPreference checkBoxPreference) {
         super(getActivity(), R.string.ApplicationPreferencesActivity_unregistering, R.string.ApplicationPreferencesActivity_unregistering_from_signal_messages_and_calls);
         this.checkBoxPreference = checkBoxPreference;
       }
@@ -178,8 +178,8 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
                          Toast.LENGTH_LONG).show();
           break;
         case SUCCESS:
-          TextSecurePreferences.setPushRegistered(getActivity(), false);
-          initializePushMessagingToggle();
+          TextSecurePreferences.setRegistered(getActivity(), false);
+          initializeMessagingToggle();
           break;
         }
       }
@@ -227,7 +227,7 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
         builder.setPositiveButton(android.R.string.ok, new DialogInterface.OnClickListener() {
           @Override
           public void onClick(DialogInterface dialog, int which) {
-            new DisablePushMessagesTask((CheckBoxPreference)preference).execute();
+            new DisableMessagesTask((CheckBoxPreference)preference).execute();
           }
         });
         builder.show();

--- a/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/AdvancedPreferenceFragment.java
@@ -206,7 +206,9 @@ public class AdvancedPreferenceFragment extends PreferenceFragment {
             Log.w(TAG, e);
           }
 
-          GoogleCloudMessaging.getInstance(context).unregister();
+          if (TextSecurePreferences.isPushRegistered(context)) {
+            GoogleCloudMessaging.getInstance(context).unregister();
+          }
 
           return SUCCESS;
         } catch (IOException ioe) {

--- a/src/org/thoughtcrime/securesms/service/DirectoryRefreshListener.java
+++ b/src/org/thoughtcrime/securesms/service/DirectoryRefreshListener.java
@@ -21,7 +21,7 @@ public class DirectoryRefreshListener extends PersistentAlarmManagerListener {
 
   @Override
   protected long onAlarm(Context context, long scheduledTime) {
-    if (scheduledTime != 0 && TextSecurePreferences.isPushRegistered(context)) {
+    if (scheduledTime != 0 && TextSecurePreferences.isRegistered(context)) {
       ApplicationContext.getInstance(context)
                         .getJobManager()
                         .add(new DirectoryRefreshJob(context));

--- a/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
+++ b/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
@@ -152,8 +152,8 @@ public class MessageRetrievalService extends Service implements Runnable, Inject
     Log.w(TAG, String.format("Network requirement: %s, active activities: %s, push pending: %s",
                              networkRequirement.isPresent(), activeActivities, pushPending.size()));
 
-    return TextSecurePreferences.isWebsocketRegistered(this) &&
-           (activeActivities > 0 || !pushPending.isEmpty())  &&
+    return TextSecurePreferences.isWebsocketRegistered(this)                                                  &&
+           (activeActivities > 0 || !pushPending.isEmpty() || !TextSecurePreferences.isPushRegistered(this))  &&
            networkRequirement.isPresent();
   }
 

--- a/src/org/thoughtcrime/securesms/service/RegistrationService.java
+++ b/src/org/thoughtcrime/securesms/service/RegistrationService.java
@@ -194,8 +194,9 @@ public class RegistrationService extends Service {
     }
 
     try {
-      String password     = Util.getSecret(18);
-      String signalingKey = Util.getSecret(52);
+      String  password     = Util.getSecret(18);
+      String  signalingKey = Util.getSecret(52);
+      boolean hasServices  = GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) == ConnectionResult.SUCCESS;
 
       initializeChallengeListener();
 
@@ -205,7 +206,7 @@ public class RegistrationService extends Service {
 
       setState(new RegistrationState(RegistrationState.STATE_VERIFYING, number));
       String challenge = waitForChallenge();
-      accountManager.verifyAccountWithCode(challenge, signalingKey, registrationId, true);
+      accountManager.verifyAccountWithCode(challenge, signalingKey, registrationId, hasServices, !hasServices);
 
       handleCommonRegistration(accountManager, number, password, signalingKey);
       markAsVerified(number, password, signalingKey);

--- a/src/org/thoughtcrime/securesms/service/RegistrationService.java
+++ b/src/org/thoughtcrime/securesms/service/RegistrationService.java
@@ -291,12 +291,14 @@ public class RegistrationService extends Service {
 
     if (verifying) {
       TextSecurePreferences.setPushRegistered(this, false);
+      TextSecurePreferences.setRegistered(this, false);
     }
   }
 
   private void markAsVerified(String number, String password, String signalingKey) {
     TextSecurePreferences.setVerifying(this, false);
     TextSecurePreferences.setPushRegistered(this, true);
+    TextSecurePreferences.setRegistered(this, true);
     TextSecurePreferences.setLocalNumber(this, number);
     TextSecurePreferences.setPushServerPassword(this, password);
     TextSecurePreferences.setSignalingKey(this, signalingKey);

--- a/src/org/thoughtcrime/securesms/service/RegistrationService.java
+++ b/src/org/thoughtcrime/securesms/service/RegistrationService.java
@@ -10,6 +10,8 @@ import android.os.Handler;
 import android.os.IBinder;
 import android.util.Log;
 
+import com.google.android.gms.common.ConnectionResult;
+import com.google.android.gms.common.GooglePlayServicesUtil;
 import com.google.android.gms.gcm.GoogleCloudMessaging;
 
 import org.thoughtcrime.redphone.signaling.RedPhoneAccountAttributes;
@@ -297,7 +299,11 @@ public class RegistrationService extends Service {
 
   private void markAsVerified(String number, String password, String signalingKey) {
     TextSecurePreferences.setVerifying(this, false);
-    TextSecurePreferences.setPushRegistered(this, true);
+
+    if (GooglePlayServicesUtil.isGooglePlayServicesAvailable(this) == ConnectionResult.SUCCESS) {
+      TextSecurePreferences.setPushRegistered(this, true);
+    }
+
     TextSecurePreferences.setRegistered(this, true);
     TextSecurePreferences.setLocalNumber(this, number);
     TextSecurePreferences.setPushServerPassword(this, password);

--- a/src/org/thoughtcrime/securesms/sms/MessageSender.java
+++ b/src/org/thoughtcrime/securesms/sms/MessageSender.java
@@ -227,7 +227,7 @@ public class MessageSender {
 
   private static boolean isPushTextSend(Context context, Recipients recipients, boolean keyExchange) {
     try {
-      if (!TextSecurePreferences.isPushRegistered(context)) {
+      if (!TextSecurePreferences.isRegistered(context)) {
         return false;
       }
 
@@ -247,7 +247,7 @@ public class MessageSender {
 
   private static boolean isPushMediaSend(Context context, Recipients recipients) {
     try {
-      if (!TextSecurePreferences.isPushRegistered(context)) {
+      if (!TextSecurePreferences.isRegistered(context)) {
         return false;
       }
 
@@ -270,7 +270,7 @@ public class MessageSender {
   }
 
   private static boolean isSelfSend(Context context, Recipients recipients) {
-    if (!TextSecurePreferences.isPushRegistered(context)) {
+    if (!TextSecurePreferences.isRegistered(context)) {
       return false;
     }
 

--- a/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
+++ b/src/org/thoughtcrime/securesms/util/DirectoryHelper.java
@@ -152,7 +152,7 @@ public class DirectoryHelper {
         return UserCapabilities.UNSUPPORTED;
       }
 
-      if (!TextSecurePreferences.isPushRegistered(context)) {
+      if (!TextSecurePreferences.isRegistered(context)) {
         return UserCapabilities.UNSUPPORTED;
       }
 

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -65,6 +65,7 @@ public class TextSecurePreferences {
   private static final String THREAD_TRIM_ENABLED              = "pref_trim_threads";
   private static final String LOCAL_NUMBER_PREF                = "pref_local_number";
   private static final String VERIFYING_STATE_PREF             = "pref_verifying";
+  public  static final String REGISTERED_PREF                  = "pref_registered";
   public  static final String REGISTERED_GCM_PREF              = "pref_gcm_registered";
   private static final String GCM_PASSWORD_PREF                = "pref_gcm_password";
   private static final String PROMPTED_PUSH_REGISTRATION_PREF  = "pref_prompted_push_registration";
@@ -416,6 +417,18 @@ public class TextSecurePreferences {
 
   public static void setVerifying(Context context, boolean verifying) {
     setBooleanPreference(context, VERIFYING_STATE_PREF, verifying);
+  }
+
+  private static boolean isUserPreviouslyRegistered(Context context) {
+    return isPushRegistered(context);
+  }
+
+  public static boolean isRegistered(Context context) {
+    return getBooleanPreference(context, REGISTERED_PREF, isUserPreviouslyRegistered(context));
+  }
+
+  public static void setRegistered(Context context, boolean registered) {
+    setBooleanPreference(context, REGISTERED_PREF, registered);
   }
 
   public static boolean isPushRegistered(Context context) {

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -71,6 +71,7 @@ public class TextSecurePreferences {
   private static final String PROMPTED_PUSH_REGISTRATION_PREF  = "pref_prompted_push_registration";
   private static final String PROMPTED_DEFAULT_SMS_PREF        = "pref_prompted_default_sms";
   private static final String PROMPTED_SHARE_PREF              = "pref_prompted_share";
+  private static final String PROMPTED_BATTERY_PREF            = "pref_prompted_battery_optimisation";
   private static final String SIGNALING_KEY_PREF               = "pref_signaling_key";
   private static final String DIRECTORY_FRESH_TIME_PREF        = "pref_directory_refresh_time";
   private static final String SIGNED_PREKEY_ROTATION_TIME_PREF = "pref_signed_pre_key_rotation_time";
@@ -438,6 +439,14 @@ public class TextSecurePreferences {
   public static void setPushRegistered(Context context, boolean registered) {
     Log.w("TextSecurePreferences", "Setting push registered: " + registered);
     setBooleanPreference(context, REGISTERED_GCM_PREF, registered);
+  }
+
+  public static boolean hasPromptedBatteryOptimisation(Context context) {
+    return getBooleanPreference(context, PROMPTED_BATTERY_PREF, false);
+  }
+
+  public static void setPromptedBatteryOptimisation(Context context, boolean prompted) {
+    setBooleanPreference(context, PROMPTED_BATTERY_PREF, prompted);
   }
 
   public static boolean isPassphraseTimeoutEnabled(Context context) {


### PR DESCRIPTION
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X (running build NMF26O of CopperheadOS), Android 7.1.1
 * Blu Diamond M, Android 6.0
- [ ] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Taken from one of the endless discussions that have already taken place on this point @moxie0 has said:

 > If the only thing that the remaining people here want out of LibreSignal is a websocket-only solution and gmscore isn't an option for whatever reason, I would consider a clean, well written, and well tested PR for websocket-only support in Signal. I expect it to have high battery consumption and an unreliable user experience, but would be fine with it if it comes with a warning and only runs in the absence of play services.

This pull request is my attempt at fulfilling that offer. I stress that I'm not concerned with removing Google from Signal completely, I just want to run it on my phone. My friends are not interested in computers and I'd rather have an app that looks after them, than try an teach them something they don't care about.

#### What does this pull request do?

In short this series of patches:

 * Creates a new method `isRegistered` to determin if a user is registered, and reserves `isPushRegistered` for checks about receiving push notifications;

 * Moves the warning that takes place just before an attempted registration without Google Play Services to the start of that activity, and allows the user to continue once they have acknowledged it; and

 * Informs the server that a device without Google Play Services is unable to receive voice calls because it'll never get the notification.

 * Provides the option for the user to disable battery optimisations for Signal (but only when Google Services are not available).

These changes mean that __a device with Play Services installed functions identically to how it does right now__, while a device without those services gains the ability use the app.

#### Why is "_My contribution is fully baked and ready to be merged as is_" left unticked?

While this pull request has been rebased and organised so it applies cleanly to the current mainline it is relient on [a patch to a libsignal-service-java][2]. Once this patch is accepted this request can update its build script.

#### Results of testing

I've been running these changes on CopperheadOS for several days and the app has performed as expected. With the exception of the loss of voice communication there have been no issues.

Testing on a platform with Google's binaries installed has been shorter but all of the functionality has been tested: there is no warning of missing packages, messages send and receive correctly (both to single users, and to groups), encrypted calls function as normal.

Both platforms register, and unregister from Signal's servers correctly.

I'm happy with this implementation. Messages are received in a timely fashion, battery life is nowhere near as bad as I thought it would be, and the app copes completely with the loss of Internet access (both dropping a 4G connection wandering around town, and turning mobile data/Wi-Fi off).

I did run into Android's doze/sleep functionality once: I left my phone not charging over night. I had no messages in the morning until I checked Signal manually, then they all came through. However, now that the option exists to combat this (in a small way) I don't see this as much of a problem.

Battery life is still good. I still get three days of my phone with no charging between.

   [1]: https://github.com/LibreSignal/LibreSignal/issues/37#issuecomment-226646872
   [2]: https://github.com/WhisperSystems/libsignal-service-java/pull/28