### PR TITLE
Android Auto voice reply

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -108,8 +108,8 @@
     <meta-data android:name="org.thoughtcrime.securesms.mms.TextSecureGlideModule"
                android:value="GlideModule" />
 
-    <!--<meta-data android:name="com.google.android.gms.car.application"-->
-               <!--android:resource="@xml/automotive_app_desc" />-->
+    <meta-data android:name="com.google.android.gms.car.application"
+               android:resource="@xml/automotive_app_desc" />
 
     <activity android:name="org.thoughtcrime.redphone.RedPhone"
               android:excludeFromRecents="true"

--- a/src/org/thoughtcrime/securesms/notifications/NotificationState.java
+++ b/src/org/thoughtcrime/securesms/notifications/NotificationState.java
@@ -131,6 +131,7 @@ public class NotificationState {
     if (threads.size() != 1) throw new AssertionError("We only support replies to single thread notifications!");
 
     Intent intent = new Intent(AndroidAutoReplyReceiver.REPLY_ACTION);
+    intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
     intent.setClass(context, AndroidAutoReplyReceiver.class);
     intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
     intent.putExtra(AndroidAutoReplyReceiver.RECIPIENT_IDS_EXTRA, recipients.getIds());
@@ -149,6 +150,7 @@ public class NotificationState {
     }
 
     Intent intent = new Intent(AndroidAutoHeardReceiver.HEARD_ACTION);
+    intent.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES);
     intent.setClass(context, AndroidAutoHeardReceiver.class);
     intent.setData((Uri.parse("custom://"+System.currentTimeMillis())));
     intent.putExtra(AndroidAutoHeardReceiver.THREAD_IDS_EXTRA, threadArray);


### PR DESCRIPTION
I have added the intent flag FLAG_INCLUDE_STOPPED_PACKAGES to the Android Auto intents, as per the examples in https://developer.android.com/training/auto/messaging/index.html
I have verified that voice reply works now, using both the Android Auto Desktop Head Unit emulator and in a real Android Auto environment in a car. This was tested on using a Google Nexus 4 running Android 5.1.1, and Android Auto 2.0.642703. 

Fixes #6124
//FREEBIE
