### PR TITLE
Keep screen on during audio playback

### DIFF
--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -1,5 +1,6 @@
 package org.thoughtcrime.securesms.audio;
 
+import android.app.Activity;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
@@ -9,6 +10,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 import android.util.Pair;
+import android.view.WindowManager;
 import android.widget.Toast;
 
 import org.thoughtcrime.securesms.R;
@@ -89,6 +91,7 @@ public class AudioSlidePlayer {
 
         notifyOnStart();
         progressEventHandler.sendEmptyMessage(0);
+        ((Activity) context).getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       }
     });
 
@@ -107,6 +110,7 @@ public class AudioSlidePlayer {
 
         notifyOnStop();
         progressEventHandler.removeMessages(0);
+        ((Activity) context).getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
       }
     });
 

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -91,7 +91,9 @@ public class AudioSlidePlayer {
 
         notifyOnStart();
         progressEventHandler.sendEmptyMessage(0);
-        ((Activity) context).getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        if (context instanceof Activity) {
+          ((Activity) context).getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
       }
     });
 
@@ -110,7 +112,9 @@ public class AudioSlidePlayer {
 
         notifyOnStop();
         progressEventHandler.removeMessages(0);
-        ((Activity) context).getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        if (context instanceof Activity) {
+          ((Activity) context).getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
       }
     });
 
@@ -132,6 +136,9 @@ public class AudioSlidePlayer {
 
         notifyOnStop();
         progressEventHandler.removeMessages(0);
+        if (context instanceof Activity) {
+          ((Activity) context).getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+        }
         return true;
       }
     });

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -159,6 +159,10 @@ public class AudioSlidePlayer {
       this.audioAttachmentServer.stop();
     }
 
+    if (context instanceof Activity) {
+      ((Activity) context).getWindow().clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+    }
+
     this.mediaPlayer           = null;
     this.audioAttachmentServer = null;
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
#4424 demands a wake lock for audio attachment playback. But a wake lock alone won't do the trick. A CPU in awake state will not be helpful if audio playback is stopped in `onPause()` (which is triggered when the screen turns off and should definitely include stopping audio playback). So I decided to implement a simple workaround that keeps the screen on during audio playback.

WhatsApp for example continues its audio playback even when the screen turned off. That's the behaviour we want for the future, I think. This PR is just an offer to slightly improve the situation.

Improves #4424
// FREEBIE