### PR TITLE
Speex decoder is vulnerable

### DIFF
--- a/jni/redphone/AudioCodec.h
+++ b/jni/redphone/AudioCodec.h
@@ -36,6 +36,7 @@ public:
 
   int init();
   int encode(short *rawData, char* encodedData, int encodedDataLen);
+  // rawData must be able to hold at least SPEEX_FRAME_SIZE samples
   int decode(char* encodedData, int encodedDataLen, short* rawData);
   int conceal(int frames, short *rawData);
 


### PR DESCRIPTION
### Bug description
The speex decoder used by Signal is vulnerable.

A malicious user can initiate a voice call with a victim, then send bad speex frames to crash the victim's Signal app. It may also be possible to achieve remote code execution.

### Steps to reproduce
- Write a minimal program replicating Signal's usage of libspeex. You can use this one: https://gist.github.com/klemensbaum/fb7c41c981ac43a5abbb3d8fb99d3902
- Obtain some sample audio and convert it to raw speex frames. Save each frame as a separate file in a testcases directory.
- *(optional)* Prune redundant test cases with `afl-tmin`
- Run `afl-fuzz` over it: `afl-fuzz -i testcases -o findings -- ./speex-fuzz @@`

**Actual result:** `afl-fuzz` finds a lot of crashes
**Expected result:** `afl-fuzz` doesn't find any crashes

### Example crashes

Some example crashes found during a short `afl-fuzz` run: https://gist.github.com/klemensbaum/3df0260fe459c10a5adb2fd569b41dda

