### PR TITLE
Add FAB animation on ConversationListFragment

### DIFF
--- a/res/layout/conversation_list_fragment.xml
+++ b/res/layout/conversation_list_fragment.xml
@@ -3,28 +3,29 @@
 <android.support.design.widget.CoordinatorLayout
               xmlns:android="http://schemas.android.com/apk/res/android"
               xmlns:tools="http://schemas.android.com/tools"
-              xmlns:fab="http://schemas.android.com/apk/res-auto"
+              xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="fill_parent"
               android:layout_height="fill_parent"
               android:orientation="vertical">
 
-    <LinearLayout android:layout_width="match_parent"
-                  android:layout_height="match_parent"
-                  android:orientation="vertical">
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
         <org.thoughtcrime.securesms.components.reminder.ReminderView
-                android:id="@+id/reminder"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content" />
+            android:id="@+id/reminder"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
         <android.support.v7.widget.RecyclerView
-                android:id="@+id/list"
-                android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:scrollbars="vertical"
-                android:nextFocusDown="@+id/fab"
-                android:nextFocusForward="@+id/fab"
-                tools:listitem="@layout/conversation_list_item_view" />
+            android:id="@+id/list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical"
+            android:nextFocusDown="@+id/fab"
+            android:nextFocusForward="@+id/fab"
+            tools:listitem="@layout/conversation_list_item_view" />
 
     </LinearLayout>
 
@@ -32,10 +33,11 @@
             android:id="@+id/fab"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
             android:layout_margin="16dp"
             android:src="@drawable/ic_create_white_24dp"
             android:focusable="true"
-            android:contentDescription="@string/conversation_list_fragment__fab_content_description"/>
+            android:contentDescription="@string/conversation_list_fragment__fab_content_description"
+            app:layout_anchor="@+id/list"
+            app:layout_anchorGravity="bottom|end" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/res/layout/conversation_list_fragment.xml
+++ b/res/layout/conversation_list_fragment.xml
@@ -8,24 +8,23 @@
               android:layout_height="fill_parent"
               android:orientation="vertical">
 
-    <LinearLayout
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical">
+    <LinearLayout android:layout_width="match_parent"
+                  android:layout_height="match_parent"
+                  android:orientation="vertical">
 
         <org.thoughtcrime.securesms.components.reminder.ReminderView
-            android:id="@+id/reminder"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content" />
+                android:id="@+id/reminder"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content" />
 
         <android.support.v7.widget.RecyclerView
-            android:id="@+id/list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scrollbars="vertical"
-            android:nextFocusDown="@+id/fab"
-            android:nextFocusForward="@+id/fab"
-            tools:listitem="@layout/conversation_list_item_view" />
+                android:id="@+id/list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical"
+                android:nextFocusDown="@+id/fab"
+                android:nextFocusForward="@+id/fab"
+                tools:listitem="@layout/conversation_list_item_view" />
 
     </LinearLayout>
 

--- a/src/org/thoughtcrime/securesms/ConversationListFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationListFragment.java
@@ -126,6 +126,18 @@ public class ConversationListFragment extends Fragment
     list.setLayoutManager(new LinearLayoutManager(getActivity()));
     list.setItemAnimator(new DeleteItemAnimator());
 
+    // show / hide Floating Action Button depending on scroll direction
+    list.addOnScrollListener(new RecyclerView.OnScrollListener() {
+      @Override
+      public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+        if(dy > 0){
+          fab.hide();
+        } else {
+          fab.show();
+        }
+      }
+    });
+
     new ItemTouchHelper(new ArchiveListenerCallback()).attachToRecyclerView(list);
 
     return view;


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Redmi Note 4X, Android 7.1.1 (LineageOS, not MIUI)
- [x] My contribution is fully baked and ready to be merged as is
- [x] ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This commit adds an animation to the floating action button on the ConversationListFragment to disappear when scrolling down and appear when scrolling up. This is an often used animation in Apps that are based on Material Design.