### PR TITLE
Debouncing send button

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1504,6 +1504,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       buttonToggle.display(attachButton);
       quickAttachmentToggle.show();
     } else {
+      sendButton.setEnabled(true);
       buttonToggle.display(sendButton);
       quickAttachmentToggle.hide();
     }
@@ -1687,6 +1688,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private class SendButtonListener implements OnClickListener, TextView.OnEditorActionListener {
     @Override
     public void onClick(View v) {
+      sendButton.setEnabled(false);
       sendMessage();
     }
 


### PR DESCRIPTION
Added simple debouncing of the send button by disabling it in the click listener and enabling it again when text is entered.

Fixes #6076

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG Nexus 4, Android 5.0.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
The send button can be pressed twice in quick succession, leading to `sendMessage()` being called twice. This method handles the `InvalidMessageException` thrown by trying to send an empty message and shows a Toast to the user.

I added simple debouncing by disabling the button in the `SendButtonListener`'s `onClick` method and it is then re-enabled in `updateToggleButtonState()` to ensure the button can be pressed after text has been entered or an attachment has been added.

The original bug report suggested that the attachment popup should appear, but I don't believe this is really desired behavior. It seems unlikely that a user would purposefully tap the button twice in _such_ quick succession, intending to go from sending one message to adding an attachment. I believe it is more likely to happen by accident, hence the [debouncing](http://stackoverflow.com/questions/16534369/avoid-button-multiple-rapid-clicks) approach.