### PR TITLE
Fix outgoing group edit action marked as unread messages

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -392,6 +392,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
       titleView.setTitle(recipients);
       setBlockedUserState(recipients, isSecureText, isDefaultSms);
       supportInvalidateOptionsMenu();
+      fragment.setLastSeen(0);
       break;
     case TAKE_PHOTO:
       if (attachmentManager.getCaptureUri() != null) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
When a user edits a group, the generated status message is shown to that user with an unread message separator.

### Steps to reproduce
- open a group conversation thread
- edit that group

### Note
- there is the remaining issue that outgoing calls are marked as unread

@moxie0 I haven't digged all to deep into this. Is there a reason that you introduced the last seen timestamp instead of using the existing message read flag?