### PR TITLE
Revert "Fixing broken unit test for ConversationAdapter"

### DIFF
--- a/test/unitTest/java/org/thoughtcrime/securesms/ConversationAdapterTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/ConversationAdapterTest.java
@@ -24,11 +24,14 @@ public class ConversationAdapterTest extends BaseUnitTest {
   }
 
   @Test
-  public void testGetItemIdEquals() {
-    when(cursor.getLong(anyInt())).thenReturn(1234L);
+  public void testGetItemIdEquals() throws Exception {
+    when(cursor.getString(anyInt())).thenReturn("SMS::1::1");
     long firstId = adapter.getItemId(cursor);
-    when(cursor.getLong(anyInt())).thenReturn(4321L);
+    when(cursor.getString(anyInt())).thenReturn("MMS::1::1");
     long secondId = adapter.getItemId(cursor);
     assertNotEquals(firstId, secondId);
+    when(cursor.getString(anyInt())).thenReturn("MMS::2::1");
+    long thirdId = adapter.getItemId(cursor);
+    assertNotEquals(secondId, thirdId);
   }
 }


### PR DESCRIPTION
Fixes #6250
Commit 7286fd9 that broke this unit test was reverted so the change to
this unit test has also to be reverted since the unit test currently
fails.

// FREEBIE

This reverts commit 11463d410dca3fc4757b9f476f77f8a72be08f17.

### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit
