### PR TITLE
Keep screen off after end of audio playback

### DIFF
--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -134,7 +134,7 @@ public class AudioSlidePlayer implements SensorEventListener {
 
           sensorManager.unregisterListener(AudioSlidePlayer.this);
 
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && wakeLock.isHeld()) {
+          if (wakeLock != null && wakeLock.isHeld()) {
             wakeLock.release(PowerManager.RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY);
           }
         }
@@ -161,7 +161,7 @@ public class AudioSlidePlayer implements SensorEventListener {
 
           sensorManager.unregisterListener(AudioSlidePlayer.this);
 
-          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && wakeLock.isHeld()) {
+          if (wakeLock != null && wakeLock.isHeld()) {
             wakeLock.release(PowerManager.RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY);
           }
         }

--- a/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
+++ b/src/org/thoughtcrime/securesms/audio/AudioSlidePlayer.java
@@ -133,7 +133,10 @@ public class AudioSlidePlayer implements SensorEventListener {
           }
 
           sensorManager.unregisterListener(AudioSlidePlayer.this);
-          if (wakeLock != null && wakeLock.isHeld()) wakeLock.release();
+
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && wakeLock.isHeld()) {
+            wakeLock.release(PowerManager.RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY);
+          }
         }
 
         notifyOnStop();
@@ -157,7 +160,10 @@ public class AudioSlidePlayer implements SensorEventListener {
           }
 
           sensorManager.unregisterListener(AudioSlidePlayer.this);
-          if (wakeLock != null && wakeLock.isHeld()) wakeLock.release();
+
+          if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && wakeLock.isHeld()) {
+            wakeLock.release(PowerManager.RELEASE_FLAG_WAIT_FOR_NO_PROXIMITY);
+          }
         }
 
         notifyOnStop();


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD Nexus 5X, Android 7.1.1
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Would be nice if some tested this on a physical Lollipop+ device. The emulator behaves a bit oddly when its screen is turned off (it just freezes and accepts input). But the logs indicate the correct behaviour :wink:.


Fixes #6654
// FREEBIE