### PR TITLE
Redesign import/export activity

### DIFF
--- a/res/layout/import_export_fragment.xml
+++ b/res/layout/import_export_fragment.xml
@@ -30,18 +30,21 @@
                       android:layout_width="wrap_content"
                       android:layout_height="76dp"
                       android:gravity="center_vertical"
-                      android:layout_marginLeft="16dip"
-                      android:layout_marginRight="16dip">
+                      android:background="?selectableItemBackground">
 
             <ImageView android:layout_width="wrap_content"
                        android:layout_height="wrap_content"
+                       android:layout_marginLeft="16dp"
+                       android:layout_marginStart="16dp"
                        android:layout_marginRight="32dp"
                        android:layout_marginEnd="32dp"
                        android:src="?import_sms"/>
 
             <LinearLayout android:orientation="vertical"
                           android:layout_width="wrap_content"
-                          android:layout_height="wrap_content">
+                          android:layout_height="wrap_content"
+                          android:layout_marginRight="16dp"
+                          android:layout_marginEnd="16dp">
 
                 <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"
@@ -69,18 +72,21 @@
                       android:layout_width="wrap_content"
                       android:layout_height="76dp"
                       android:gravity="center_vertical"
-                      android:layout_marginLeft="16dip"
-                      android:layout_marginRight="16dip">
+                      android:background="?selectableItemBackground">
 
             <ImageView android:layout_width="wrap_content"
                        android:layout_height="wrap_content"
+                       android:layout_marginLeft="16dp"
+                       android:layout_marginStart="16dp"
                        android:layout_marginRight="32dip"
                        android:layout_marginEnd="32dip"
                        android:src="?plaintext_backup"/>
 
             <LinearLayout android:orientation="vertical"
                           android:layout_width="wrap_content"
-                          android:layout_height="wrap_content">
+                          android:layout_height="wrap_content"
+                          android:layout_marginRight="16dp"
+                          android:layout_marginEnd="16dp">
 
                 <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"
@@ -121,18 +127,21 @@
                       android:layout_width="wrap_content"
                       android:layout_height="76dp"
                       android:gravity="center_vertical"
-                      android:layout_marginLeft="16dip"
-                      android:layout_marginRight="16dip">
+                      android:background="?selectableItemBackground">
 
             <ImageView android:layout_width="wrap_content"
                        android:layout_height="wrap_content"
+                       android:layout_marginLeft="16dp"
+                       android:layout_marginStart="16dp"
                        android:layout_marginRight="32dp"
                        android:layout_marginEnd="32dp"
                        android:src="?plaintext_backup"/>
 
             <LinearLayout android:orientation="vertical"
                           android:layout_width="wrap_content"
-                          android:layout_height="wrap_content">
+                          android:layout_height="wrap_content"
+                          android:layout_marginRight="16dp"
+                          android:layout_marginEnd="16dp">
 
                 <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"

--- a/res/layout/import_export_fragment.xml
+++ b/res/layout/import_export_fragment.xml
@@ -2,188 +2,157 @@
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            xmlns:card_view="http://schemas.android.com/apk/res-auto"
             android:layout_gravity="center_vertical"
             android:gravity="center_vertical">
 
 <LinearLayout android:orientation="vertical"
               android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:gravity="center_vertical"
-              android:layout_gravity="center_vertical"
-              android:padding="8dip">
+              android:layout_height="wrap_content">
 
-    <android.support.v7.widget.CardView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            card_view:cardElevation="3dp"
-            card_view:cardCornerRadius="3dp"
-            card_view:cardUseCompatPadding="true">
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        android:gravity="center_vertical"
+        android:text="@string/ImportExportActivity_import"
+        android:textSize="14sp"
+        android:fontFamily="sans-serif-medium"
+        android:textColor="@color/signal_primary_dark"/>
 
-        <LinearLayout android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      android:orientation="vertical">
+    <LinearLayout android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:orientation="vertical">
 
-            <FrameLayout android:layout_width="wrap_content"
-                         android:layout_height="wrap_content"
-                         android:padding="20dp">
+        <LinearLayout android:id="@+id/import_sms"
+                      android:clickable="true"
+                      android:orientation="horizontal"
+                      android:layout_width="wrap_content"
+                      android:layout_height="76dp"
+                      android:gravity="center_vertical"
+                      android:layout_marginLeft="16dip"
+                      android:layout_marginRight="16dip">
 
-                <TextView android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:text="@string/import_export_fragment__import"
-                          android:textSize="20sp"/>
+            <ImageView android:layout_width="wrap_content"
+                       android:layout_height="wrap_content"
+                       android:layout_marginRight="32dp"
+                       android:layout_marginEnd="32dp"
+                       android:src="?import_sms"/>
 
-            </FrameLayout>
-
-            <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/gray10"/>
-
-            <LinearLayout android:id="@+id/import_sms"
-                          android:clickable="true"
-                          android:orientation="horizontal"
+            <LinearLayout android:orientation="vertical"
                           android:layout_width="wrap_content"
+                          android:layout_height="wrap_content">
+
+                <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"
-                          android:gravity="center_vertical"
-                          android:paddingTop="8dip"
-                          android:paddingBottom="8dip"
-                          android:layout_marginLeft="16dip"
-                          android:layout_marginRight="16dip">
+                          android:gravity="start"
+                          style="@style/Registration.Description"
+                          android:text="@string/import_fragment__import_system_sms_database"/>
 
-                <ImageView android:layout_width="wrap_content"
-                           android:layout_height="wrap_content"
-                           android:layout_marginRight="10dip"
-                           android:layout_marginEnd="10dip"
-                           android:src="?import_sms"/>
-
-                <LinearLayout android:orientation="vertical"
-                              android:layout_width="wrap_content"
-                              android:layout_height="wrap_content">
-
-                    <TextView android:layout_width="match_parent"
-                              android:layout_height="wrap_content"
-                              android:gravity="start"
-                              style="@style/Registration.Description"
-                              android:text="@string/import_fragment__import_system_sms_database"/>
-
-                    <TextView android:layout_width="match_parent"
-                              android:layout_height="wrap_content"
-                              android:gravity="start"
-                              android:textAppearance="?android:attr/textAppearanceSmall"
-                              android:text="@string/import_fragment__import_the_database_from_the_default_system"/>
-
-                </LinearLayout>
-            </LinearLayout>
-
-            <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/gray10"/>
-
-            <LinearLayout android:id="@+id/import_plaintext_backup"
-                          android:clickable="true"
-                          android:orientation="horizontal"
-                          android:layout_width="wrap_content"
+                <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"
-                          android:gravity="center_vertical"
-                          android:paddingTop="8dip"
-                          android:paddingBottom="8dip"
-                          android:layout_marginLeft="16dip"
-                          android:layout_marginRight="16dip">
+                          android:gravity="start"
+                          android:textAppearance="?android:attr/textAppearanceSmall"
+                          android:text="@string/import_fragment__import_the_database_from_the_default_system"/>
 
-                <ImageView android:layout_width="wrap_content"
-                           android:layout_height="wrap_content"
-                           android:layout_marginRight="10dip"
-                           android:layout_marginEnd="10dip"
-                           android:src="?plaintext_backup"/>
-
-                <LinearLayout android:orientation="vertical"
-                              android:layout_width="wrap_content"
-                              android:layout_height="wrap_content">
-
-                    <TextView android:layout_width="match_parent"
-                              android:layout_height="wrap_content"
-                              android:gravity="start"
-                              style="@style/Registration.Description"
-                              android:text="@string/import_fragment__import_plaintext_backup"/>
-
-                    <TextView android:layout_width="match_parent"
-                              android:layout_height="wrap_content"
-                              android:gravity="start"
-                              android:textAppearance="?android:attr/textAppearanceSmall"
-                              android:text="@string/import_fragment__import_a_plaintext_backup_file"/>
-                </LinearLayout>
             </LinearLayout>
-
         </LinearLayout>
 
-    </android.support.v7.widget.CardView>
-
-    <android.support.v7.widget.CardView
-            android:layout_marginTop="20dp"
-            card_view:cardElevation="3dp"
-            card_view:cardCornerRadius="2dp"
-            card_view:cardUseCompatPadding="true"
+        <View
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"/>
 
-        <LinearLayout android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      android:orientation="vertical">
+        <LinearLayout android:id="@+id/import_plaintext_backup"
+                      android:clickable="true"
+                      android:orientation="horizontal"
+                      android:layout_width="wrap_content"
+                      android:layout_height="76dp"
+                      android:gravity="center_vertical"
+                      android:layout_marginLeft="16dip"
+                      android:layout_marginRight="16dip">
 
-            <FrameLayout android:layout_width="wrap_content"
-                         android:layout_height="wrap_content"
-                         android:padding="20dp">
+            <ImageView android:layout_width="wrap_content"
+                       android:layout_height="wrap_content"
+                       android:layout_marginRight="32dip"
+                       android:layout_marginEnd="32dip"
+                       android:src="?plaintext_backup"/>
 
-                <TextView android:layout_width="wrap_content"
-                          android:layout_height="wrap_content"
-                          android:text="@string/import_export_fragment__export"
-                          android:textSize="20sp"/>
-
-            </FrameLayout>
-
-            <View
-                    android:layout_width="match_parent"
-                    android:layout_height="1dp"
-                    android:background="@color/gray10"/>
-
-            <LinearLayout android:id="@+id/export_plaintext_backup"
-                          android:clickable="true"
-                          android:orientation="horizontal"
+            <LinearLayout android:orientation="vertical"
                           android:layout_width="wrap_content"
+                          android:layout_height="wrap_content">
+
+                <TextView android:layout_width="match_parent"
                           android:layout_height="wrap_content"
-                          android:gravity="center_vertical"
-                          android:paddingTop="8dip"
-                          android:paddingBottom="8dip"
-                          android:layout_marginLeft="16dip"
-                          android:layout_marginRight="16dip">
+                          android:gravity="start"
+                          style="@style/Registration.Description"
+                          android:text="@string/import_fragment__import_plaintext_backup"/>
 
-                <ImageView android:layout_width="wrap_content"
-                           android:layout_height="wrap_content"
-                           android:layout_marginRight="10dip"
-                           android:layout_marginEnd="10dip"
-                           android:src="?plaintext_backup"/>
-
-                <LinearLayout android:orientation="vertical"
-                              android:layout_width="wrap_content"
-                              android:layout_height="wrap_content">
-
-                    <TextView android:layout_width="match_parent"
-                              android:layout_height="wrap_content"
-                              android:gravity="start"
-                              style="@style/Registration.Description"
-                              android:text="@string/export_fragment__export_plaintext_backup"/>
-
-                    <TextView android:layout_width="match_parent"
-                              android:layout_height="wrap_content"
-                              android:gravity="start"
-                              android:textAppearance="?android:attr/textAppearanceSmall"
-                              android:text="@string/export_fragment__export_a_plaintext_backup_compatible_with"/>
-                </LinearLayout>
+                <TextView android:layout_width="match_parent"
+                          android:layout_height="wrap_content"
+                          android:gravity="start"
+                          android:textAppearance="?android:attr/textAppearanceSmall"
+                          android:text="@string/import_fragment__import_a_plaintext_backup_file"/>
             </LinearLayout>
-
         </LinearLayout>
-    </android.support.v7.widget.CardView>
+
+    </LinearLayout>
+
+    <include layout="@layout/preference_divider"/>
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="48dp"
+        android:layout_marginLeft="16dp"
+        android:layout_marginStart="16dp"
+        android:gravity="center_vertical"
+        android:text="@string/ImportExportActivity_export"
+        android:textSize="14sp"
+        android:fontFamily="sans-serif-medium"
+        android:textColor="@color/signal_primary_dark"/>
+
+    <LinearLayout android:layout_width="wrap_content"
+                  android:layout_height="wrap_content"
+                  android:orientation="vertical">
+
+        <LinearLayout android:id="@+id/export_plaintext_backup"
+                      android:clickable="true"
+                      android:orientation="horizontal"
+                      android:layout_width="wrap_content"
+                      android:layout_height="76dp"
+                      android:gravity="center_vertical"
+                      android:layout_marginLeft="16dip"
+                      android:layout_marginRight="16dip">
+
+            <ImageView android:layout_width="wrap_content"
+                       android:layout_height="wrap_content"
+                       android:layout_marginRight="32dp"
+                       android:layout_marginEnd="32dp"
+                       android:src="?plaintext_backup"/>
+
+            <LinearLayout android:orientation="vertical"
+                          android:layout_width="wrap_content"
+                          android:layout_height="wrap_content">
+
+                <TextView android:layout_width="match_parent"
+                          android:layout_height="wrap_content"
+                          android:gravity="start"
+                          style="@style/Registration.Description"
+                          android:text="@string/export_fragment__export_plaintext_backup"/>
+
+                <TextView android:layout_width="match_parent"
+                          android:layout_height="wrap_content"
+                          android:gravity="start"
+                          android:textAppearance="?android:attr/textAppearanceSmall"
+                          android:text="@string/export_fragment__export_a_plaintext_backup_compatible_with"/>
+            </LinearLayout>
+        </LinearLayout>
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"/>
+
+    </LinearLayout>
 </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 3T, Android 7.1.1
 * AVD, Android 4.4.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Switches the import/export activity from a card-based layout to a list-based one.

Material design spec on cards:

>When to use
>Use a card layout when displaying content that:
>
>* As a collection, comprises multiple data types, such as images, movies, and text
>* Does not require direct comparison (a user is not directly comparing images or text)
>* Supports content of highly variable length, such as comments
>* Contains interactive content, such as +1 buttons or comments
>* Would otherwise be in a grid list but needs to display more content to supplement the image

The import/export activity doesn't fit these criteria; using cards when they aren't necessary just adds extra clutter to the layout.

| Before | Light | Dark |
|--|--|--|
|![io-before](https://cloud.githubusercontent.com/assets/17954071/25307170/eacdb3c2-2761-11e7-83de-be352015c200.png)|![io-light](https://cloud.githubusercontent.com/assets/17954071/25314242/f0eb540e-2805-11e7-88ca-455fc63c6266.png)|![io-dark](https://cloud.githubusercontent.com/assets/17954071/25314243/f49a858e-2805-11e7-80ae-c8cbb813df22.png)|