### PR TITLE
Add Catalan to language selector FREEBIE

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -6,6 +6,7 @@
       <item>English</item>
       <item>Arabic العربية</item>
       <item>Bulgarian български</item>
+      <item>Català</item>
       <item>Čeština</item>
       <item>Chinese (Simplified) 中文 (简体)</item>
       <item>Chinese (Traditional) 中文 (繁體)</item>
@@ -50,6 +51,7 @@
       <item>en</item>
       <item>ar</item>
       <item>bg</item>
+      <item>ca</item>
       <item>cs</item>
       <item>zh_CN</item>
       <item>zh_TW</item>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Adding Catalan to language selector. It's useful when setting Catalan is not possible on device language selector (Motorola and other vendors remove Catalan language)
