### PR TITLE
Fixing broken unit test for ConversationAdapter

### DIFF
--- a/test/unitTest/java/org/thoughtcrime/securesms/ConversationAdapterTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/ConversationAdapterTest.java
@@ -24,14 +24,11 @@ public class ConversationAdapterTest extends BaseUnitTest {
   }
 
   @Test
-  public void testGetItemIdEquals() throws Exception {
-    when(cursor.getString(anyInt())).thenReturn("SMS::1::1");
+  public void testGetItemIdEquals() {
+    when(cursor.getLong(anyInt())).thenReturn(1234L);
     long firstId = adapter.getItemId(cursor);
-    when(cursor.getString(anyInt())).thenReturn("MMS::1::1");
+    when(cursor.getLong(anyInt())).thenReturn(4321L);
     long secondId = adapter.getItemId(cursor);
     assertNotEquals(firstId, secondId);
-    when(cursor.getString(anyInt())).thenReturn("MMS::2::1");
-    long thirdId = adapter.getItemId(cursor);
-    assertNotEquals(secondId, thirdId);
   }
 }


### PR DESCRIPTION
The unit test for ConversationAdapter.getItemId() was broken by this change: 7286fd9
I've replaced the test with the best remaining test I can think of that is still the same vein as the original.
It's not particularly high value, but deleting the test means deleting the class, and perhaps it's more useful to have the class there for future tests.

Fixes #6088
// FREEBIE

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * `./gradlew test` because this is only a unit test fix
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Quick unit test fix to prevent build failures. Should ideally add more unit tests in this class to make it valuable.
