### PR TITLE
Fix NPE crash when no bluetooth is available

### DIFF
--- a/src/org/thoughtcrime/securesms/webrtc/audio/BluetoothStateManager.java
+++ b/src/org/thoughtcrime/securesms/webrtc/audio/BluetoothStateManager.java
@@ -49,6 +49,9 @@ public class BluetoothStateManager {
     this.bluetoothConnectionReceiver = new BluetoothConnectionReceiver();
     this.listener                    = listener;
 
+    if (this.bluetoothAdapter == null)
+      return;
+
     requestHeadsetProxyProfile();
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am ALWAYS ^^ following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Emulator NEXUS API 23 
 * Sony Z1 comapct, Android 5.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Fixes #6355
If a device has no bluetooth support (like the Android Emulator)
`BluetoothAdapter.getDefaultAdapter()` [returns null](https://developer.android.com/reference/android/bluetooth/BluetoothAdapter.html#getDefaultAdapter())

No negative impact detected on my bluetooth device.