### PR TITLE
Fix last seen divider crash on Android <5.0

### DIFF
--- a/res/drawable/last_seen_divider_text_background_dark.xml
+++ b/res/drawable/last_seen_divider_text_background_dark.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
+    <solid android:color="#ff333333"/>
+
+    <corners android:radius="65dp"/>
+    <padding android:bottom="10dp" android:left="15dp" android:right="15dp" android:top="10dp"/>
+</shape>

--- a/res/drawable/last_seen_divider_text_background_light.xml
+++ b/res/drawable/last_seen_divider_text_background_light.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
-    <solid android:color="?conversation_item_last_seen_text_background"/>
+    <solid android:color="@color/white"/>
 
     <corners android:radius="65dp"/>
     <padding android:bottom="10dp" android:left="15dp" android:right="15dp" android:top="10dp"/>

--- a/res/layout/conversation_item_last_seen.xml
+++ b/res/layout/conversation_item_last_seen.xml
@@ -15,6 +15,6 @@
                   android:textSize="12sp"
                   android:textAllCaps="true"
                   android:textStyle="bold"
-                  android:background="@drawable/last_seen_divider_text_background"
+                  android:background="?conversation_item_last_seen_text_background"
                   tools:text="3 unread messages" />
 </FrameLayout>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -73,7 +73,7 @@
     <attr name="conversation_item_sent_indicator_text_background" format="reference" />
     <attr name="conversation_item_header_background" format="reference"/>
     <attr name="conversation_item_last_seen_background" format="reference|color"/>
-    <attr name="conversation_item_last_seen_text_background" format="color"/>
+    <attr name="conversation_item_last_seen_text_background" format="reference"/>
 
     <attr name="dialog_info_icon" format="reference" />
     <attr name="dialog_alert_icon" format="reference" />

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -158,7 +158,7 @@
         <item name="conversation_item_received_text_secondary_color">#BFffffff</item>
         <item name="conversation_item_header_background">@drawable/conversation_item_header_background</item>
         <item name="conversation_item_last_seen_background">@drawable/last_seen_background</item>
-        <item name="conversation_item_last_seen_text_background">@color/white</item>
+        <item name="conversation_item_last_seen_text_background">@drawable/last_seen_divider_text_background_light</item>
 
         <item name="quick_camera_icon">@drawable/quick_camera_light</item>
         <item name="quick_mic_icon">@drawable/ic_mic_grey600_24dp</item>
@@ -247,7 +247,7 @@
         <item name="conversation_item_sent_indicator_text_background">@drawable/conversation_item_sent_indicator_text_shape_dark</item>
         <item name="conversation_item_header_background">@drawable/conversation_item_header_background_dark</item>
         <item name="conversation_item_last_seen_background">#66333333</item>
-        <item name="conversation_item_last_seen_text_background">#ff333333</item>
+        <item name="conversation_item_last_seen_text_background">@drawable/last_seen_divider_text_background_dark</item>
 
         <item name="verification_background">#ff333333</item>
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * API 25 emulator
 * Android 4.2 phone
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Currently, Signal 3.30 crashes for me on Android 4.2 when it tries to inflate the new "last seen" divider in a conversation. I get
```
android.view.InflateException: Binary XML file line #11: Error inflating class TextView
```
caused by
```
android.content.res.Resources$NotFoundException: File res/drawable/last_seen_divider_text_background.xml from drawable resource ID #0x7f0201b8
```
caused by
```
java.lang.UnsupportedOperationException: Can't convert to color: type=0x2
```
Apparently, it's not possible to reference an attribute in an xml drawable on API <21, so we have to use separate light and dark theme drawables instead.

Tested in a 7.1 emulator and on my 4.2 device with both light and dark themes.