### PR TITLE
Don't display date for drafts in media preview

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1270,6 +1270,7 @@
     <string name="MediaPreviewActivity_you">You</string>
     <string name="MediaPreviewActivity_cant_display">Failed to preview this image</string>
     <string name="MediaPreviewActivity_unssuported_media_type">Unsupported media type</string>
+    <string name="MediaPreviewActivity_draft">Draft</string>
 
     <!-- media_preview -->
     <string name="media_preview__save_title">Save</string>

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -106,7 +106,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     if (date > 0) {
       relativeTimeSpan = DateUtils.getExtendedRelativeTimeSpanString(this,dynamicLanguage.getCurrentLocale(),date);
     } else {
-      relativeTimeSpan = null;
+      relativeTimeSpan = getString(R.string.MediaPreviewActivity_draft);
     }
     getSupportActionBar().setTitle(recipient == null ? getString(R.string.MediaPreviewActivity_you)
                                                      : recipient.toShortString());
@@ -147,7 +147,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
 
     mediaUri     = getIntent().getData();
     mediaType    = getIntent().getType();
-    date         = getIntent().getLongExtra(DATE_EXTRA, System.currentTimeMillis());
+    date         = getIntent().getLongExtra(DATE_EXTRA, -1);
     size         = getIntent().getLongExtra(SIZE_EXTRA, 0);
     threadId     = getIntent().getLongExtra(THREAD_ID_EXTRA, -1);
 
@@ -208,7 +208,8 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
       @Override
       public void onClick(DialogInterface dialogInterface, int i) {
         SaveAttachmentTask saveTask = new SaveAttachmentTask(MediaPreviewActivity.this, masterSecret);
-        saveTask.execute(new Attachment(mediaUri, mediaType, date));
+        long saveDate = (date > 0) ? date : System.currentTimeMillis();
+        saveTask.execute(new Attachment(mediaUri, mediaType, saveDate));
       }
     });
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Display "Draft" instead of the current time "Just now" as subtitle in media preview.

### Screenshots
![device-2017-02-10-204112](https://cloud.githubusercontent.com/assets/16167751/22841564/6399178c-efd2-11e6-9bd1-a137092726f9.png)
![device-2017-02-10-203824](https://cloud.githubusercontent.com/assets/16167751/22841563/63954c1a-efd2-11e6-911b-3cfdc0d97267.png)