### PR TITLE
Add travis-ci configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: android
+jdk: oraclejdk8
+env:
+    global:
+        - ADB_INSTALL_TIMEOUT = 10
+android:
+    components:
+        - tools
+        - platform-tools
+        - build-tools-25.0.0
+        - android-25
+
+        - extra-google-m2repository
+        - extra-android-m2repository
+
+        # System image for emulation
+        - sys-img-armeabi-v7a-android-21
+    licenses:
+        - 'android-sdk-license-.+'
+script:
+    - set -e # enable fast finish
+    - ./gradlew -PjavaMaxHeapSize=1g assemble lint
+    - android list targets
+    - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+    - emulator -avd test -no-audio -no-window &
+    - android-wait-for-emulator
+    - adb shell input keyevent 82 &
+    - ./gradlew -PjavaMaxHeapSize=1g connectedCheck
+    - set +e

--- a/build.gradle
+++ b/build.gradle
@@ -195,7 +195,7 @@ android {
     useLibrary 'org.apache.http.legacy'
 
     dexOptions {
-        javaMaxHeapSize "4g"
+        javaMaxHeapSize project.hasProperty('javaMaxHeapSize') ? project.getProperty('javaMaxHeapSize') : "4g"
     }
 
     defaultConfig {


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * DOES NOT APPLY
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

* __Scope:__ I am just adding a `.travis.yml` file and editing one line in `build.gradle`. The "WhisperSystems" account should be linked to a Travis-CI (https://travis-ci.org/) account for it to work. The integration with GitHub is quite good (I tested on my fork).
* __Risk:__ Almost inexistant. I had to change one minor line in the `build.gradle`, but that has no consequences on the code itself.
* __Notes:__ The travis configuration required a few tricks (the build was crashing because of memory issues, for instance, so the javaMaxHeapSize had to be decreased and the simulator had to be started after the build, ...). It is working right now on my fork, but I guess that will have to be checked with the other branches.