### PR TITLE
Warn about disabling built-in emoji support

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1192,8 +1192,8 @@
     <string name="preferences_chats__when_roaming">When roaming</string>
     <string name="preferences_chats__media_auto_download">Media auto-download</string>
     <string name="preferences_chats__message_trimming">Message trimming</string>
-    <string name="preferences_advanced__use_system_emoji">Use system emoji</string>
-    <string name="preferences_advanced__disable_signal_built_in_emoji_support">Disable Signal\'s built-in emoji support</string>
+    <string name="preferences_advanced__disable_built_in_emoji">Disable built-in emoji</string>
+    <string name="preferences_advanced__disable_signal_built_in_emoji_support">Disable Signal\'s built-in emoji support and use system emoji instead. This might result in different emoji for you and your contacts.</string>
     <string name="preferences_advanced__video_calling_beta">Video calling beta</string>
     <string name="preferences_advanced__enable_support_for_next_generation_video_and_voice_calls">Support for next-generation video and voice calls when enabled by both parties. This feature is in beta.</string>
     <string name="preferences_advanced__relay_all_calls_through_the_signal_server_to_avoid_revealing_your_ip_address">Relay all calls through the Signal server to avoid revealing your IP address to your contact. Enabling will reduce call quality.</string>

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -47,7 +47,7 @@
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="pref_system_emoji"
-                android:title="@string/preferences_advanced__use_system_emoji"
+                android:title="@string/preferences_advanced__disable_built_in_emoji"
                 android:summary="@string/preferences_advanced__disable_signal_built_in_emoji_support" />
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Warn user about disabling Signal's built-in emoji because it can lead to different interpretations.

See #6640, cc @FeuRenard 

// FREEBIE
