### PR TITLE
Fix some wording for group conversations

### DIFF
--- a/res/menu/conversation_push_group_options.xml
+++ b/res/menu/conversation_push_group_options.xml
@@ -2,7 +2,7 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item android:id="@+id/menu_edit_group"
-          android:title="@string/conversation__menu_update_group"
+          android:title="@string/conversation__menu_edit_group"
           app:showAsAction="collapseActionView" />
 
     <item android:id="@+id/menu_leave"

--- a/res/menu/group_create.xml
+++ b/res/menu/group_create.xml
@@ -2,7 +2,7 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android" xmlns:app="http://schemas.android.com/apk/res-auto">
 
-    <item android:title="@string/GroupCreateActivity_menu_create_title"
+    <item android:title="@string/GroupCreateActivity_menu_apply_button"
           android:id="@+id/menu_create_group"
           android:icon="?menu_accept_icon"
           app:showAsAction="always|withText"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -279,7 +279,7 @@
     
     <!-- GroupCreateActivity -->
     <string name="GroupCreateActivity_actionbar_title">New group</string>
-    <string name="GroupCreateActivity_actionbar_update_title">Update group</string>
+    <string name="GroupCreateActivity_actionbar_edit_title">Edit group</string>
     <string name="GroupCreateActivity_group_name_hint">Group name</string>
     <string name="GroupCreateActivity_actionbar_mms_title">New MMS group</string>
     <string name="GroupCreateActivity_contacts_dont_support_push">You have selected a contact that doesn\'t support Signal groups, so this group will be MMS.</string>
@@ -288,7 +288,7 @@
     <string name="GroupCreateActivity_contacts_no_members">You need at least one person in your group!</string>
     <string name="GroupCreateActivity_contacts_invalid_number">One of the members of your group has a number that can\'t be read correctly. Please fix or remove that contact and try again.</string>
     <string name="GroupCreateActivity_avatar_content_description">Group avatar</string>
-    <string name="GroupCreateActivity_menu_create_title">Create group</string>
+    <string name="GroupCreateActivity_menu_apply_button">Apply</string>
     <string name="GroupCreateActivity_creating_group">Creating %1$s&#8230;</string>
     <string name="GroupCreateActivity_updating_group">Updating %1$s...</string>
     <string name="GroupCreateActivity_cannot_add_non_push_to_existing_group">Couldn\'t add %1$s because they\'re not a Signal user.</string>
@@ -1216,7 +1216,7 @@
 
     <!-- conversation -->
     <string name="conversation__menu_add_attachment">Add attachment</string>
-    <string name="conversation__menu_update_group">Update group</string>
+    <string name="conversation__menu_edit_group">Edit group</string>
     <string name="conversation__menu_leave_group">Leave group</string>
     <string name="conversation__menu_delete_thread">Delete conversation</string>
     <string name="conversation__menu_view_media">All images</string>

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -167,7 +167,7 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     } else {
       enableSignalGroupViews();
       getSupportActionBar().setTitle(groupToUpdate.isPresent()
-                                     ? R.string.GroupCreateActivity_actionbar_update_title
+                                     ? R.string.GroupCreateActivity_actionbar_edit_title
                                      : R.string.GroupCreateActivity_actionbar_title);
     }
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #6193

Changes "Create group" to "Apply" (button)
Changes "Update group" to "Edit group" (menu item)
Changes "Update group" to "Edit group" (action bar title)

I'm leaving the 3rd point mentioned in the issue description to #5416 , which I guess has solved this nicely.

// FREEBIE