### PR TITLE
Add action indicator when resending a message.

### DIFF
--- a/res/layout/message_recipient_list_item.xml
+++ b/res/layout/message_recipient_list_item.xml
@@ -56,6 +56,13 @@
                       tools:visibility="visible"
                       tools:text="New identity" />
 
+            <TextView android:id="@+id/action_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:visibility="visible"
+                tools:text="action" />
+
         </LinearLayout>
 
         <Button android:id="@+id/conflict_button"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -880,6 +880,7 @@
     <!-- message_recipients_list_item -->
     <string name="message_recipients_list_item__verify">VERIFY</string>
     <string name="message_recipients_list_item__resend">RESEND</string>
+    <string name="message_recipients_list_item__resending">Resending&#8230;</string>
 
     <!-- GroupUtil -->
     <plurals name="GroupUtil_joined_the_group">

--- a/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
+++ b/src/org/thoughtcrime/securesms/MessageRecipientListItem.java
@@ -50,6 +50,7 @@ public class MessageRecipientListItem extends RelativeLayout
   private Recipient       recipient;
   private FromTextView    fromView;
   private TextView        errorDescription;
+  private TextView        actionDescription;
   private Button          conflictButton;
   private Button          resendButton;
   private AvatarImageView contactPhotoImage;
@@ -68,6 +69,7 @@ public class MessageRecipientListItem extends RelativeLayout
   protected void onFinishInflate() {
     this.fromView          = (FromTextView)    findViewById(R.id.from);
     this.errorDescription  = (TextView)        findViewById(R.id.error_description);
+    this.actionDescription = (TextView)        findViewById(R.id.action_description);
     this.contactPhotoImage = (AvatarImageView) findViewById(R.id.contact_photo_image);
     this.conflictButton    = (Button)          findViewById(R.id.conflict_button);
     this.resendButton      = (Button)          findViewById(R.id.resend_button);
@@ -116,7 +118,10 @@ public class MessageRecipientListItem extends RelativeLayout
       resendButton.setOnClickListener(new OnClickListener() {
         @Override
         public void onClick(View v) {
-          resendButton.setEnabled(false);
+          resendButton.setVisibility(View.GONE);
+          errorDescription.setVisibility(View.GONE);
+          actionDescription.setVisibility(View.VISIBLE);
+          actionDescription.setText(R.string.message_recipients_list_item__resending);
           new ResendAsyncTask(masterSecret, record, networkFailure).execute();
         }
       });


### PR DESCRIPTION

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [X] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [X] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [X] I have tested my contribution on these devices:
 * Nexus 5x, Android 7.1.1
- [X] My contribution is fully baked and ready to be merged as is
- [X] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [X] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

When sending of message fails, user can go into details of that message and click RESEND button to retry. As issue #6307 mentions, after clicking that button nothing really indicates on the screen that message is being resent in the background.

This pull request hides the RESEND button when resending asynchronous task is started, as well as hides the "error_description" TextView and replaces it with the "action_description" TextView which says "Resending...". That should provide a nice indicator that clicking the RESEND button actually had an effect.