### PR TITLE
Use HTTPS for all support links

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@ You can also preview your report before submitting it. You may remove sections t
 Before we begin, please note that this tracker is only for issues, not questions or comments.
 
 If you are looking for support, please see our support center instead:
-http://support.whispersystems.org/
+https://support.whispersystems.org/
 or email support@whispersystems.org
 
 Let's begin with a checklist: replace the empty checkboxes [ ] below with checked ones [x] accordingly -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,7 +73,7 @@ Accepted pull requests will be rewarded with Bitcoins! After your pull request h
 ## How can I contribute?
 Any one can help by
 - advising new people about the guidelines of this project
- - redirecting support questions to support@whispersystems.org and the [support site](http://support.whispersystems.org)
+ - redirecting support questions to support@whispersystems.org and the [support site](https://support.whispersystems.org)
  - redirecting non-bug related discussions to the [community forum](https://whispersystems.discoursehosting.net)
 - improving documentation at the [wiki](https://github.com/WhisperSystems/Signal-Android/wiki)
 - [translating](https://www.transifex.com/projects/p/signal-android/)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Help
 ## Support
 For troubleshooting and questions, please visit our support center!
 
-http://support.whispersystems.org/
+https://support.whispersystems.org/
 
 ## Documentation
 Looking for documentation? Check out the wiki!

--- a/src/org/thoughtcrime/securesms/ConversationListActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationListActivity.java
@@ -214,7 +214,7 @@ public class ConversationListActivity extends PassphraseRequiredActionBarActivit
 
   private void handleHelp() {
     try {
-      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("http://support.whispersystems.org")));
+      startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse("https://support.whispersystems.org")));
     } catch (ActivityNotFoundException e) {
       Toast.makeText(this, R.string.ConversationListActivity_there_is_no_browser_installed_on_your_device, Toast.LENGTH_LONG).show();
     }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The support website is now available through HTTPS, but the in-app help button attempts open the link using HTTP, making the user vulnerable to SSL stripping. While I was at it, I also updated the readme, contribution guidelines, and the issue template to reflect this change as well.