### PR TITLE
Make plaintext export more compatible with SMS Backup and Restore

### DIFF
--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -51,6 +51,7 @@ public class PlaintextBackupExporter {
       while ((record = reader.getNext()) != null) {
         XmlBackup.XmlBackupItem item =
             new XmlBackup.XmlBackupItem(0, record.getIndividualRecipient().getNumber(),
+                                        record.getIndividualRecipient().getName(),
                                         record.getDateReceived(),
                                         MmsSmsColumns.Types.translateToSystemBaseType(record.getType()),
                                         null, record.getDisplayBody().toString(), null,

--- a/src/org/thoughtcrime/securesms/database/XmlBackup.java
+++ b/src/org/thoughtcrime/securesms/database/XmlBackup.java
@@ -11,6 +11,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.text.SimpleDateFormat;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -18,7 +19,9 @@ public class XmlBackup {
 
   private static final String PROTOCOL       = "protocol";
   private static final String ADDRESS        = "address";
+  private static final String CONTACT_NAME   = "contact_name";
   private static final String DATE           = "date";
+  private static final String READABLE_DATE  = "readable_date";
   private static final String TYPE           = "type";
   private static final String SUBJECT        = "subject";
   private static final String BODY           = "body";
@@ -28,6 +31,8 @@ public class XmlBackup {
   private static final String TOA            = "toa";
   private static final String SC_TOA         = "sc_toa";
   private static final String LOCKED         = "locked";
+
+  private static final SimpleDateFormat dateFormatter = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z");
 
   private final XmlPullParser parser;
 
@@ -62,7 +67,9 @@ public class XmlBackup {
 
         if      (attributeName.equals(PROTOCOL      )) item.protocol      = Integer.parseInt(parser.getAttributeValue(i));
         else if (attributeName.equals(ADDRESS       )) item.address       = parser.getAttributeValue(i);
+        else if (attributeName.equals(CONTACT_NAME  )) item.contactName   = parser.getAttributeValue(i);
         else if (attributeName.equals(DATE          )) item.date          = Long.parseLong(parser.getAttributeValue(i));
+        else if (attributeName.equals(READABLE_DATE )) item.readableDate  = parser.getAttributeValue(i);
         else if (attributeName.equals(TYPE          )) item.type          = Integer.parseInt(parser.getAttributeValue(i));
         else if (attributeName.equals(SUBJECT       )) item.subject       = parser.getAttributeValue(i);
         else if (attributeName.equals(BODY          )) item.body          = parser.getAttributeValue(i);
@@ -80,7 +87,9 @@ public class XmlBackup {
   public static class XmlBackupItem {
     private int    protocol;
     private String address;
+    private String contactName;
     private long   date;
+    private String readableDate;
     private int    type;
     private String subject;
     private String body;
@@ -90,12 +99,14 @@ public class XmlBackup {
 
     public XmlBackupItem() {}
 
-    public XmlBackupItem(int protocol, String address, long date, int type, String subject,
-                         String body, String serviceCenter, int read, int status)
+    public XmlBackupItem(int protocol, String address, String contactName, long date, int type,
+                         String subject, String body, String serviceCenter, int read, int status)
     {
       this.protocol      = protocol;
       this.address       = address;
+      this.contactName   = contactName;
       this.date          = date;
+      this.readableDate  = dateFormatter.format(date);
       this.type          = type;
       this.subject       = subject;
       this.body          = body;
@@ -112,8 +123,16 @@ public class XmlBackup {
       return address;
     }
 
+    public String getContactName() {
+      return contactName;
+    }
+
     public long getDate() {
       return date;
+    }
+
+    public String getReadableDate() {
+      return readableDate;
     }
 
     public int getType() {
@@ -172,7 +191,9 @@ public class XmlBackup {
       stringBuilder.append(OPEN_TAG_SMS);
       appendAttribute(stringBuilder, PROTOCOL, item.getProtocol());
       appendAttribute(stringBuilder, ADDRESS, escapeXML(item.getAddress()));
+      appendAttribute(stringBuilder, CONTACT_NAME, item.getContactName());
       appendAttribute(stringBuilder, DATE, item.getDate());
+      appendAttribute(stringBuilder, READABLE_DATE, item.getReadableDate());
       appendAttribute(stringBuilder, TYPE, item.getType());
       appendAttribute(stringBuilder, SUBJECT, escapeXML(item.getSubject()));
       appendAttribute(stringBuilder, BODY, escapeXML(item.getBody()));


### PR DESCRIPTION
This commit adds the contact name and the readable date (and time) to
the plaintext export of every message. That's because that is how SMS
Backup and Restore does it, so this commit makes Signal more compatible.

// FREEBIE

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy Express Prime, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This makes the plaintext export from Signal more compatible with the export from SMS Backup and Restore by adding a readable date (and time), as well as the contact name, to every message.