### PR TITLE
Add scroll to bottom button in conversation view

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,8 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           xmlns:tools="http://schemas.android.com/tools"
           package="org.thoughtcrime.securesms"
-      android:versionCode="226"
-      android:versionName="3.27.0">
+      android:versionCode="227"
+      android:versionName="3.27.1">
 
     <uses-sdk tools:overrideLibrary="com.amulyakhare.textdrawable,com.astuetz.pagerslidingtabstrip,pl.tajchert.waitingdots,com.h6ah4i.android.multiselectlistpreferencecompat,android.support.v13,com.davemorrissey.labs.subscaleview"/>
 

--- a/res/layout/conversation_fragment.xml
+++ b/res/layout/conversation_fragment.xml
@@ -21,4 +21,16 @@
           android:alpha="0"
           android:visibility="invisible" />
 
+    <android.support.design.widget.FloatingActionButton
+        android:id="@+id/scroll_to_bottom_button"
+        android:visibility="invisible"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/scroll_to_bottom_button_margin_end"
+        android:layout_marginRight="@dimen/scroll_to_bottom_button_margin_end"
+        android:layout_marginBottom="@dimen/scroll_to_bottom_button_margin_bottom"
+        android:layout_gravity="bottom|end"
+        android:contentDescription="@string/conversation_fragment__scroll_to_the_bottom_content_description"
+        android:src="@drawable/ic_keyboard_arrow_down_white_36dp" />
+
 </FrameLayout>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -66,4 +66,7 @@
     <dimen name="onboarding_subtitle_size">20sp</dimen>
 
     <dimen name="scribble_stroke_size">3dp</dimen>
+
+    <dimen name="scroll_to_bottom_button_margin_end">10dp</dimen>
+    <dimen name="scroll_to_bottom_button_margin_bottom">10dp</dimen>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -722,6 +722,9 @@
     <string name="conversation_fragment_cab__batch_selection_mode">Batch selection mode</string>
     <string name="conversation_fragment_cab__batch_selection_amount">%s selected</string>
 
+    <!-- conversation_fragment -->
+    <string name="conversation_fragment__scroll_to_the_bottom_content_description">Scroll to the bottom</string>
+
     <!-- country_selection_fragment -->
     <string name="country_selection_fragment__loading_countries">Loading countries...</string>
     <string name="country_selection_fragment__search">Search</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -91,6 +91,7 @@ public class ConversationFragment extends Fragment
   private RecyclerView list;
   private View         loadMoreView;
   private View         composeDivider;
+  private View         scrollToBottomButton;
 
   @Override
   public void onCreate(Bundle icicle) {
@@ -102,8 +103,16 @@ public class ConversationFragment extends Fragment
   @Override
   public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle bundle) {
     final View view = inflater.inflate(R.layout.conversation_fragment, container, false);
-    list           = ViewUtil.findById(view, android.R.id.list);
-    composeDivider = ViewUtil.findById(view, R.id.compose_divider);
+    list                 = ViewUtil.findById(view, android.R.id.list);
+    composeDivider       = ViewUtil.findById(view, R.id.compose_divider);
+    scrollToBottomButton = ViewUtil.findById(view, R.id.scroll_to_bottom_button);
+
+    scrollToBottomButton.setOnClickListener(new OnClickListener() {
+      @Override
+      public void onClick(final View view) {
+        scrollToBottom();
+      }
+    });
 
     final LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, true);
     list.setHasFixedSize(false);
@@ -404,11 +413,14 @@ public class ConversationFragment extends Fragment
 
       if (wasAtBottom != currentlyAtBottom) {
         composeDivider.setVisibility(currentlyAtBottom ? View.INVISIBLE : View.VISIBLE);
+        scrollToBottomButton.setVisibility(currentlyAtBottom ? View.INVISIBLE : View.VISIBLE);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB_MR1) {
           composeDivider.animate().alpha(currentlyAtBottom ? 0 : 1);
+          scrollToBottomButton.animate().alpha(currentlyAtBottom ? 0 : 1);
         } else if (Build.VERSION.SDK_INT > Build.VERSION_CODES.HONEYCOMB) {
           composeDivider.setAlpha(currentlyAtBottom ? 0 : 1);
+          scrollToBottomButton.setAlpha(currentlyAtBottom ? 0 : 1);
         }
 
         wasAtBottom = currentlyAtBottom;


### PR DESCRIPTION
Added a FloatingActionButton to the conversation_fragment that appears and disappears using the same logic as the existing compose divider: appear when the conversation list is scrolled away from the bottom, disappear when the list is scrolled to the bottom.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG Nexus 4, Android 5.0.2
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Added FloatingActionButton to the ConversationFragment to allow quick scrolling to the bottom of the conversation when not already at the bottom.

Re-used an existing icon and a method for smooth scrolling.