### PR TITLE
Fix domain fronts for Cuba and Oman

### DIFF
--- a/src/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.java
+++ b/src/org/thoughtcrime/securesms/push/SignalServiceNetworkAccess.java
@@ -37,12 +37,12 @@ public class SignalServiceNetworkAccess {
                                                                googleTrustStore),
                                           baseAndroid, baseGoogle});
 
-      put("+53", new SignalServiceUrl[] {new SignalServiceUrl("https://www.google.com.om",
+      put("+53", new SignalServiceUrl[] {new SignalServiceUrl("https://www.google.com.cu",
                                                               APPSPOT_REFLECTOR_HOST,
                                                               googleTrustStore),
                                          baseAndroid, baseGoogle});
 
-      put("+968", new SignalServiceUrl[] {new SignalServiceUrl("https://www.google.com.cu",
+      put("+968", new SignalServiceUrl[] {new SignalServiceUrl("https://www.google.com.om",
                                                                APPSPOT_REFLECTOR_HOST,
                                                                googleTrustStore),
                                           baseAndroid, baseGoogle});


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Oneplus One Android 5.1

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Front domain for Oman used https://www.google.com.cu, for Cuba http://www.google.com.om was used, this PR corrects that to be consistent with Egypt and UAE


//FREEBIE