### PR TITLE
Tweak reminder layout

### DIFF
--- a/res/layout/reminder_header.xml
+++ b/res/layout/reminder_header.xml
@@ -1,69 +1,57 @@
 <?xml version="1.0" encoding="utf-8"?>
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/reminder_background"
+    android:focusable="true"
+    android:nextFocusRight="@+id/cancel"
+    android:orientation="horizontal"
+    android:visibility="gone"
+    tools:visibility="visible">
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:tools="http://schemas.android.com/tools"
-              android:orientation="vertical"
-              android:layout_width="fill_parent"
-              android:layout_height="wrap_content">
-    <LinearLayout android:id="@+id/container"
-                  android:orientation="horizontal"
-                  android:layout_width="match_parent"
-                  android:layout_height="wrap_content"
-                  android:visibility="gone"
-                  tools:visibility="visible"
-                  android:padding="2dp"
-                  android:gravity="center_vertical"
-                  android:focusable="true"
-                  android:nextFocusRight="@+id/cancel"
-                  android:background="@drawable/reminder_background">
+    <LinearLayout
+        android:id="@+id/reminder"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:layout_margin="16dp"
+        android:orientation="vertical">
 
-        <LinearLayout android:id="@+id/reminder"
-                      android:layout_width="0dp"
-                      android:layout_height="wrap_content"
-                      android:layout_weight="1"
-                      android:layout_margin="10dp"
-                      android:orientation="vertical">
+        <TextView
+            android:id="@+id/reminder_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="4dp"
+            android:textColor="@color/white"
+            android:textSize="18sp"
+            tools:text="Invite to Signal"/>
 
-            <TextView android:id="@+id/reminder_title"
-                      android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      android:layout_marginBottom="5dp"
-                      tools:text="Invite to Signal"
-                      android:textColor="@color/white"
-                      android:textSize="18sp"/>
-
-            <TextView android:id="@+id/reminder_text"
-                      android:layout_width="wrap_content"
-                      android:layout_height="wrap_content"
-                      tools:text="Take your conversation with Jules Bonnot to the next level."
-                      android:fontFamily="sans-serif-light"
-                      android:textColor="@color/white"
-                      android:textSize="16sp"/>
-
-        </LinearLayout>
-
-        <LinearLayout android:layout_width="wrap_content"
-                      android:layout_height="match_parent"
-                      android:gravity="right"
-                      android:layout_marginLeft="15dp"
-                      android:orientation="vertical">
-
-            <LinearLayout android:layout_width="wrap_content"
-                          android:layout_height="0dp"
-                          android:layout_weight="1"
-                          android:gravity="top">
-
-                <ImageButton android:id="@+id/cancel"
-                             android:layout_width="40dp"
-                             android:layout_height="40dp"
-                             android:padding="10dp"
-                             android:focusable="true"
-                             android:nextFocusRight="@+id/container"
-                             android:nextFocusLeft="@+id/container"
-                             android:background="@drawable/touch_highlight_background"
-                             android:src="@drawable/ic_close_white_24dp"/>
-            </LinearLayout>
-          </LinearLayout>
+        <TextView
+            android:id="@+id/reminder_text"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:fontFamily="sans-serif-light"
+            android:textColor="@color/white"
+            android:textSize="16sp"
+            tools:text="Take your conversation with Jules Bonnot to the next level."/>
 
     </LinearLayout>
+
+    <ImageButton
+        android:id="@+id/cancel"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_marginTop="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginEnd="8dp"
+        android:background="?selectableItemBackgroundBorderless"
+        android:focusable="true"
+        android:nextFocusLeft="@+id/container"
+        android:nextFocusRight="@+id/container"
+        android:src="@drawable/ic_close_white_24dp"
+        android:contentDescription="@string/InviteActivity_cancel"/>
+
 </LinearLayout>


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 3T, Android 7.1.1
 * AVDs, Android 7.1.1/Android 4.4.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
On the UI side:
* Use a 8dp baseline grid for layouts/4dp baseline grid for text
* Add a little more padding to make things less cramped
* Increase touch target for the close button

On the XML side:
* Remove redundant layout cruft

|Before|After|
|-|-|
|![screenshot_1493263907](https://cloud.githubusercontent.com/assets/17954071/25466915/f58f7ee0-2ad0-11e7-8af7-481e15aa0c27.png)|![screenshot_1493263829](https://cloud.githubusercontent.com/assets/17954071/25466918/fb5e0cc4-2ad0-11e7-9092-caba7673870a.png)|
|![screenshot_1493264101](https://cloud.githubusercontent.com/assets/17954071/25466924/015c81c8-2ad1-11e7-9761-662b54d74859.png)|![screenshot_1493264056](https://cloud.githubusercontent.com/assets/17954071/25466929/0951366c-2ad1-11e7-8bbc-d48661fe89f2.png)|