### PR TITLE
Make "safety numbers" singular for WebRTC strings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -642,11 +642,9 @@
     <string name="SingleRecipientNotificationBuilder_new_message">New message</string>
 
     <!-- WebRtcCallScreen -->
-    <string name="WebRtcCallScreen_new_safety_numbers">The safety numbers for your conversation with %1$s have changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply re-installed Signal.</string>
-    <string name="WebRtcCallScreen_you_may_wish_to_verify_this_contact">You may wish to verify
-        safety numbers for this contact.
-    </string>
-    <string name="WebRtcCallScreen_new_safety_numbers_title">New safety numbers</string>
+    <string name="WebRtcCallScreen_new_safety_number">Your safety number with %1$s has changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply reinstalled Signal.</string>
+    <string name="WebRtcCallScreen_you_may_wish_to_verify_this_contact">You may wish to verify your safety number with this contact.</string>
+    <string name="WebRtcCallScreen_new_safety_number_title">New safety number</string>
 
     <!-- WebRtcCallControls -->
     <string name="WebRtcCallControls_tap_to_enable_your_video">Tap to enable your video</string>

--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallScreen.java
@@ -117,7 +117,7 @@ public class WebRtcCallScreen extends FrameLayout implements Recipient.Recipient
 
   public void setUntrustedIdentity(Recipient personInfo, IdentityKey untrustedIdentity) {
     String          name            = recipient.toShortString();
-    String          introduction    = String.format(getContext().getString(R.string.WebRtcCallScreen_new_safety_numbers), name, name);
+    String          introduction    = String.format(getContext().getString(R.string.WebRtcCallScreen_new_safety_number), name, name);
     SpannableString spannableString = new SpannableString(introduction + " " + getContext().getString(R.string.WebRtcCallScreen_you_may_wish_to_verify_this_contact));
 
     spannableString.setSpan(new VerifySpan(getContext(), personInfo.getRecipientId(), untrustedIdentity),
@@ -127,7 +127,7 @@ public class WebRtcCallScreen extends FrameLayout implements Recipient.Recipient
     setPersonInfo(personInfo);
 
     this.incomingCallOverlay.setActiveCall();
-    this.status.setText(R.string.WebRtcCallScreen_new_safety_numbers_title);
+    this.status.setText(R.string.WebRtcCallScreen_new_safety_number_title);
     this.untrustedIdentityContainer.setVisibility(View.VISIBLE);
     this.untrustedIdentityExplanation.setText(spannableString);
     this.untrustedIdentityExplanation.setMovementMethod(LinkMovementMethod.getInstance());


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Changes "safety numbers" to "safety number" for strings introduced with WebRTC