### PR TITLE
Fix copying links when scrolling in #6343

### DIFF
--- a/src/org/thoughtcrime/securesms/util/LongClickMovementMethod.java
+++ b/src/org/thoughtcrime/securesms/util/LongClickMovementMethod.java
@@ -90,6 +90,7 @@ public class LongClickMovementMethod extends LinkMovementMethod {
         aSpan.setHighlighted(false, Color.TRANSPARENT);
       }
       Selection.removeSelection(buffer);
+      return gestureDetector.onTouchEvent(event);
     }
     return super.onTouchEvent(widget, buffer, event);
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 6P Android 7.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
@FeuRenard reported an issue where links gets copied when the user starts scrolling starting from them.
The reason behind that issue was that the GestureDetector wasn't receiving the `ACTION_CANCELLED` MotionEvent so it still called the `onLongPress` even though it shouldn't.
This fix merely passes the `ACTION_CANCELLED` MotionEvent to the GestureDetector so that it cancels its onLongPress handler.
