### PR TITLE
Make VideoPlayer toast error message translatable

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1297,6 +1297,8 @@
     <!-- transport_selection_list_item -->
     <string name="transport_selection_list_item__transport_icon">Transport icon</string>
 
+    <!-- VideoPlayer -->
+    <string name="VideoPlayer_error_playing_video">Error playing video</string>
 
     <!-- EOF -->
 

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -60,7 +60,7 @@ public class VideoPlayer extends FrameLayout {
       Log.w(TAG, "Playing video directly from non-local Uri...");
       this.videoView.setVideoURI(videoSource.getUri());
     } else {
-      Toast.makeText(getContext(), "Error playing video...", Toast.LENGTH_LONG).show();
+      Toast.makeText(getContext(), getContext().getString(R.string.VideoPlayer_error_playing_video), Toast.LENGTH_LONG).show();
       return;
     }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Android 7.1.1 emulator
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
...and remove the ellipsis, cc @RiseT

// FREEBIE