### PR TITLE
Do not call Notification.setSound with empty ringtone

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
+++ b/src/org/thoughtcrime/securesms/notifications/AbstractNotificationBuilder.java
@@ -44,8 +44,8 @@ public abstract class AbstractNotificationBuilder extends NotificationCompat.Bui
     String  defaultRingtoneName = TextSecurePreferences.getNotificationRingtone(context);
     boolean defaultVibrate      = TextSecurePreferences.isNotificationVibrateEnabled(context);
 
-    if      (ringtone != null)                        setSound(ringtone);
-    else if (!TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
+    if      (ringtone == null && !TextUtils.isEmpty(defaultRingtoneName)) setSound(Uri.parse(defaultRingtoneName));
+    else if (ringtone != null && !ringtone.toString().isEmpty())          setSound(ringtone);
 
     if (vibrate == RecipientPreferenceDatabase.VibrateState.ENABLED ||
         (vibrate == RecipientPreferenceDatabase.VibrateState.DEFAULT && defaultVibrate))


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

This PR fixes/improves #5462 and makes the behavior consistent between Signal default notification preferences and per recipient preferences.

Info on recipient ringtone preferences (see #4957):
* `ringtone == null` means Signal default
* `ringtone.toString().isEmpty()` means silent

If you set a recipient's ringtone to silent, Android will not play a notification sound because the value is an empty URI. But whenever `Notification.setSound` was called and the device is muted, Android will vibrate on notifications instead (even in case of an empty URI). I tested this on Android 5.1.1, so it is possible that other versions of Android do not vibrate in that case.

How to test / steps to reproduce (Android 5.1.1):
1. set device muted (vibrate only)
2. set Signal notification preferences to: Sound none, Vibrate disabled
2a. set Recipient notification settings to default
3a. receive message: notification **does not** vibrate
3. set Recipient notification settings to: Sound silent, Vibrate disabled
1a. set Signal notification settings to: Sound default, Vibrate on
2a. receive message: notification **does** vibrate

So Signal should not call `setSound` in either case if the URI is empty.