### PR TITLE
Change MMS Size Limit based on Carrier Restrictions

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -641,16 +641,6 @@
     <string name="SingleRecipientNotificationBuilder_signal">Signal</string>
     <string name="SingleRecipientNotificationBuilder_new_message">New message</string>
 
-    <!-- WebRtcCallScreen -->
-    <string name="WebRtcCallScreen_new_safety_numbers">The safety numbers for your conversation with %1$s have changed. This could either mean that someone is trying to intercept your communication, or that %2$s simply re-installed Signal.</string>
-    <string name="WebRtcCallScreen_you_may_wish_to_verify_this_contact">You may wish to verify
-        safety numbers for this contact.
-    </string>
-    <string name="WebRtcCallScreen_new_safety_numbers_title">New safety numbers</string>
-
-    <!-- WebRtcCallControls -->
-    <string name="WebRtcCallControls_tap_to_enable_your_video">Tap to enable your video</string>
-
     <!-- attachment_type_selector -->
     <string name="attachment_type_selector__image">Image</string>
     <string name="attachment_type_selector__image_description">Image</string>
@@ -1139,9 +1129,6 @@
     <string name="preferences_chats__message_trimming">Message trimming</string>
     <string name="preferences_advanced__use_system_emoji">Use system emoji</string>
     <string name="preferences_advanced__disable_signal_built_in_emoji_support">Disable Signal\'s built-in emoji support</string>
-    <string name="preferences_advanced__video_calling_beta">Video calling beta</string>
-    <string name="preferences_advanced__enable_support_for_next_generation_video_and_voice_calls">Support for next-generation video and voice calls when enabled by both parties. This feature is in beta.</string>
-
 
     <!-- **************************************** -->
     <!-- menus -->
@@ -1310,6 +1297,22 @@
     <!-- transport_selection_list_item -->
     <string name="transport_selection_list_item__transport_icon">Transport icon</string>
 
+    <!-- MMS Carrier Size Limits -->
+    <string-array name="CarrierConstraintKeys">
+        <item>default</item>
+        <item>http://mms.msg.eng.t-mobile.com/mms/wapenc</item>
+        <item>http://mms.sprintpcs.com/servlets/mms</item>
+        <item>http://mmsc.mobile.att.net</item>
+        <item>http://mms.vtext.com/servlets/mms</item>
+    </string-array>
+
+    <string-array name="CarrierConstraintValues">
+        <item>280</item>
+        <item>984</item>
+        <item>1984</item>
+        <item>584</item>
+        <item>1176</item>
+    </string-array>
 
     <!-- EOF -->
 

--- a/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MediaConstraints.java
@@ -28,21 +28,21 @@ public abstract class MediaConstraints {
 
   public abstract int getImageMaxWidth(Context context);
   public abstract int getImageMaxHeight(Context context);
-  public abstract int getImageMaxSize();
+  public abstract int getImageMaxSize(Context context);
 
-  public abstract int getGifMaxSize();
+  public abstract int getGifMaxSize(Context context);
 
-  public abstract int getVideoMaxSize();
+  public abstract int getVideoMaxSize(Context context);
 
-  public abstract int getAudioMaxSize();
+  public abstract int getAudioMaxSize(Context context);
 
   public boolean isSatisfied(@NonNull Context context, @NonNull MasterSecret masterSecret, @NonNull Attachment attachment) {
     try {
-      return (MediaUtil.isGif(attachment)    && attachment.getSize() <= getGifMaxSize()   && isWithinBounds(context, masterSecret, attachment.getDataUri())) ||
-             (MediaUtil.isImage(attachment)  && attachment.getSize() <= getImageMaxSize() && isWithinBounds(context, masterSecret, attachment.getDataUri())) ||
-             (MediaUtil.isAudio(attachment)  && attachment.getSize() <= getAudioMaxSize()) ||
-             (MediaUtil.isVideo(attachment)  && attachment.getSize() <= getVideoMaxSize()) ||
-             (!MediaUtil.isImage(attachment) && !MediaUtil.isAudio(attachment) && !MediaUtil.isVideo(attachment));
+      return (MediaUtil.isGif(attachment)    && attachment.getSize() <= getGifMaxSize(context)   && isWithinBounds(context, masterSecret, attachment.getDataUri())) ||
+              (MediaUtil.isImage(attachment)  && attachment.getSize() <= getImageMaxSize(context) && isWithinBounds(context, masterSecret, attachment.getDataUri())) ||
+              (MediaUtil.isAudio(attachment)  && attachment.getSize() <= getAudioMaxSize(context)) ||
+              (MediaUtil.isVideo(attachment)  && attachment.getSize() <= getVideoMaxSize(context)) ||
+              (!MediaUtil.isImage(attachment) && !MediaUtil.isAudio(attachment) && !MediaUtil.isVideo(attachment));
     } catch (IOException ioe) {
       Log.w(TAG, "Failed to determine if media's constraints are satisfied.", ioe);
       return false;
@@ -54,7 +54,7 @@ public abstract class MediaConstraints {
       InputStream is = PartAuthority.getAttachmentStream(context, masterSecret, uri);
       Pair<Integer, Integer> dimensions = BitmapUtil.getDimensions(is);
       return dimensions.first  > 0 && dimensions.first  <= getImageMaxWidth(context) &&
-             dimensions.second > 0 && dimensions.second <= getImageMaxHeight(context);
+              dimensions.second > 0 && dimensions.second <= getImageMaxHeight(context);
     } catch (BitmapDecodingException e) {
       throw new IOException(e);
     }
@@ -67,7 +67,7 @@ public abstract class MediaConstraints {
   public MediaStream getResizedMedia(@NonNull Context context,
                                      @NonNull MasterSecret masterSecret,
                                      @NonNull Attachment attachment)
-      throws IOException
+          throws IOException
   {
     if (!canResize(attachment)) {
       throw new UnsupportedOperationException("Cannot resize this content type");
@@ -76,7 +76,7 @@ public abstract class MediaConstraints {
     try {
       // XXX - This is loading everything into memory! We want the send path to be stream-like.
       return new MediaStream(new ByteArrayInputStream(BitmapUtil.createScaledBytes(context, new DecryptableUri(masterSecret, attachment.getDataUri()), this)),
-                             ContentType.IMAGE_JPEG);
+              ContentType.IMAGE_JPEG);
     } catch (BitmapDecodingException e) {
       throw new IOException(e);
     }

--- a/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/MmsMediaConstraints.java
@@ -2,12 +2,15 @@ package org.thoughtcrime.securesms.mms;
 
 import android.content.Context;
 
+import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.Util;
+
+import java.util.LinkedHashMap;
 
 public class MmsMediaConstraints extends MediaConstraints {
   private static final int MAX_IMAGE_DIMEN_LOWMEM = 768;
   private static final int MAX_IMAGE_DIMEN        = 1024;
-  public  static final int MAX_MESSAGE_SIZE       = 280 * 1024;
+  public  static int MAX_MESSAGE_SIZE             = 280 * 1024;
 
   @Override
   public int getImageMaxWidth(Context context) {
@@ -20,22 +23,47 @@ public class MmsMediaConstraints extends MediaConstraints {
   }
 
   @Override
-  public int getImageMaxSize() {
-    return MAX_MESSAGE_SIZE;
+  public int getImageMaxSize(Context context) {
+    return getCarrierMax(context);
   }
 
   @Override
-  public int getGifMaxSize() {
-    return MAX_MESSAGE_SIZE;
+  public int getGifMaxSize(Context context) {
+    return getCarrierMax(context);
   }
 
   @Override
-  public int getVideoMaxSize() {
-    return MAX_MESSAGE_SIZE;
+  public int getVideoMaxSize(Context context) {
+    return getCarrierMax(context);
   }
 
   @Override
-  public int getAudioMaxSize() {
+  public int getAudioMaxSize(Context context) {
+    return getCarrierMax(context);
+  }
+
+  private int getCarrierMax(Context context)
+  {
+    LegacyMmsConnection.Apn a;
+    String mmscUrl;
+    try {
+      a = LegacyMmsConnection.getApn(context);
+      mmscUrl = a.getMmsc();
+    } catch (ApnUnavailableException aue)
+    {
+      return MAX_MESSAGE_SIZE;
+    }
+
+    String[] keys = context.getResources().getStringArray(R.array.CarrierConstraintKeys);
+    String[] values = context.getResources().getStringArray(R.array.CarrierConstraintValues);
+    LinkedHashMap<String,String> map = new LinkedHashMap<String,String>();
+    for (int i = 0; i < Math.min(keys.length, values.length); ++i) {
+      map.put(keys[i], values[i]);
+    }
+    if(map.containsKey(mmscUrl)){
+      MAX_MESSAGE_SIZE = Integer.parseInt(map.get(mmscUrl)) * 1024;
+    }
+
     return MAX_MESSAGE_SIZE;
   }
 }

--- a/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
+++ b/src/org/thoughtcrime/securesms/mms/PushMediaConstraints.java
@@ -21,22 +21,22 @@ public class PushMediaConstraints extends MediaConstraints {
   }
 
   @Override
-  public int getImageMaxSize() {
+  public int getImageMaxSize(Context context) {
     return 6 * MB;
   }
 
   @Override
-  public int getGifMaxSize() {
+  public int getGifMaxSize(Context context) {
     return 6 * MB;
   }
 
   @Override
-  public int getVideoMaxSize() {
+  public int getVideoMaxSize(Context context) {
     return 100 * MB;
   }
 
   @Override
-  public int getAudioMaxSize() {
+  public int getAudioMaxSize(Context context) {
     return 100 * MB;
   }
 }


### PR DESCRIPTION
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel XL, Android 7.1.1
 * Nexus 6, Android 7.0
 * Virtual device Nexus 5x, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This adjusts the MMS Max Size for the 4 major US carriers based on APN MMSC URL properties. The design tenet of no new preferences required an automatic fix, but that fix requires assumption of new data (aka keeping and referencing known carrier URLs. These URLs used for matching are housed in strings.xml, to be easily maintained in the future. When creating a new MMS, the size constraints query the existing APN database information and matches to a URL and either passes a new size factor, or continues with the default.
