### PR TITLE
Grey 'LED blink pattern' when LED Color is None

### DIFF
--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -20,7 +20,7 @@
                         android:title="@string/preferences__vibrate"
                         android:summary="@string/preferences__also_vibrate_when_notified" />
 
-    <ListPreference
+    <org.thoughtcrime.securesms.preferences.BooleanListPreference
         android:key="pref_led_color"
         android:defaultValue="blue"
         android:title="@string/preferences__led_color"
@@ -32,7 +32,7 @@
         android:key="pref_led_blink"
         android:defaultValue="500,2000"
         android:title="@string/preferences__pref_led_blink_title"
-        android:dependency="pref_key_enable_notifications"
+        android:dependency="pref_led_color"
         android:entries="@array/pref_led_blink_pattern_entries"
         android:entryValues="@array/pref_led_blink_pattern_values" />
 

--- a/src/org/thoughtcrime/securesms/preferences/BooleanListPreference.java
+++ b/src/org/thoughtcrime/securesms/preferences/BooleanListPreference.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (C) 2017 Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.preferences;
+
+import android.content.Context;
+import android.preference.ListPreference;
+import android.util.AttributeSet;
+
+import org.thoughtcrime.securesms.R;
+
+/**
+ * List preference that disables dependents when set to "none", similar to a CheckBoxPreference.
+ *
+ * @author Taylor Kline
+ */
+
+public class BooleanListPreference extends ListPreference {
+
+  public BooleanListPreference(Context context, AttributeSet attrs) {
+    super(context, attrs);
+  }
+
+  public BooleanListPreference(Context context) {
+    super(context);
+  }
+
+  @Override
+  public void setValue(String value) {
+    CharSequence oldEntry = getEntry();
+    super.setValue(value);
+    CharSequence newEntry = getEntry();
+    if (oldEntry != newEntry) {
+      notifyDependencyChange(shouldDisableDependents());
+    }
+  }
+
+  @Override
+  public boolean shouldDisableDependents() {
+    CharSequence newEntry = getEntry();
+    String noneEntry = getContext().getString(R.string.preferences__none);
+    boolean shouldDisable = newEntry.equals(noneEntry);
+    return shouldDisable || super.shouldDisableDependents();
+  }
+}


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
* Nexus 6P running 6.0.1 (CM 13.0)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Add BooleanListPreference to allow pref_led_blink to depend on pref_led_color being non-None. When pref_led_color is None, pref_led_blink will be greyed out.

----------

### Screenshot

![LED notifications disabled](https://cloud.githubusercontent.com/assets/2641739/22085695/cb342f34-dd9a-11e6-99ec-aa208ccbda2a.png)