### PR TITLE
Allow swipe gestures in media preview

### DIFF
--- a/res/layout-v16/video_player.xml
+++ b/res/layout-v16/video_player.xml
@@ -4,11 +4,20 @@
              android:layout_width="match_parent"
              android:layout_height="match_parent">
 
+    <org.thoughtcrime.securesms.components.ThumbnailView
+        android:id="@+id/video_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:visibility="visible"/>
+
     <com.google.android.exoplayer2.ui.SimpleExoPlayerView
             android:id="@+id/video_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:layout_gravity="center"
-            android:gravity="center"/>
+            android:gravity="center"
+            android:visibility="gone"/>
 
 </FrameLayout>

--- a/res/layout/media_preview_activity.xml
+++ b/res/layout/media_preview_activity.xml
@@ -5,16 +5,10 @@
                 android:layout_height="match_parent"
                 android:background="@color/gray95">
 
-    <org.thoughtcrime.securesms.components.ZoomingImageView
-               android:id="@+id/image"
-               android:layout_width="match_parent"
-               android:layout_height="match_parent"
-               android:contentDescription="@string/media_preview_activity__media_content_description" />
-
-    <org.thoughtcrime.securesms.video.VideoPlayer
-            android:id="@+id/video_player"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:visibility="gone"/>
+    <android.support.v4.view.ViewPager
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:contentDescription="@string/media_preview_activity__media_content_description"/>
 
 </RelativeLayout>

--- a/res/layout/media_preview_page.xml
+++ b/res/layout/media_preview_page.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+    <org.thoughtcrime.securesms.components.ZoomingImageView
+        android:id="@+id/image"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"/>
+
+    <org.thoughtcrime.securesms.video.VideoPlayer
+        android:id="@+id/video_player"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"/>
+
+</RelativeLayout>

--- a/res/layout/video_player.xml
+++ b/res/layout/video_player.xml
@@ -4,10 +4,19 @@
               android:layout_width="match_parent"
               android:layout_height="match_parent">
 
+    <org.thoughtcrime.securesms.components.ThumbnailView
+        android:id="@+id/video_placeholder"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:visibility="visible"/>
+
     <VideoView android:id="@+id/video_view"
                android:layout_width="match_parent"
                android:layout_height="match_parent"
                android:layout_gravity="center"
-               android:gravity="center"/>
+               android:gravity="center"
+               android:visibility="gone"/>
 
 </FrameLayout>

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -190,7 +190,9 @@ public class MediaPreviewActivity extends    PassphraseRequiredActionBarActivity
                                                                             getWindow(),
                                                                             masterSecret,
                                                                             cursor);
+    final int startPosition = adapter.getAndSetStartPosition(mediaUri);
     viewPager.setAdapter(adapter);
+    viewPager.setCurrentItem(startPosition);
   }
 
   private void cleanupMedia() {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -76,6 +76,7 @@ public class MediaPreviewActivity extends    PassphraseRequiredActionBarActivity
   private long      date;
   private long      size;
   private boolean   outgoing;
+  private boolean   setSelectedVideoPlay = true;
 
   @Override
   protected void onCreate(Bundle bundle, @NonNull MasterSecret masterSecret) {
@@ -147,6 +148,7 @@ public class MediaPreviewActivity extends    PassphraseRequiredActionBarActivity
   @Override
   protected void onNewIntent(Intent intent) {
     super.onNewIntent(intent);
+    setSelectedVideoPlay = true;
     if (recipient != null) recipient.removeListener(this);
     viewPager.clearOnPageChangeListeners();
     setIntent(intent);
@@ -196,9 +198,11 @@ public class MediaPreviewActivity extends    PassphraseRequiredActionBarActivity
                                                                             masterSecret,
                                                                             cursor);
     viewPager.addOnPageChangeListener(adapter);
-    final int startPosition = adapter.getAndSetStartPosition(mediaUri);
+    final int startPosition = adapter.getAndSetStartPosition(mediaUri, setSelectedVideoPlay);
     viewPager.setAdapter(adapter);
     viewPager.setCurrentItem(startPosition);
+
+    setSelectedVideoPlay = false;
   }
 
   private void cleanupMedia() {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -195,6 +195,7 @@ public class MediaPreviewActivity extends    PassphraseRequiredActionBarActivity
                                                                             getWindow(),
                                                                             masterSecret,
                                                                             cursor);
+    viewPager.addOnPageChangeListener(adapter);
     final int startPosition = adapter.getAndSetStartPosition(mediaUri);
     viewPager.setAdapter(adapter);
     viewPager.setCurrentItem(startPosition);

--- a/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewAdapter.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2017 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Context;
+import android.net.Uri;
+import android.support.v4.view.PagerAdapter;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Toast;
+
+import org.thoughtcrime.securesms.components.ZoomingImageView;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.mms.VideoSlide;
+import org.thoughtcrime.securesms.video.VideoPlayer;
+
+import java.io.IOException;
+
+/**
+ * Adapter for providing a ViewPager with a single media item
+ */
+class MediaPreviewAdapter extends PagerAdapter {
+  private final static String TAG = MediaPreviewAdapter.class.getSimpleName();
+
+  private final Context      context;
+  private final Window       window;
+  private final MasterSecret masterSecret;
+  private final Uri          mediaUri;
+  private final String       mediaType;
+  private final long         size;
+
+  MediaPreviewAdapter(Context      context,
+                      Window       window,
+                      MasterSecret masterSecret,
+                      Uri          mediaUri,
+                      String       mediaType,
+                      long         size) {
+    this.context      = context;
+    this.window       = window;
+    this.masterSecret = masterSecret;
+    this.mediaUri     = mediaUri;
+    this.mediaType    = mediaType;
+    this.size         = size;
+  }
+
+  @Override
+  public Object instantiateItem(ViewGroup container, int position) {
+    final View             view  = LayoutInflater.from(context)
+                                                 .inflate(R.layout.media_preview_page,
+                                                          container,
+                                                          false);
+    final ZoomingImageView image = (ZoomingImageView) view.findViewById(R.id.image);
+    final VideoPlayer      video = (VideoPlayer) view.findViewById(R.id.video_player);
+
+    setMedia(image, video);
+    container.addView(view);
+    return view;
+  }
+
+  private void setMedia(ZoomingImageView image, VideoPlayer video) {
+    Log.w(TAG, "Loading Part URI: " + mediaUri);
+
+    try {
+      if (mediaType != null && mediaType.startsWith("image/")) {
+        image.setVisibility(View.VISIBLE);
+        video.setVisibility(View.GONE);
+        image.setImageUri(masterSecret, GlideApp.with(context), mediaUri, mediaType);
+      } else if (mediaType != null && mediaType.startsWith("video/")) {
+        image.setVisibility(View.GONE);
+        video.setVisibility(View.VISIBLE);
+        video.setWindow(window);
+        video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size));
+      }
+    } catch (IOException e) {
+      Log.w(TAG, e);
+      Toast.makeText(context, R.string.MediaPreviewActivity_unssuported_media_type, Toast.LENGTH_LONG).show();
+      ((Activity) context).finish();
+    }
+  }
+
+  @Override
+  public void destroyItem(ViewGroup container, int position, Object object) {
+    ((ZoomingImageView) ((View) object).findViewById(R.id.image)).cleanup();
+    ((VideoPlayer) ((View) object).findViewById(R.id.video_player)).cleanup();
+    container.removeView((View) object);
+  }
+
+  @Override
+  public int getCount() {
+    return 1;
+  }
+
+  @Override
+  public boolean isViewFromObject(View view, Object object) {
+    return view == object;
+  }
+}

--- a/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
@@ -36,10 +36,10 @@ import org.thoughtcrime.securesms.video.VideoPlayer;
 import java.io.IOException;
 
 /**
- * Adapter for providing a ViewPager with a single media item
+ * Adapter for providing a ViewPager with a media draft
  */
-class MediaPreviewAdapter extends PagerAdapter {
-  private final static String TAG = MediaPreviewAdapter.class.getSimpleName();
+class MediaPreviewDraftAdapter extends PagerAdapter {
+  private final static String TAG = MediaPreviewDraftAdapter.class.getSimpleName();
 
   private final Context      context;
   private final Window       window;
@@ -48,12 +48,12 @@ class MediaPreviewAdapter extends PagerAdapter {
   private final String       mediaType;
   private final long         size;
 
-  MediaPreviewAdapter(Context      context,
-                      Window       window,
-                      MasterSecret masterSecret,
-                      Uri          mediaUri,
-                      String       mediaType,
-                      long         size) {
+  MediaPreviewDraftAdapter(Context      context,
+                           Window       window,
+                           MasterSecret masterSecret,
+                           Uri          mediaUri,
+                           String       mediaType,
+                           long         size) {
     this.context      = context;
     this.window       = window;
     this.masterSecret = masterSecret;

--- a/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
@@ -16,7 +16,6 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.app.Activity;
 import android.content.Context;
 import android.net.Uri;
 import android.support.v4.view.PagerAdapter;
@@ -25,15 +24,12 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.video.VideoPlayer;
-
-import java.io.IOException;
 
 /**
  * Adapter for providing a ViewPager with a media draft
@@ -79,21 +75,15 @@ class MediaPreviewDraftAdapter extends PagerAdapter {
   private void setMedia(ZoomingImageView image, VideoPlayer video) {
     Log.w(TAG, "Loading Part URI: " + mediaUri);
 
-    try {
-      if (mediaType != null && mediaType.startsWith("image/")) {
-        image.setVisibility(View.VISIBLE);
-        video.setVisibility(View.GONE);
-        image.setImageUri(masterSecret, GlideApp.with(context), mediaUri, mediaType);
-      } else if (mediaType != null && mediaType.startsWith("video/")) {
-        image.setVisibility(View.GONE);
-        video.setVisibility(View.VISIBLE);
-        video.setWindow(window);
-        video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size));
-      }
-    } catch (IOException e) {
-      Log.w(TAG, e);
-      Toast.makeText(context, R.string.MediaPreviewActivity_unssuported_media_type, Toast.LENGTH_LONG).show();
-      ((Activity) context).finish();
+    if (mediaType != null && mediaType.startsWith("image/")) {
+      image.setVisibility(View.VISIBLE);
+      video.setVisibility(View.GONE);
+      image.setImageUri(masterSecret, GlideApp.with(context), mediaUri, mediaType);
+    } else if (mediaType != null && mediaType.startsWith("video/")) {
+      image.setVisibility(View.GONE);
+      video.setVisibility(View.VISIBLE);
+      video.setWindow(window);
+      video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
@@ -90,7 +90,7 @@ class MediaPreviewDraftAdapter extends PagerAdapter {
   @Override
   public void destroyItem(ViewGroup container, int position, Object object) {
     ((ZoomingImageView) ((View) object).findViewById(R.id.image)).cleanup();
-    ((VideoPlayer) ((View) object).findViewById(R.id.video_player)).cleanup();
+    ((VideoPlayer) ((View) object).findViewById(R.id.video_player)).cleanup(true);
     container.removeView((View) object);
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewDraftAdapter.java
@@ -83,7 +83,7 @@ class MediaPreviewDraftAdapter extends PagerAdapter {
       image.setVisibility(View.GONE);
       video.setVisibility(View.VISIBLE);
       video.setWindow(window);
-      video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size));
+      video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size), true);
     }
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -110,6 +110,10 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter {
     return view == object;
   }
 
+  MediaRecord getMediaRecord(int position) {
+    return MediaRecord.from(context, masterSecret, getCursorAtPositionOrThrow(position));
+  }
+
   int getAndSetStartPosition(Uri mediaUri) {
     int startPosition = -1;
     for (int i = 0; i < getCount(); i++) {

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -109,4 +109,19 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter {
   public boolean isViewFromObject(View view, Object object) {
     return view == object;
   }
+
+  int getAndSetStartPosition(Uri mediaUri) {
+    int startPosition = -1;
+    for (int i = 0; i < getCount(); i++) {
+      Uri dataUri = MediaRecord.from(context,
+                                     masterSecret,
+                                     getCursorAtPositionOrThrow(i)).getAttachment()
+                                                                   .getDataUri();
+      if (dataUri != null && dataUri.equals(mediaUri)) {
+        startPosition = i;
+        break;
+      }
+    }
+    return startPosition;
+  }
 }

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -16,7 +16,6 @@
  */
 package org.thoughtcrime.securesms;
 
-import android.app.Activity;
 import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
@@ -25,7 +24,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.widget.Toast;
 
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
@@ -34,8 +32,6 @@ import org.thoughtcrime.securesms.database.MediaDatabase.MediaRecord;
 import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.video.VideoPlayer;
-
-import java.io.IOException;
 
 /**
  * Adapter for providing a ViewPager with all media of a thread
@@ -74,27 +70,18 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter {
                                                      getCursorAtReversedPositionOrThrow(position));
     final String      mediaType   = mediaRecord.getContentType();
     final Uri         mediaUri    = mediaRecord.getAttachment().getDataUri();
-    final long        size        = mediaRecord.getAttachment().getSize();
 
     Log.w(TAG, "Loading Part URI: " + mediaUri);
 
-    try {
-      if (mediaType != null && mediaType.startsWith("image/")) {
-        image.setVisibility(View.VISIBLE);
-        video.setVisibility(View.GONE);
-        image.setImageUri(masterSecret, GlideApp.with(context), mediaUri, mediaType);
-      } else if (mediaType != null && mediaType.startsWith("video/")) {
-        image.setVisibility(View.GONE);
-        video.setVisibility(View.VISIBLE);
-        video.setWindow(window);
-        video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size));
-      }
-    } catch (IOException e) {
-      Log.w(TAG, e);
-      Toast.makeText(context.getApplicationContext(),
-                     R.string.MediaPreviewActivity_unssuported_media_type,
-                     Toast.LENGTH_LONG).show();
-      ((Activity)context).finish();
+    if (mediaType != null && mediaType.startsWith("image/")) {
+      image.setVisibility(View.VISIBLE);
+      video.setVisibility(View.GONE);
+      image.setImageUri(masterSecret, GlideApp.with(context), mediaUri, mediaType);
+    } else if (mediaType != null && mediaType.startsWith("video/")) {
+      image.setVisibility(View.GONE);
+      video.setVisibility(View.VISIBLE);
+      video.setWindow(window);
+      video.setVideoSource(masterSecret, new VideoSlide(context, mediaRecord.getAttachment()));
     }
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2017 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms;
+
+import android.app.Activity;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.Window;
+import android.widget.Toast;
+
+import org.thoughtcrime.securesms.components.ZoomingImageView;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.database.CursorPagerAdapter;
+import org.thoughtcrime.securesms.database.MediaDatabase.MediaRecord;
+import org.thoughtcrime.securesms.mms.GlideApp;
+import org.thoughtcrime.securesms.mms.VideoSlide;
+import org.thoughtcrime.securesms.video.VideoPlayer;
+
+import java.io.IOException;
+
+/**
+ * Adapter for providing a ViewPager with all media of a thread
+ */
+class MediaPreviewThreadAdapter extends CursorPagerAdapter {
+  private final static String TAG = MediaPreviewThreadAdapter.class.getSimpleName();
+
+  private final Context      context;
+  private final Window       window;
+  private final MasterSecret masterSecret;
+
+  MediaPreviewThreadAdapter(Context context, Window window, MasterSecret masterSecret, Cursor cursor) {
+    super(cursor);
+    this.context      = context;
+    this.window       = window;
+    this.masterSecret = masterSecret;
+  }
+
+  @Override
+  public Object instantiateItem(ViewGroup container, int position) {
+    final View             view  = LayoutInflater.from(context)
+                                                 .inflate(R.layout.media_preview_page,
+                                                          container,
+                                                          false);
+    final ZoomingImageView image = (ZoomingImageView) view.findViewById(R.id.image);
+    final VideoPlayer      video = (VideoPlayer) view.findViewById(R.id.video_player);
+
+    setMedia(image, video, position);
+    container.addView(view);
+    return view;
+  }
+
+  private void setMedia(ZoomingImageView image, VideoPlayer video, int position) {
+    final MediaRecord mediaRecord = MediaRecord.from(context,
+                                                     masterSecret,
+                                                     getCursorAtPositionOrThrow(position));
+    final String      mediaType   = mediaRecord.getContentType();
+    final Uri         mediaUri    = mediaRecord.getAttachment().getDataUri();
+    final long        size        = mediaRecord.getAttachment().getSize();
+
+    Log.w(TAG, "Loading Part URI: " + mediaUri);
+
+    try {
+      if (mediaType != null && mediaType.startsWith("image/")) {
+        image.setVisibility(View.VISIBLE);
+        video.setVisibility(View.GONE);
+        image.setImageUri(masterSecret, GlideApp.with(context), mediaUri, mediaType);
+      } else if (mediaType != null && mediaType.startsWith("video/")) {
+        image.setVisibility(View.GONE);
+        video.setVisibility(View.VISIBLE);
+        video.setWindow(window);
+        video.setVideoSource(masterSecret, new VideoSlide(context, mediaUri, size));
+      }
+    } catch (IOException e) {
+      Log.w(TAG, e);
+      Toast.makeText(context.getApplicationContext(),
+                     R.string.MediaPreviewActivity_unssuported_media_type,
+                     Toast.LENGTH_LONG).show();
+      ((Activity)context).finish();
+    }
+  }
+
+  @Override
+  public void destroyItem(ViewGroup container, int position, Object object) {
+    ((ZoomingImageView) ((View) object).findViewById(R.id.image)).cleanup();
+    ((VideoPlayer) ((View) object).findViewById(R.id.video_player)).cleanup();
+    container.removeView((View) object);
+  }
+
+  @Override
+  public boolean isViewFromObject(View view, Object object) {
+    return view == object;
+  }
+}

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -71,7 +71,7 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter {
   private void setMedia(ZoomingImageView image, VideoPlayer video, int position) {
     final MediaRecord mediaRecord = MediaRecord.from(context,
                                                      masterSecret,
-                                                     getCursorAtPositionOrThrow(position));
+                                                     getCursorAtReversedPositionOrThrow(position));
     final String      mediaType   = mediaRecord.getContentType();
     final Uri         mediaUri    = mediaRecord.getAttachment().getDataUri();
     final long        size        = mediaRecord.getAttachment().getSize();
@@ -111,16 +111,16 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter {
   }
 
   MediaRecord getMediaRecord(int position) {
-    return MediaRecord.from(context, masterSecret, getCursorAtPositionOrThrow(position));
+    return MediaRecord.from(context, masterSecret, getCursorAtReversedPositionOrThrow(position));
   }
 
   int getAndSetStartPosition(Uri mediaUri) {
     int startPosition = -1;
-    for (int i = 0; i < getCount(); i++) {
+    for (int i = getCount()-1; i >= 0; i--) {
       Uri dataUri = MediaRecord.from(context,
                                      masterSecret,
-                                     getCursorAtPositionOrThrow(i)).getAttachment()
-                                                                   .getDataUri();
+                                     getCursorAtReversedPositionOrThrow(i)).getAttachment()
+                                                                           .getDataUri();
       if (dataUri != null && dataUri.equals(mediaUri)) {
         startPosition = i;
         break;

--- a/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewThreadAdapter.java
@@ -64,12 +64,15 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter implements OnPageChan
     final ZoomingImageView image = (ZoomingImageView) view.findViewById(R.id.image);
     final VideoPlayer      video = (VideoPlayer) view.findViewById(R.id.video_player);
 
-    setMedia(image, video, position);
+    boolean startVideo = directPlayPosition == position;
+    if (startVideo) directPlayPosition = -1;
+
+    setMedia(image, video, position, startVideo);
     container.addView(view);
     return view;
   }
 
-  private void setMedia(ZoomingImageView image, VideoPlayer video, int position) {
+  private void setMedia(ZoomingImageView image, VideoPlayer video, int position, boolean setPlay) {
     final MediaRecord mediaRecord = MediaRecord.from(context,
                                                      masterSecret,
                                                      getCursorAtReversedPositionOrThrow(position));
@@ -86,7 +89,9 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter implements OnPageChan
       image.setVisibility(View.GONE);
       video.setVisibility(View.VISIBLE);
       video.setWindow(window);
-      video.setVideoSource(masterSecret, new VideoSlide(context, mediaRecord.getAttachment()));
+      video.setVideoSource(masterSecret,
+                           new VideoSlide(context, mediaRecord.getAttachment()),
+                           setPlay);
       instantiatedVideos.put(position, video);
     }
   }
@@ -122,7 +127,7 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter implements OnPageChan
     return MediaRecord.from(context, masterSecret, getCursorAtReversedPositionOrThrow(position));
   }
 
-  int getAndSetStartPosition(Uri mediaUri) {
+  int getAndSetStartPosition(Uri mediaUri, boolean startVideo) {
     int startPosition = -1;
     for (int i = getCount()-1; i >= 0; i--) {
       Uri dataUri = MediaRecord.from(context,
@@ -134,6 +139,7 @@ class MediaPreviewThreadAdapter extends CursorPagerAdapter implements OnPageChan
         break;
       }
     }
+    if (startVideo) directPlayPosition = startPosition;
     return startPosition;
   }
 }

--- a/src/org/thoughtcrime/securesms/database/CursorPagerAdapter.java
+++ b/src/org/thoughtcrime/securesms/database/CursorPagerAdapter.java
@@ -73,12 +73,13 @@ public abstract class CursorPagerAdapter extends PagerAdapter {
     return cursor.getCount();
   }
 
-  protected @NonNull Cursor getCursorAtPositionOrThrow(final int position) {
+  protected @NonNull Cursor getCursorAtReversedPositionOrThrow(final int position) {
     if (!isActiveCursor()) {
       throw new IllegalStateException("this should only be called when the cursor is valid");
     }
-    if (!cursor.moveToPosition(position)) {
-      throw new IllegalStateException("couldn't move cursor to position " + position);
+    final int reversedPosition = getCount()-1-position;
+    if (!cursor.moveToPosition(reversedPosition)) {
+      throw new IllegalStateException("couldn't move cursor to position " + reversedPosition);
     }
     return cursor;
   }

--- a/src/org/thoughtcrime/securesms/database/CursorPagerAdapter.java
+++ b/src/org/thoughtcrime/securesms/database/CursorPagerAdapter.java
@@ -1,0 +1,103 @@
+/**
+ * Copyright (C) 2017 Open Whisper Systems
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package org.thoughtcrime.securesms.database;
+
+import android.database.Cursor;
+import android.database.DataSetObserver;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.view.PagerAdapter;
+
+/**
+ * PagerAdapter that manages a Cursor, adapted from CursorRecyclerViewAdapter.
+ */
+public abstract class CursorPagerAdapter extends PagerAdapter {
+  private final DataSetObserver observer = new AdapterDataSetObserver();
+
+  private Cursor  cursor;
+  private boolean valid;
+
+  protected CursorPagerAdapter(Cursor cursor) {
+    this.cursor = cursor;
+    if (cursor != null) {
+      valid = true;
+      cursor.registerDataSetObserver(observer);
+    }
+  }
+
+  public void changeCursor(Cursor cursor) {
+    Cursor old = swapCursor(cursor);
+    if (old != null) {
+      old.close();
+    }
+  }
+
+  private @Nullable Cursor swapCursor(Cursor newCursor) {
+    if (newCursor == cursor) {
+      return null;
+    }
+
+    final Cursor oldCursor = cursor;
+    if (oldCursor != null) {
+      oldCursor.unregisterDataSetObserver(observer);
+    }
+
+    cursor = newCursor;
+    if (cursor != null) {
+      cursor.registerDataSetObserver(observer);
+    }
+
+    valid = cursor != null;
+    notifyDataSetChanged();
+    return oldCursor;
+  }
+
+  @Override
+  public int getCount() {
+    if (!isActiveCursor()) return 0;
+
+    return cursor.getCount();
+  }
+
+  protected @NonNull Cursor getCursorAtPositionOrThrow(final int position) {
+    if (!isActiveCursor()) {
+      throw new IllegalStateException("this should only be called when the cursor is valid");
+    }
+    if (!cursor.moveToPosition(position)) {
+      throw new IllegalStateException("couldn't move cursor to position " + position);
+    }
+    return cursor;
+  }
+
+  private boolean isActiveCursor() {
+    return valid && cursor != null;
+  }
+
+  private class AdapterDataSetObserver extends DataSetObserver {
+    @Override
+    public void onChanged() {
+      super.onChanged();
+      valid = true;
+    }
+
+    @Override
+    public void onInvalidated() {
+      super.onInvalidated();
+      valid = false;
+    }
+  }
+}

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -133,6 +133,10 @@ public class VideoPlayer extends FrameLayout {
       this.exoPlayer.release();
     }
 
+    if (this.videoView != null) {
+      this.videoView.suspend();
+    }
+
     if (clearPlaceholder) videoPlaceholder.clear(GlideApp.with(getContext()));
   }
 

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -124,7 +124,7 @@ public class VideoPlayer extends FrameLayout {
     }
   }
 
-  public void cleanup() {
+  public void cleanup(boolean clearPlaceholder) {
     if (this.attachmentServer != null) {
       this.attachmentServer.stop();
     }
@@ -133,7 +133,7 @@ public class VideoPlayer extends FrameLayout {
       this.exoPlayer.release();
     }
 
-    videoPlaceholder.clear(GlideApp.with(getContext()));
+    if (clearPlaceholder) videoPlaceholder.clear(GlideApp.with(getContext()));
   }
 
   public void setWindow(Window window) {
@@ -188,6 +188,17 @@ public class VideoPlayer extends FrameLayout {
     this.videoPlaceholder.setVisibility(View.GONE);
     this.videoView.setVisibility(View.VISIBLE);
     this.videoView.start();
+  }
+
+  public void hideVideo() {
+    if (exoPlayer != null) exoPlayer.stop();
+    if (exoView != null)   exoView.setVisibility(View.GONE);
+    if (videoView != null) {
+      videoView.stopPlayback();
+      videoView.setVisibility(View.GONE);
+    }
+    videoPlaceholder.setVisibility(View.VISIBLE);
+    cleanup(false);
   }
 
   private void initializeVideoViewControls(@NonNull VideoView videoView) {

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
@@ -53,7 +54,9 @@ import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.attachments.AttachmentServer;
+import org.thoughtcrime.securesms.components.ThumbnailView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.mms.GlideApp;
 import org.thoughtcrime.securesms.mms.PartAuthority;
 import org.thoughtcrime.securesms.mms.VideoSlide;
 import org.thoughtcrime.securesms.util.ViewUtil;
@@ -65,6 +68,7 @@ public class VideoPlayer extends FrameLayout {
 
   private static final String TAG = VideoPlayer.class.getName();
 
+  @NonNull  private final ThumbnailView       videoPlaceholder;
   @Nullable private final VideoView           videoView;
   @Nullable private final SimpleExoPlayerView exoView;
 
@@ -93,13 +97,31 @@ public class VideoPlayer extends FrameLayout {
       this.exoView   = null;
       initializeVideoViewControls(videoView);
     }
+    this.videoPlaceholder = ViewUtil.findById(this, R.id.video_placeholder);
   }
 
-  public void setVideoSource(@NonNull MasterSecret masterSecret, @NonNull VideoSlide videoSource)
-      throws IOException
+  public void setVideoSource(@NonNull final MasterSecret masterSecret,
+                             @NonNull final VideoSlide videoSource)
   {
-    if (Build.VERSION.SDK_INT >= 16) setExoViewSource(masterSecret, videoSource);
-    else                             setVideoViewSource(masterSecret, videoSource);
+    videoPlaceholder.setImageResource(masterSecret, GlideApp.with(getContext()), videoSource, false, false);
+    videoPlaceholder.setOnClickListener(new OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        showVideo(masterSecret,videoSource);
+      }
+    });
+  }
+
+  private void showVideo(MasterSecret masterSecret, VideoSlide videoSource) {
+    try {
+      if (Build.VERSION.SDK_INT >= 16) setExoViewSource(masterSecret, videoSource);
+      else                             setVideoViewSource(masterSecret, videoSource);
+    } catch (IOException e) {
+      Log.w(TAG, e);
+      Toast.makeText(getContext(),
+                     R.string.MediaPreviewActivity_unssuported_media_type,
+                     Toast.LENGTH_LONG).show();
+    }
   }
 
   public void cleanup() {
@@ -110,6 +132,8 @@ public class VideoPlayer extends FrameLayout {
     if (this.exoPlayer != null) {
       this.exoPlayer.release();
     }
+
+    videoPlaceholder.clear(GlideApp.with(getContext()));
   }
 
   public void setWindow(Window window) {
@@ -135,6 +159,8 @@ public class VideoPlayer extends FrameLayout {
     MediaSource mediaSource = new ExtractorMediaSource(videoSource.getUri(), attachmentDataSourceFactory, extractorsFactory, null, null);
 
     exoPlayer.prepare(mediaSource);
+    videoPlaceholder.setVisibility(View.GONE);
+    exoView.setVisibility(View.VISIBLE);
     exoPlayer.setPlayWhenReady(true);
   }
 
@@ -159,6 +185,8 @@ public class VideoPlayer extends FrameLayout {
       return;
     }
 
+    this.videoPlaceholder.setVisibility(View.GONE);
+    this.videoView.setVisibility(View.VISIBLE);
     this.videoView.start();
   }
 

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -101,8 +101,8 @@ public class VideoPlayer extends FrameLayout {
   }
 
   public void setVideoSource(@NonNull final MasterSecret masterSecret,
-                             @NonNull final VideoSlide videoSource)
-  {
+                             @NonNull final VideoSlide   videoSource,
+                                            boolean      setPlay) {
     videoPlaceholder.setImageResource(masterSecret, GlideApp.with(getContext()), videoSource, false, false);
     videoPlaceholder.setOnClickListener(new OnClickListener() {
       @Override
@@ -110,6 +110,8 @@ public class VideoPlayer extends FrameLayout {
         showVideo(masterSecret,videoSource);
       }
     });
+
+    if (setPlay) showVideo(masterSecret, videoSource);
   }
 
   private void showVideo(MasterSecret masterSecret, VideoSlide videoSource) {


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Please read the commit messages to see, which changes I applied.

The following problems remain:

- Raise offscreen page limit of the viewPager to enable a smoother paging experience? By default the viewed page plus one page to the right and one to the left is instantiated (offscreen page limit = 1). If you use a slow phone and swipe swiftly, you will reach a page whose media are not yet instantiated. You will see a black page which will display media with some latency. We can try to solve this issue by raising the offscreen page limit to 2. In worst case you are still using a slow phone and 5 GIFs are now instantiated (animated). I observed that the animations get slow in this situation. This could be solved by stopping GIF animations when GIFs are offscreen. If you want this behaviour, I will implement it.
- Do we want to be able to switch pages when an image is zoomed in? I implemented this feature in #5801, but decided to keep it out of this PR to keep the diff low.
- On Android versions prior to Marshmallow no video thumbnails are created. In media preview when swiping to a video the placeholder will be shown. It has to be tapped to start video playback. To make this clear, we should show the play overlay above the placeholder. This should go in a separate PR, too. -> #6635
- The video thumbnails maybe should have the same size as the video and don't fill the whole screen.

Sadly I'm not able to test this contribution with the platforms that use the old video player, which are Android versions 4.0.1 downwards (see #6603). I would be happy, if someone tested this PR using such a device :)

Fixes #2355 
Supersedes #5801