### PR TITLE
Fix crash when clicking on a gif image

### DIFF
--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -86,7 +86,7 @@ public class ZoomingImageView extends FrameLayout {
       }
 
       protected void onPostExecute(@Nullable Pair<Integer, Integer> dimensions) {
-        Log.w(TAG, "Dimensions: " + dimensions.first + ", " + dimensions.second);
+        Log.w(TAG, "Dimensions: " + (dimensions == null ? "(null)" : dimensions.first + ", " + dimensions.second));
 
         if (dimensions == null || (dimensions.first <= maxTextureSize && dimensions.second <= maxTextureSize)) {
           Log.w(TAG, "Loading in standard image view...");


### PR DESCRIPTION


### Contributor checklist

- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 4, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

Signal crashes with a NullPointerException when clicking on a gif attachment. A log statement uses the nullable dimensions without checking for null.
For gif images, the dimensions is always null.

//FREEBIE