### PR TITLE
Fix vertical space in import_export_fragment 

### DIFF
--- a/res/layout/import_export_fragment.xml
+++ b/res/layout/import_export_fragment.xml
@@ -28,7 +28,9 @@
                       android:clickable="true"
                       android:orientation="horizontal"
                       android:layout_width="wrap_content"
-                      android:layout_height="76dp"
+                      android:layout_height="wrap_content"
+                      android:paddingTop="12dp"
+                      android:paddingBottom="12dp"
                       android:gravity="center_vertical"
                       android:background="?selectableItemBackground">
 
@@ -71,7 +73,9 @@
                       android:clickable="true"
                       android:orientation="horizontal"
                       android:layout_width="wrap_content"
-                      android:layout_height="76dp"
+                      android:layout_height="wrap_content"
+                      android:paddingTop="12dp"
+                      android:paddingBottom="12dp"
                       android:gravity="center_vertical"
                       android:background="?selectableItemBackground">
 
@@ -127,7 +131,9 @@
                       android:clickable="true"
                       android:orientation="horizontal"
                       android:layout_width="wrap_content"
-                      android:layout_height="76dp"
+                      android:layout_height="wrap_content"
+                      android:paddingTop="12dp"
+                      android:paddingBottom="12dp"
                       android:gravity="center_vertical"
                       android:background="?selectableItemBackground">
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung GT-I8160, Android 4.4.4 (CyanogenMod)
 * Wileyfox Swift, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

Changed the layout_height to wrap_content and added padding to the top and bottom of the affected layouts.

Fixes https://github.com/WhisperSystems/Signal-Android/issues/6590
// FREEBIE
