### PR TITLE
Move SMS/MMS pref hiding logic to onCreate

### DIFF
--- a/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
+++ b/src/org/thoughtcrime/securesms/preferences/SmsMmsPreferenceFragment.java
@@ -31,6 +31,8 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
 
     this.findPreference(MMS_PREF)
       .setOnPreferenceClickListener(new ApnPreferencesClickListener());
+
+    initializePlatformSpecificOptions();
   }
 
   @Override
@@ -38,7 +40,7 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
     super.onResume();
     ((ApplicationPreferencesActivity) getActivity()).getSupportActionBar().setTitle(R.string.preferences__sms_mms);
 
-    initializePlatformSpecificOptions();
+    initializeDefaultPreference();
   }
 
   private void initializePlatformSpecificOptions() {
@@ -51,24 +53,29 @@ public class SmsMmsPreferenceFragment extends PreferenceFragment {
     if (VERSION.SDK_INT >= VERSION_CODES.KITKAT) {
       if (allSmsPreference != null) preferenceScreen.removePreference(allSmsPreference);
       if (allMmsPreference != null) preferenceScreen.removePreference(allMmsPreference);
-
-      if (Util.isDefaultSmsProvider(getActivity())) {
-        defaultPreference.setIntent(new Intent(Settings.ACTION_WIRELESS_SETTINGS));
-        defaultPreference.setTitle(getString(R.string.ApplicationPreferencesActivity_sms_enabled));
-        defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_change_your_default_sms_app));
-      } else {
-        Intent intent = new Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT);
-        intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, getActivity().getPackageName());
-        defaultPreference.setIntent(intent);
-        defaultPreference.setTitle(getString(R.string.ApplicationPreferencesActivity_sms_disabled));
-        defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_make_signal_your_default_sms_app));
-      }
     } else if (defaultPreference != null) {
       preferenceScreen.removePreference(defaultPreference);
     }
 
     if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP && manualMmsPreference != null) {
       preferenceScreen.removePreference(manualMmsPreference);
+    }
+  }
+
+  private void initializeDefaultPreference() {
+    if (VERSION.SDK_INT < VERSION_CODES.KITKAT) return;
+
+    Preference defaultPreference = findPreference(KITKAT_DEFAULT_PREF);
+    if (Util.isDefaultSmsProvider(getActivity())) {
+      defaultPreference.setIntent(new Intent(Settings.ACTION_WIRELESS_SETTINGS));
+      defaultPreference.setTitle(getString(R.string.ApplicationPreferencesActivity_sms_enabled));
+      defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_change_your_default_sms_app));
+    } else {
+      Intent intent = new Intent(Telephony.Sms.Intents.ACTION_CHANGE_DEFAULT);
+      intent.putExtra(Telephony.Sms.Intents.EXTRA_PACKAGE_NAME, getActivity().getPackageName());
+      defaultPreference.setIntent(intent);
+      defaultPreference.setTitle(getString(R.string.ApplicationPreferencesActivity_sms_disabled));
+      defaultPreference.setSummary(getString(R.string.ApplicationPreferencesActivity_touch_to_make_signal_your_default_sms_app));
     }
   }
 


### PR DESCRIPTION
// FREEBIE
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy S5, Lineage OS 14.1
 * AVD, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Hide SMS/MMS preferences early in `onCreate`, rather than in `onResume`, to avoid rendering all preferences for the first few frames.

(25% speed)

| Before | After |
| ---- | ---- |
| ![before-cut](https://cloud.githubusercontent.com/assets/17954071/25065369/7b71f624-21d4-11e7-89cb-b75017963496.gif) | ![after-cut](https://cloud.githubusercontent.com/assets/17954071/25065368/7b706f5c-21d4-11e7-991a-ff7d99088a05.gif) |

Fixes #6321