### PR TITLE
Allow conversation font scaling using volume button

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1162,7 +1162,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
   }
 
-  private void textSizeUp() {
+  public void textSizeUp() {
     float size = TextSecurePreferences.getConversationTextSize(this);
     if (size < 80.0f) {
       size += 2.0f;
@@ -1171,7 +1171,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     applyTextSize();
   }
 
-  private void textSizeDown() {
+  public void textSizeDown() {
     float size = TextSecurePreferences.getConversationTextSize(this);
     if (size > 10.0f) {
       size -= 2.0f;

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -300,6 +300,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   protected void onStart() {
     super.onStart();
     EventBus.getDefault().register(this);
+    applyTextSize();
   }
 
   @Override
@@ -532,6 +533,20 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   @Override
   public void onKeyboardShown() {
     inputPanel.onKeyboardShown();
+  }
+
+  @Override
+  public boolean dispatchKeyEvent(KeyEvent event) {
+    switch(event.getKeyCode()) {
+      case KeyEvent.KEYCODE_VOLUME_UP:
+        textSizeUp();
+        return true;
+      case KeyEvent.KEYCODE_VOLUME_DOWN:
+        textSizeDown();
+        return true;
+      default:
+        return super.dispatchKeyEvent(event);
+    }
   }
 
   //////// Event Handlers
@@ -1145,6 +1160,30 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       quickCameraToggle.setVisibility(View.GONE);
       quickCameraToggle.setEnabled(false);
     }
+  }
+
+  private void textSizeUp() {
+    float size = TextSecurePreferences.getConversationTextSize(this);
+    if (size < 80.0f) {
+      size += 2.0f;
+    }
+    TextSecurePreferences.setConversationTextSize(this, size);
+    applyTextSize();
+  }
+
+  private void textSizeDown() {
+    float size = TextSecurePreferences.getConversationTextSize(this);
+    if (size > 10.0f) {
+      size -= 2.0f;
+    }
+    TextSecurePreferences.setConversationTextSize(this, size);
+    applyTextSize();
+  }
+
+  private void applyTextSize() {
+    float size = TextSecurePreferences.getConversationTextSize(this);
+    fragment.setTextSize(size);
+    composeText.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, size + 2.0f);
   }
 
   protected void initializeActionBar() {

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -95,6 +95,8 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
   private final @NonNull  Calendar          calendar;
   private final @NonNull  MessageDigest     digest;
 
+  private float textSize = 0.0f;
+
   protected static class ViewHolder extends RecyclerView.ViewHolder {
     public <V extends View & BindableConversationItem> ViewHolder(final @NonNull V itemView) {
       super(itemView);
@@ -180,12 +182,21 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     super.changeCursor(cursor);
   }
 
+  public void setTextSize(float size) {
+    textSize = size;
+    notifyDataSetChanged();
+  }
+
   @Override
   public void onBindItemViewHolder(ViewHolder viewHolder, @NonNull Cursor cursor) {
     long          start         = System.currentTimeMillis();
     MessageRecord messageRecord = getMessageRecord(cursor);
 
     viewHolder.getView().bind(masterSecret, messageRecord, locale, batchSelected, recipients);
+    TextView t = (TextView) viewHolder.getView().findViewById(R.id.conversation_item_body);
+    if (t != null && textSize > 0.0f) {
+      t.setTextSize(android.util.TypedValue.COMPLEX_UNIT_SP, textSize);
+    }
     Log.w(TAG, "Bind time: " + (System.currentTimeMillis() - start));
   }
 

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -41,6 +41,8 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
+import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
@@ -101,6 +103,8 @@ public class ConversationFragment extends Fragment
   private View                        scrollToBottomButton;
   private TextView                    scrollDateHeader;
 
+  private ScaleGestureDetector scaleGestureDetector;
+
   public void setTextSize(float size) {
     if (list == null) return;
     ConversationAdapter a = (ConversationAdapter) list.getAdapter();
@@ -130,6 +134,9 @@ public class ConversationFragment extends Fragment
       }
     });
 
+    list.setOnTouchListener(onTouchListener);
+    scaleGestureDetector = new ScaleGestureDetector(getContext(), new ScaleListener());
+
     final LinearLayoutManager layoutManager = new LinearLayoutManager(getActivity(), LinearLayoutManager.VERTICAL, true);
     list.setHasFixedSize(false);
     list.setLayoutManager(layoutManager);
@@ -146,6 +153,16 @@ public class ConversationFragment extends Fragment
     });
     return view;
   }
+
+  private final View.OnTouchListener onTouchListener = new View.OnTouchListener() {
+    @Override
+    public boolean onTouch(View v, MotionEvent event) {
+      if (scaleGestureDetector != null) {
+        scaleGestureDetector.onTouchEvent(event);
+      }
+      return scaleGestureDetector.isInProgress();
+    }
+  };
 
   @Override
   public void onActivityCreated(Bundle bundle) {
@@ -465,6 +482,20 @@ public class ConversationFragment extends Fragment
 
   public interface ConversationFragmentListener {
     void setThreadId(long threadId);
+  }
+
+  private class ScaleListener extends ScaleGestureDetector.SimpleOnScaleGestureListener {
+    @Override
+    public boolean onScale(ScaleGestureDetector detector) {
+      float f = detector.getScaleFactor();
+      if (f > 1.0f) {
+        ((ConversationActivity) getActivity()).textSizeUp();
+      }
+      else if (f < 1.0f) {
+        ((ConversationActivity) getActivity()).textSizeDown();
+      }
+      return true;
+    }
   }
 
   private class ConversationScrollListener extends OnScrollListener {

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -101,6 +101,13 @@ public class ConversationFragment extends Fragment
   private View                        scrollToBottomButton;
   private TextView                    scrollDateHeader;
 
+  public void setTextSize(float size) {
+    if (list == null) return;
+    ConversationAdapter a = (ConversationAdapter) list.getAdapter();
+    if (a == null) return;
+    a.setTextSize(size);
+  }
+
   @Override
   public void onCreate(Bundle icicle) {
     super.onCreate(icicle);

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -103,6 +103,17 @@ public class TextSecurePreferences {
   public  static final String DIRECT_CAPTURE_CAMERA_ID         = "pref_direct_capture_camera_id";
   private static final String ALWAYS_RELAY_CALLS_PREF          = "pref_turn_only";
 
+  private static final String CONVERSATION_TEXT_SIZE_PREF      = "pref_conversation_text_size";
+
+  public static float getConversationTextSize(Context context) {
+    // Default value stolen from conversation_item_body_text_size in res/values/dimens.xml
+    return getFloatPreference(context, CONVERSATION_TEXT_SIZE_PREF, 16.0f);
+  }
+
+  public static void setConversationTextSize(Context context, float size) {
+    setFloatPreference(context, CONVERSATION_TEXT_SIZE_PREF, size);
+  }
+
   public static boolean isTurnOnly(Context context) {
     return getBooleanPreference(context, ALWAYS_RELAY_CALLS_PREF, false);
   }
@@ -607,6 +618,14 @@ public class TextSecurePreferences {
 
   private static void setLongPreference(Context context, String key, long value) {
     PreferenceManager.getDefaultSharedPreferences(context).edit().putLong(key, value).apply();
+  }
+
+  private static float getFloatPreference(Context context, String key, float defaultValue) {
+    return PreferenceManager.getDefaultSharedPreferences(context).getFloat(key, defaultValue);
+  }
+
+  private static void setFloatPreference(Context context, String key, float value) {
+    PreferenceManager.getDefaultSharedPreferences(context).edit().putFloat(key, value).apply();
   }
 
   private static Set<String> getStringSetPreference(Context context, String key, Set<String> defaultValues) {


### PR DESCRIPTION
This provides approximately the same functionality as the default
messaging app on Android, i.e. the volume button can now be used to
scale the font up and down when viewing a conversation.  The scale
range is somewhat arbitrarily set to 10sp - 80sp, with the text
input field having a size 2sp larger than the conversation text.
Metadata display (message delivery time, acks, etc.) remains
unaffected.

Fixes #1509

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S5, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

As above. Tested by starting signal, bouncing between the conversation list and two individual conversations, and wiggling the volume button. The size set is adjustable when viewing conversations, and is maintained between conversation views.