### PR TITLE
Jumbomoji support

### DIFF
--- a/res/layout/conversation_item_received.xml
+++ b/res/layout/conversation_item_received.xml
@@ -75,7 +75,8 @@
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="?conversation_item_received_text_primary_color"
                     android:textColorLink="?conversation_item_received_text_primary_color"
-                    android:textSize="@dimen/conversation_item_body_text_size" />
+                    android:textSize="@dimen/conversation_item_body_text_size"
+                    app:scaleEmojis="true" />
 
             <LinearLayout android:layout_width="wrap_content"
                           android:layout_height="wrap_content"

--- a/res/layout/conversation_item_sent.xml
+++ b/res/layout/conversation_item_sent.xml
@@ -65,7 +65,8 @@
                     android:textColor="?conversation_item_sent_text_primary_color"
                     android:textColorLink="?conversation_item_sent_text_primary_color"
                     android:textSize="@dimen/conversation_item_body_text_size"
-                    tools:text="Mango pickle lorem ipsum" />
+                    app:scaleEmojis="true"
+                    tools:text="Mango pickle lorem ipsum"/>
 
             <LinearLayout android:layout_width="wrap_content"
                           android:layout_height="wrap_content"

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -197,5 +197,9 @@
         <attr name="documentForegroundTintColor" format="color" />
         <attr name="documentBackgroundTintColor" format="color" />
     </declare-styleable>
+    
+    <declare-styleable name="EmojiTextView">
+        <attr name="scaleEmojis" format="boolean" />
+    </declare-styleable>
 
 </resources>

--- a/src/org/thoughtcrime/securesms/components/emoji/EmojiProvider.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/EmojiProvider.java
@@ -26,7 +26,6 @@ import org.thoughtcrime.securesms.components.emoji.parsing.EmojiTree;
 import org.thoughtcrime.securesms.util.FutureTaskListener;
 import org.thoughtcrime.securesms.util.Util;
 
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 class EmojiProvider {
@@ -71,10 +70,19 @@ class EmojiProvider {
     }
   }
 
-  @Nullable Spannable emojify(@Nullable CharSequence text, @NonNull TextView tv) {
+  @Nullable EmojiParser.CandidateList getCandidates(@Nullable CharSequence text) {
     if (text == null) return null;
+    return new EmojiParser(emojiTree).findCandidates(text);
+  }
 
-    List<EmojiParser.Candidate> matches = new EmojiParser(emojiTree).findCandidates(text);
+  @Nullable Spannable emojify(@Nullable CharSequence text, @NonNull TextView tv) {
+    return emojify(getCandidates(text), text, tv);
+  }
+
+  @Nullable Spannable emojify(@Nullable EmojiParser.CandidateList matches,
+                              @Nullable CharSequence text,
+                              @NonNull TextView tv) {
+    if (matches == null || text == null) return null;
     SpannableStringBuilder      builder = new SpannableStringBuilder(text);
 
     for (EmojiParser.Candidate candidate : matches) {

--- a/src/org/thoughtcrime/securesms/components/emoji/parsing/EmojiParser.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/parsing/EmojiParser.java
@@ -24,6 +24,7 @@ package org.thoughtcrime.securesms.components.emoji.parsing;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -38,10 +39,12 @@ public class EmojiParser {
     this.emojiTree = emojiTree;
   }
 
-  public @NonNull List<Candidate> findCandidates(@Nullable CharSequence text) {
+  public @NonNull CandidateList findCandidates(@Nullable CharSequence text) {
     List<Candidate> results = new LinkedList<>();
 
-    if (text == null) return results;
+    if (text == null) return new CandidateList(results, false);
+
+    boolean allEmojis = text.length() > 0;
 
     for (int i = 0; i < text.length(); i++) {
       int emojiEnd = getEmojiEndPos(text, i);
@@ -58,10 +61,12 @@ public class EmojiParser {
         results.add(new Candidate(i, emojiEnd, drawInfo));
 
         i = emojiEnd - 1;
+      } else {
+        allEmojis = false;
       }
     }
 
-    return results;
+    return new CandidateList(results, allEmojis);
   }
 
   private int getEmojiEndPos(CharSequence text, int startPos) {
@@ -102,6 +107,25 @@ public class EmojiParser {
 
     public int getStartIndex() {
       return startIndex;
+    }
+  }
+
+  public class CandidateList implements Iterable<Candidate> {
+    public final List<EmojiParser.Candidate> list;
+    public final boolean                     allEmojis;
+
+    public CandidateList(List<EmojiParser.Candidate> candidates, boolean allEmojis) {
+      this.list = candidates;
+      this.allEmojis = allEmojis;
+    }
+
+    public int size() {
+      return list.size();
+    }
+
+    @Override
+    public Iterator<Candidate> iterator() {
+      return list.iterator();
     }
   }
 


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Galaxy S5, Lineage OS 14.1
 * AVD, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Show emoji-only messages larger, like how WhatsApp/Slack/others do it.

Screenshots:

| Before | After |
| --- | --- |
| ![before-ios](https://cloud.githubusercontent.com/assets/17954071/25067587/eaf521ea-220d-11e7-9cec-c0a2c75319e3.png) | ![after-ios](https://cloud.githubusercontent.com/assets/17954071/25067591/f2ccd2f0-220d-11e7-8da2-cc8953f263c5.png) |
| ![before-system](https://cloud.githubusercontent.com/assets/17954071/25067593/fd6889de-220d-11e7-9a23-0ea5ead7218c.png) | ![after-system-out](https://cloud.githubusercontent.com/assets/17954071/25067597/04ea64fc-220e-11e7-8002-95eb86a10df0.png) |

* 1-2 emojis: 200% size
* 3-4 emojis: 175%
* 5-6: 150%
* 7-8: 125%

Closes #6269