### PR TITLE
Disable AudioView controls clicks when message is selected

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -257,6 +257,9 @@ public class ConversationItem extends LinearLayout
     mediaThumbnail.setFocusable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
     mediaThumbnail.setClickable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
     mediaThumbnail.setLongClickable(batchSelected.isEmpty());
+    audioView.setFocusable(!shouldInterceptClicks(messageRecord) && batchSelected.isEmpty());
+    audioView.setClickable(batchSelected.isEmpty());
+    audioView.setEnabled(batchSelected.isEmpty());
     bodyText.setAutoLinkMask(batchSelected.isEmpty() ? Linkify.ALL : 0);
   }
 

--- a/src/org/thoughtcrime/securesms/components/AudioView.java
+++ b/src/org/thoughtcrime/securesms/components/AudioView.java
@@ -12,6 +12,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -158,6 +159,35 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
   }
 
   @Override
+  public void setFocusable(boolean focusable) {
+    super.setFocusable(focusable);
+    this.playButton.setFocusable(focusable);
+    this.pauseButton.setFocusable(focusable);
+    this.seekBar.setFocusable(focusable);
+    this.seekBar.setFocusableInTouchMode(focusable);
+    this.downloadButton.setFocusable(focusable);
+  }
+
+  @Override
+  public void setClickable(boolean clickable) {
+    super.setClickable(clickable);
+    this.playButton.setClickable(clickable);
+    this.pauseButton.setClickable(clickable);
+    this.seekBar.setClickable(clickable);
+    this.seekBar.setOnTouchListener(clickable ? null : new TouchIgnoringListener());
+    this.downloadButton.setClickable(clickable);
+  }
+
+  @Override
+  public void setEnabled(boolean enabled) {
+    super.setEnabled(enabled);
+    this.playButton.setEnabled(enabled);
+    this.pauseButton.setEnabled(enabled);
+    this.seekBar.setEnabled(enabled);
+    this.downloadButton.setEnabled(enabled);
+  }
+
+  @Override
   public void onProgress(double progress, long millis) {
     int seekProgress = (int)Math.floor(progress * this.seekBar.getMax());
 
@@ -283,6 +313,13 @@ public class AudioView extends FrameLayout implements AudioSlidePlayer.Listener 
       } catch (IOException e) {
         Log.w(TAG, e);
       }
+    }
+  }
+
+  private class TouchIgnoringListener implements OnTouchListener {
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+      return true;
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy Nexus, Android 4.3
 * Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This commit fixes #5898 by disabling clickable elements inside AudioView. Attributes that are set to AudioView are forwarded to all clickable elements. Additionally OnTouchListener is set to SeekBar to prevent it from scrolling.