### PR TITLE
Fix unread messages separator not shown (timestamp comparison)

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -289,7 +289,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
       Cursor        cursor        = getCursorAtPositionOrThrow(i);
       MessageRecord messageRecord = getMessageRecord(cursor);
 
-      if (messageRecord.getTimestamp() < lastSeen) {
+      if (messageRecord.getDateReceived() <= lastSeen) {
         return i;
       }
     }
@@ -335,7 +335,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     return Util.hashCode(calendar.get(Calendar.YEAR), calendar.get(Calendar.DAY_OF_YEAR));
   }
 
-  public long getTimestamp(int position) {
+  public long getReceivedTimestamp(int position) {
     if (!isActiveCursor())          return 0;
     if (isHeaderPosition(position)) return 0;
     if (isFooterPosition(position)) return 0;
@@ -345,7 +345,7 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     Cursor        cursor        = getCursorAtPositionOrThrow(position);
     MessageRecord messageRecord = getMessageRecord(cursor);
 
-    return messageRecord.getTimestamp();
+    return messageRecord.getDateReceived();
   }
 
   @Override
@@ -388,10 +388,10 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
         return false;
       }
 
-      long currentRecordTimestamp  = adapter.getTimestamp(position);
-      long previousRecordTimestamp = adapter.getTimestamp(position + 1);
+      long currentRecordTimestamp  = adapter.getReceivedTimestamp(position);
+      long previousRecordTimestamp = adapter.getReceivedTimestamp(position + 1);
 
-      return currentRecordTimestamp > lastSeenTimestamp && previousRecordTimestamp < lastSeenTimestamp;
+      return currentRecordTimestamp > lastSeenTimestamp && previousRecordTimestamp <= lastSeenTimestamp;
     }
 
     @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
The unread message separator is missing sometimes because the `lastSeen` timestamp is compared to the sent date of the message instead of the received date.

### Steps to reproduce
- disable wifi and mobile date
- a contact sends you a message (which you do not yet receive)
- check that contacts message thread to read some old messages
- leave the conversation
- enable wifi / mobile date
- receive the new message
- enter conversation thread 
