### PR TITLE
Fall back to Camera1Enumerator on exceptions (Fix for #6537)

### DIFF
--- a/src/org/thoughtcrime/securesms/webrtc/PeerConnectionWrapper.java
+++ b/src/org/thoughtcrime/securesms/webrtc/PeerConnectionWrapper.java
@@ -273,11 +273,18 @@ public class PeerConnectionWrapper {
   }
 
   private @Nullable CameraVideoCapturer createVideoCapturer(@NonNull Context context) {
-    Log.w(TAG, "Camera2 enumerator supported: " + Camera2Enumerator.isSupported(context));
+    boolean camera2EnumeratorIsSupported = false;
+    try {
+      camera2EnumeratorIsSupported = Camera2Enumerator.isSupported(context);
+    } catch (final Throwable throwable) {
+      Log.w(TAG, "Camera2Enumator.isSupport() threw.", throwable);
+    }
+
+    Log.w(TAG, "Camera2 enumerator supported: " + camera2EnumeratorIsSupported);
     CameraEnumerator enumerator;
 
-    if (Camera2Enumerator.isSupported(context)) enumerator = new Camera2Enumerator(context);
-    else                                        enumerator = new Camera1Enumerator(true);
+    if (camera2EnumeratorIsSupported) enumerator = new Camera2Enumerator(context);
+    else                              enumerator = new Camera1Enumerator(true);
 
     String[] deviceNames = enumerator.getDeviceNames();
 


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S2 (i9100), Android 7.1.2
 * Samsung Galaxy S3 (i9300), Android 7.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
If Camera2Enumerator.isSupported() throws, consider Camera2Enumerator to
not be supported, log the Throwable, and use Camera1Enumerator instead.

Before this patch, an exception thrown by Camera2Enumerator.isSupported
would crash any Signal call (even if video was not enabled).

Fixes #6537
// FREEBIE

I experienced the same errors as described in #6537 on the two devices mentioned above. This patch makes video calls work for these devices.