### PR TITLE
Fix KitKat preference divider crash

### DIFF
--- a/res/drawable/preference_divider_dark.xml
+++ b/res/drawable/preference_divider_dark.xml
@@ -4,14 +4,14 @@
     <item>
         <shape>
             <padding android:top="1dp" android:right="0dp" android:bottom="0dp" android:left="0dp" />
-            <solid android:color="?preference_divider_background_dark" />
+            <solid android:color="#222222" />
         </shape>
     </item>
 
     <item>
         <shape>
             <padding android:top="1dp" android:right="0dp" android:bottom="0dp" android:left="0dp" />
-            <solid android:color="?preference_divider_background_light" />
+            <solid android:color="#101010" />
             <size android:height="20dp"/>
         </shape>
     </item>

--- a/res/drawable/preference_divider_light.xml
+++ b/res/drawable/preference_divider_light.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item>
+        <shape>
+            <padding android:top="1dp" android:right="0dp" android:bottom="0dp" android:left="0dp" />
+            <solid android:color="#d4d4d4" />
+        </shape>
+    </item>
+
+    <item>
+        <shape>
+            <padding android:top="1dp" android:right="0dp" android:bottom="0dp" android:left="0dp" />
+            <solid android:color="#dddddd" />
+            <size android:height="20dp"/>
+        </shape>
+    </item>
+
+</layer-list>

--- a/res/layout/preference_divider.xml
+++ b/res/layout/preference_divider.xml
@@ -9,6 +9,6 @@
     <View
             android:layout_width="match_parent"
             android:layout_height="10dp"
-            android:background="@drawable/preference_divider"/>
+            android:background="?pref_divider"/>
 
 </LinearLayout>

--- a/res/values/attrs.xml
+++ b/res/values/attrs.xml
@@ -125,8 +125,7 @@
     <attr name="pref_ic_devices" format="reference" />
     <attr name="pref_ic_advanced" format="reference" />
 
-    <attr name="preference_divider_background_light" format="color" />
-    <attr name="preference_divider_background_dark" format="color"/>
+    <attr name="pref_divider" format="reference" />
 
     <attr name="app_protect_timeout_picker_color" format="reference"/>
 

--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -216,8 +216,7 @@
         <item name="pref_ic_devices">@drawable/ic_laptop_black_24dp</item>
         <item name="pref_ic_advanced">@drawable/ic_advanced_black_24dp</item>
 
-        <item name="preference_divider_background_light">#dddddd</item>
-        <item name="preference_divider_background_dark">#d4d4d4</item>
+        <item name="pref_divider">@drawable/preference_divider_light</item>
 
         <item name="app_protect_timeout_picker_color">@style/BetterPickersDialogFragment.Light</item>
 
@@ -349,8 +348,7 @@
         <item name="pref_ic_devices">@drawable/ic_laptop_white_24dp</item>
         <item name="pref_ic_advanced">@drawable/ic_advanced_white_24dp</item>
 
-        <item name="preference_divider_background_light">#222222</item>
-        <item name="preference_divider_background_dark">#101010</item>
+        <item name="pref_divider">@drawable/preference_divider_dark</item>
 
         <item name="app_protect_timeout_picker_color">@style/BetterPickersDialogFragment</item>
 


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Android 7.1.1/Android 4.4.4
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
KitKat doesn't like theme attributes in drawable XML, use separate drawables instead
Fixes #6544 