### PR TITLE
Fallback to SMS app for invitations

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -647,12 +647,23 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void handleInviteLink() {
+    String inviteText;
     try {
       boolean a = SecureRandom.getInstance("SHA1PRNG").nextBoolean();
-      if (a) composeText.appendInvite(getString(R.string.ConversationActivity_lets_switch_to_signal, "https://sgnl.link/1LoIMUl"));
-      else   composeText.appendInvite(getString(R.string.ConversationActivity_lets_use_this_to_chat, "https://sgnl.link/1MF56H1"));
+      if (a) inviteText = getString(R.string.ConversationActivity_lets_switch_to_signal, "https://sgnl.link/1LoIMUl");
+      else   inviteText = getString(R.string.ConversationActivity_lets_use_this_to_chat, "https://sgnl.link/1MF56H1");
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
+    }
+
+    if (isDefaultSms) {
+      composeText.appendInvite(inviteText);
+    } else {
+      Intent intent = new Intent(Intent.ACTION_SENDTO);
+      intent.setData(Uri.parse("smsto:".concat(recipients.getPrimaryRecipient().getNumber())));
+      intent.putExtra("sms_body", inviteText);
+      intent.putExtra(Intent.EXTRA_TEXT, inviteText);
+      startActivity(intent);
     }
   }
 


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 5.1
 * AVD Nexus 5X, Android 7.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
If Signal is not the default SMS app, the default SMS app will be used for in-conversation invitations.

Some people at stackoverflow wrote, that they needed to use `intent.putExtra(Intent.EXTRA_TEXT, inviteText);` to actually pass text to the SMS app prior to 4.4.4. I was not able to verify this due to problems setting up an appropriate emulator. But including this line won't hurt.

Fixes #6369
// FREEBIE