### PR TITLE
Add disappearing message time of 3 weeks

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -251,6 +251,7 @@
         <item>43200</item>
         <item>86400</item>
         <item>604800</item>
+        <item>1814400</item> 
     </integer-array>
 
     <array name="scribble_colors">


### PR DESCRIPTION
This adds 3 weeks to the selectable times for disappearing messages. 
1 week maximum is too short for certain uses.

(I added the word // FREEBIE)


- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)


- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

This simply adds 3 weeks to the list for disappearing messages, making the list feel more complete and allowing to have most conversations with this default setting (1 week is too short).

PR on other clients Desktop and iOS
[WhisperSystems/Signal-Desktop#1062](https://github.com/WhisperSystems/Signal-Desktop/pull/1062)
[WhisperSystems/SignalServiceKit#115](https://github.com/WhisperSystems/SignalServiceKit/pull/115)
