### PR TITLE
Fix occasional crash on Android 7 direct reply

### DIFF
--- a/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
+++ b/src/org/thoughtcrime/securesms/notifications/RemoteReplyReceiver.java
@@ -60,7 +60,6 @@ public class RemoteReplyReceiver extends MasterSecretBroadcastReceiver {
 
     final long[]       recipientIds = intent.getLongArrayExtra(RECIPIENT_IDS_EXTRA);
     final CharSequence responseText = remoteInput.getCharSequence(MessageNotifier.EXTRA_REMOTE_REPLY);
-    final Recipients   recipients   = RecipientFactory.getRecipientsForIds(context, recipientIds, false);
 
     if (masterSecret != null && responseText != null) {
       new AsyncTask<Void, Void, Void>() {
@@ -72,6 +71,7 @@ public class RemoteReplyReceiver extends MasterSecretBroadcastReceiver {
           int  subscriptionId = preferences.isPresent() ? preferences.get().getDefaultSubscriptionId().or(-1) : -1;
           long expiresIn      = preferences.isPresent() ? preferences.get().getExpireMessages() * 1000 : 0;
 
+          Recipients recipients = RecipientFactory.getRecipientsForIds(context, recipientIds, false);
           if (recipients.isGroupRecipient()) {
             OutgoingMediaMessage reply = new OutgoingMediaMessage(recipients, responseText.toString(), new LinkedList<Attachment>(), System.currentTimeMillis(), subscriptionId, expiresIn, 0);
             threadId = MessageSender.send(context, masterSecret, reply, -1, false);


### PR DESCRIPTION

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 4, Android 7.1
 * Galaxy S5, LineageOS Android 7.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The use of the RecipientFactory in the RemoteReplyReceiver was done in the main thread. This is a problem when the recipient's data isn't cached because then the ContactPhotoFactory would perform Glide actions on the main thread, which calls the exception of the issue.

I just moved the use of the RecipientFactory inside the AsyncTask we use later; this is also the place where we need the recipients the first time.

Direct reply still works as intended after this change.

Related Issue: https://github.com/WhisperSystems/Signal-Android/issues/6185