### PR TITLE
Fixed name and picture loading for DirectShare

### DIFF
--- a/src/org/thoughtcrime/securesms/service/DirectShareService.java
+++ b/src/org/thoughtcrime/securesms/service/DirectShareService.java
@@ -29,10 +29,10 @@ import java.util.List;
 @RequiresApi(api = Build.VERSION_CODES.M)
 public class DirectShareService extends ChooserTargetService {
 
-  private boolean waitingUntilConversationsLoaded = true;
-  private int getConversationsRetryRate = 2;
-  private int maxGetConversationTries = 5;
-  private int getConversationsTryCounter = 0;
+  private boolean waitingUntilConversationsLoaded   = true;
+  private long    getConversationsRetryRate         = 200;
+  private int     maxGetConversationTries           = 15;
+  private int     getConversationsTryCounter        = 0;
 
   @Override
   public List<ChooserTarget> onGetChooserTargets(ComponentName targetActivityName,
@@ -46,8 +46,8 @@ public class DirectShareService extends ChooserTargetService {
     }
 
     while (waitingUntilConversationsLoaded) {
-      ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(this);
-      Cursor cursor = threadDatabase.getDirectShareList();
+      ThreadDatabase threadDatabase   = DatabaseFactory.getThreadDatabase(this);
+      Cursor         cursor           = threadDatabase.getDirectShareList();
 
       try {
         ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, new MasterCipher(masterSecret));
@@ -56,7 +56,6 @@ public class DirectShareService extends ChooserTargetService {
         while ((record = reader.getNext()) != null) {
           if (record.getRecipients().getPrimaryRecipient().getName() != null
                   && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
-
             waitingUntilConversationsLoaded = false;
             break;
           }
@@ -66,7 +65,7 @@ public class DirectShareService extends ChooserTargetService {
       }
 
       try {
-        Thread.sleep(getConversationsRetryRate * 1000);
+        Thread.sleep(getConversationsRetryRate);
       } catch (Exception exception) {
         Log.i("DirectShareService: ", exception.getMessage());
       }
@@ -80,9 +79,9 @@ public class DirectShareService extends ChooserTargetService {
       getConversationsTryCounter++;
     }
 
-    ComponentName  componentName  = new ComponentName(this, ShareActivity.class);
-    ThreadDatabase threadDatabase = DatabaseFactory.getThreadDatabase(this);
-    Cursor         cursor         = threadDatabase.getDirectShareList();
+    ComponentName  componentName    = new ComponentName(this, ShareActivity.class);
+    ThreadDatabase threadDatabase   = DatabaseFactory.getThreadDatabase(this);
+    Cursor         cursor           = threadDatabase.getDirectShareList();
 
     try {
       ThreadDatabase.Reader reader = threadDatabase.readerFor(cursor, new MasterCipher(masterSecret));
@@ -91,10 +90,10 @@ public class DirectShareService extends ChooserTargetService {
       while ((record = reader.getNext()) != null && results.size() < 10) {
         if (record.getRecipients().getPrimaryRecipient().getName() != null
                 && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
-          Recipients recipients = RecipientFactory.getRecipientsForIds(this, record.getRecipients().getIds(), false);
-          String name = recipients.toShortString();
-          Drawable drawable = recipients.getContactPhoto().asDrawable(this, recipients.getColor().toConversationColor(this));
-          Bitmap avatar = BitmapUtil.createFromDrawable(drawable, 500, 500);
+          Recipients recipients   = RecipientFactory.getRecipientsForIds(this, record.getRecipients().getIds(), false);
+          String     name         = recipients.toShortString();
+          Drawable   drawable     = recipients.getContactPhoto().asDrawable(this, recipients.getColor().toConversationColor(this));
+          Bitmap     avatar       = BitmapUtil.createFromDrawable(drawable, 500, 500);
 
           Bundle bundle = new Bundle();
           bundle.putLong(ShareActivity.EXTRA_THREAD_ID, record.getThreadId());

--- a/src/org/thoughtcrime/securesms/service/DirectShareService.java
+++ b/src/org/thoughtcrime/securesms/service/DirectShareService.java
@@ -35,7 +35,8 @@ public class DirectShareService extends ChooserTargetService {
   private int getConversationsTryCounter = 0;
 
   @Override
-  public List<ChooserTarget> onGetChooserTargets(ComponentName targetActivityName, IntentFilter matchedFilter)
+  public List<ChooserTarget> onGetChooserTargets(ComponentName targetActivityName,
+                                                 IntentFilter matchedFilter)
   {
     List<ChooserTarget> results        = new LinkedList<>();
     MasterSecret        masterSecret   = KeyCachingService.getMasterSecret(this);
@@ -53,7 +54,8 @@ public class DirectShareService extends ChooserTargetService {
         ThreadRecord record;
 
         while ((record = reader.getNext()) != null) {
-          if (record.getRecipients().getPrimaryRecipient().getName() != null && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
+          if (record.getRecipients().getPrimaryRecipient().getName() != null
+                  && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
 
             waitingUntilConversationsLoaded = false;
             break;
@@ -87,7 +89,8 @@ public class DirectShareService extends ChooserTargetService {
       ThreadRecord record;
 
       while ((record = reader.getNext()) != null && results.size() < 10) {
-        if (record.getRecipients().getPrimaryRecipient().getName() != null && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
+        if (record.getRecipients().getPrimaryRecipient().getName() != null
+                && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
           Recipients recipients = RecipientFactory.getRecipientsForIds(this, record.getRecipients().getIds(), false);
           String name = recipients.toShortString();
           Drawable drawable = recipients.getContactPhoto().asDrawable(this, recipients.getColor().toConversationColor(this));

--- a/src/org/thoughtcrime/securesms/service/DirectShareService.java
+++ b/src/org/thoughtcrime/securesms/service/DirectShareService.java
@@ -58,7 +58,7 @@ public class DirectShareService extends ChooserTargetService {
         ThreadRecord record;
 
         while ((record = reader.getNext()) != null) {
-          if (record.getRecipients().getPrimaryRecipient().getName() != null) {
+          if (record.getRecipients().getPrimaryRecipient().getName() != null && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
 
             waitingUntilConversationsLoaded = false;
             break;
@@ -88,7 +88,7 @@ public class DirectShareService extends ChooserTargetService {
       ThreadRecord record;
 
       while ((record = reader.getNext()) != null && results.size() < 10) {
-        if (record.getRecipients().getPrimaryRecipient().getName() != null && record.getRecipients().getPrimaryRecipient().getNumber() != null) {
+        if (record.getRecipients().getPrimaryRecipient().getName() != null && record.getRecipients().getPrimaryRecipient().getContactPhoto() != null) {
           Recipients recipients = RecipientFactory.getRecipientsForIds(this, record.getRecipients().getIds(), false);
           String name = recipients.toShortString();
           Drawable drawable = recipients.getContactPhoto().asDrawable(this, recipients.getColor().toConversationColor(this));


### PR DESCRIPTION
Now the service is waiting until all names and pictures are loaded

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ X] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ X] I have signed the [Contributor Licence Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [ X] I have tested my contribution on these devices:
 * Oneplus 3, Omnirom 7.1.1 / Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [ X] Fixes #6082 
- [ X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This workaround will wait until all conversation are encrypted correctly. When we pull the conversations on startup, the names and the pictures are null. So we wait until everything is loaded. After that, we set the DirectShare contacts.
