### PR TITLE
Allow hiding action bar in media preview

### DIFF
--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -24,6 +24,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -78,6 +79,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     dynamicLanguage.onCreate(this);
 
     setFullscreenIfPossible();
+    supportRequestWindowFeature(AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR_OVERLAY);
     getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                          WindowManager.LayoutParams.FLAG_FULLSCREEN);
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -155,6 +155,13 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
         toggleActionBar();
       }
     });
+
+    image.setOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        toggleActionBar();
+      }
+    });
   }
 
   private void toggleActionBar() {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -34,6 +34,8 @@ import android.view.View;
 import android.view.WindowManager;
 import android.widget.Toast;
 
+import com.google.android.exoplayer2.ui.PlaybackControlView.VisibilityListener;
+
 import org.thoughtcrime.securesms.components.ZoomingImageView;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.Address;
@@ -160,6 +162,17 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
       @Override
       public void onClick(View v) {
         toggleActionBar();
+      }
+    });
+
+    video.setPlaybackControlVisibilityListener(new VisibilityListener() {
+      @Override
+      public void onVisibilityChange(int visibility) {
+        if (visibility == View.VISIBLE) {
+          getSupportActionBar().show();
+        } else {
+          getSupportActionBar().hide();
+        }
       }
     });
   }

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -24,6 +24,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
 import android.view.Menu;
@@ -46,6 +47,8 @@ import org.thoughtcrime.securesms.util.SaveAttachmentTask.Attachment;
 import org.thoughtcrime.securesms.video.VideoPlayer;
 
 import java.io.IOException;
+
+import uk.co.senab.photoview.PhotoViewAttacher.OnViewTapListener;
 
 /**
  * Activity for displaying media attachments in-app
@@ -87,6 +90,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     setContentView(R.layout.media_preview_activity);
 
     initializeViews();
+    initializeListeners();
     initializeResources();
     initializeActionBar();
   }
@@ -142,6 +146,21 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   private void initializeViews() {
     image = (ZoomingImageView) findViewById(R.id.image);
     video = (VideoPlayer) findViewById(R.id.video_player);
+  }
+
+  private void initializeListeners() {
+    image.setOnViewTapListener(new OnViewTapListener() {
+      @Override
+      public void onViewTap(View view, float v, float v1) {
+        toggleActionBar();
+      }
+    });
+  }
+
+  private void toggleActionBar() {
+    ActionBar actionBar = getSupportActionBar();
+    if (actionBar.isShowing()) actionBar.hide();
+    else                       actionBar.show();
   }
 
   private void initializeResources() {

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -19,11 +19,13 @@ package org.thoughtcrime.securesms;
 import android.annotation.TargetApi;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.graphics.drawable.ColorDrawable;
 import android.net.Uri;
 import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatDelegate;
 import android.util.Log;
@@ -89,6 +91,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
                          WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    getSupportActionBar().setBackgroundDrawable(new ColorDrawable(ContextCompat.getColor(this, R.color.gray95_transparent50)));
     setContentView(R.layout.media_preview_activity);
 
     initializeViews();

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -86,7 +86,6 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     dynamicLanguage.onCreate(this);
 
     setFullscreenIfPossible();
-    supportRequestWindowFeature(AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR_OVERLAY);
     getWindow().setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
                          WindowManager.LayoutParams.FLAG_FULLSCREEN);
 
@@ -95,7 +94,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     setContentView(R.layout.media_preview_activity);
 
     initializeViews();
-    initializeListeners();
+    initializeListenersIfNecessary();
     initializeResources();
     initializeActionBar();
   }
@@ -104,6 +103,7 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   private void setFullscreenIfPossible() {
     if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
       getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_FULLSCREEN);
+      supportRequestWindowFeature(AppCompatDelegate.FEATURE_SUPPORT_ACTION_BAR_OVERLAY);
     }
   }
 
@@ -153,31 +153,33 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
     video = (VideoPlayer) findViewById(R.id.video_player);
   }
 
-  private void initializeListeners() {
-    image.setOnViewTapListener(new OnViewTapListener() {
-      @Override
-      public void onViewTap(View view, float v, float v1) {
-        toggleActionBar();
-      }
-    });
-
-    image.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View v) {
-        toggleActionBar();
-      }
-    });
-
-    video.setPlaybackControlVisibilityListener(new VisibilityListener() {
-      @Override
-      public void onVisibilityChange(int visibility) {
-        if (visibility == View.VISIBLE) {
-          getSupportActionBar().show();
-        } else {
-          getSupportActionBar().hide();
+  private void initializeListenersIfNecessary() {
+    if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
+      image.setOnViewTapListener(new OnViewTapListener() {
+        @Override
+        public void onViewTap(View view, float v, float v1) {
+          toggleActionBar();
         }
-      }
-    });
+      });
+
+      image.setOnClickListener(new View.OnClickListener() {
+        @Override
+        public void onClick(View v) {
+          toggleActionBar();
+        }
+      });
+
+      video.setPlaybackControlVisibilityListener(new VisibilityListener() {
+        @Override
+        public void onVisibilityChange(int visibility) {
+          if (visibility == View.VISIBLE) {
+            getSupportActionBar().show();
+          } else {
+            getSupportActionBar().hide();
+          }
+        }
+      });
+    }
   }
 
   private void toggleActionBar() {

--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -128,4 +128,8 @@ public class ZoomingImageView extends FrameLayout {
     imageView.setImageDrawable(null);
     subsamplingImageView.recycle();
   }
+
+  public void setOnViewTapListener(PhotoViewAttacher.OnViewTapListener listener) {
+    imageViewAttacher.setOnViewTapListener(listener);
+  }
 }

--- a/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
+++ b/src/org/thoughtcrime/securesms/components/ZoomingImageView.java
@@ -132,4 +132,9 @@ public class ZoomingImageView extends FrameLayout {
   public void setOnViewTapListener(PhotoViewAttacher.OnViewTapListener listener) {
     imageViewAttacher.setOnViewTapListener(listener);
   }
+
+  @Override
+  public void setOnClickListener(OnClickListener listener) {
+    subsamplingImageView.setOnClickListener(listener);
+  }
 }

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -46,6 +46,7 @@ import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
 import com.google.android.exoplayer2.trackselection.TrackSelectionArray;
 import com.google.android.exoplayer2.trackselection.TrackSelector;
+import com.google.android.exoplayer2.ui.PlaybackControlView.VisibilityListener;
 import com.google.android.exoplayer2.ui.SimpleExoPlayerView;
 import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
@@ -168,6 +169,10 @@ public class VideoPlayer extends FrameLayout {
     mediaController.setMediaPlayer(videoView);
 
     videoView.setMediaController(mediaController);
+  }
+
+  public void setPlaybackControlVisibilityListener(VisibilityListener listener) {
+    if (exoView != null) exoView.setControllerVisibilityListener(listener);
   }
 
   private class ExoPlayerListener implements ExoPlayer.EventListener {

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -69,9 +69,9 @@ public class VideoPlayer extends FrameLayout {
   @Nullable private final VideoView           videoView;
   @Nullable private final SimpleExoPlayerView exoView;
 
-  @Nullable private       SimpleExoPlayer  exoPlayer;
-  @Nullable private       AttachmentServer attachmentServer;
-  @Nullable private       Window           window;
+  @Nullable private       SimpleExoPlayer     exoPlayer;
+  @Nullable private       AttachmentServer    attachmentServer;
+  @Nullable private       Window              window;
 
   public VideoPlayer(Context context) {
     this(context, null);

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -22,7 +22,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
-import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
@@ -70,10 +69,9 @@ public class VideoPlayer extends FrameLayout {
   @Nullable private final VideoView           videoView;
   @Nullable private final SimpleExoPlayerView exoView;
 
-  @Nullable private       SimpleExoPlayer           exoPlayer;
-  @Nullable private       AttachmentServer          attachmentServer;
-  @Nullable private       Window                    window;
-  @Nullable private       PlaybackControlViewCompat mediaController;
+  @Nullable private       SimpleExoPlayer  exoPlayer;
+  @Nullable private       AttachmentServer attachmentServer;
+  @Nullable private       Window           window;
 
   public VideoPlayer(Context context) {
     this(context, null);
@@ -166,7 +164,7 @@ public class VideoPlayer extends FrameLayout {
   }
 
   private void initializeVideoViewControls(@NonNull VideoView videoView) {
-    mediaController = new PlaybackControlViewCompat(getContext());
+    MediaController mediaController = new MediaController(getContext());
     mediaController.setAnchorView(videoView);
     mediaController.setMediaPlayer(videoView);
 
@@ -174,42 +172,7 @@ public class VideoPlayer extends FrameLayout {
   }
 
   public void setPlaybackControlVisibilityListener(VisibilityListener listener) {
-    if (exoView != null)         exoView.setControllerVisibilityListener(listener);
-    if (mediaController != null) mediaController.setVisibilityListener(listener);
-  }
-
-  private class PlaybackControlViewCompat extends MediaController {
-    private VisibilityListener visibilityListener;
-    private static final int DEFAULT_TIMEOUT = 5000;
-
-    private PlaybackControlViewCompat(Context context) {
-      super(context);
-    }
-
-    @Override
-    public void show() {
-      show(DEFAULT_TIMEOUT);
-    }
-
-    @Override
-    public void show(int timeout) {
-      super.show(timeout);
-      notifyVisibilityListener(View.VISIBLE);
-    }
-
-    @Override
-    public void hide() {
-      super.hide();
-      notifyVisibilityListener(View.GONE);
-    }
-
-    private void setVisibilityListener(VisibilityListener listener) {
-      this.visibilityListener = listener;
-    }
-
-    private void notifyVisibilityListener(int visibility) {
-      if (visibilityListener != null) visibilityListener.onVisibilityChange(visibility);
-    }
+    if (exoView != null) exoView.setControllerVisibilityListener(listener);
   }
 
   private class ExoPlayerListener implements ExoPlayer.EventListener {

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -22,6 +22,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.View;
 import android.view.Window;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
@@ -69,9 +70,10 @@ public class VideoPlayer extends FrameLayout {
   @Nullable private final VideoView           videoView;
   @Nullable private final SimpleExoPlayerView exoView;
 
-  @Nullable private       SimpleExoPlayer     exoPlayer;
-  @Nullable private       AttachmentServer    attachmentServer;
-  @Nullable private       Window              window;
+  @Nullable private       SimpleExoPlayer           exoPlayer;
+  @Nullable private       AttachmentServer          attachmentServer;
+  @Nullable private       Window                    window;
+  @Nullable private       PlaybackControlViewCompat mediaController;
 
   public VideoPlayer(Context context) {
     this(context, null);
@@ -164,7 +166,7 @@ public class VideoPlayer extends FrameLayout {
   }
 
   private void initializeVideoViewControls(@NonNull VideoView videoView) {
-    MediaController mediaController = new MediaController(getContext());
+    mediaController = new PlaybackControlViewCompat(getContext());
     mediaController.setAnchorView(videoView);
     mediaController.setMediaPlayer(videoView);
 
@@ -172,7 +174,36 @@ public class VideoPlayer extends FrameLayout {
   }
 
   public void setPlaybackControlVisibilityListener(VisibilityListener listener) {
-    if (exoView != null) exoView.setControllerVisibilityListener(listener);
+    if (exoView != null)         exoView.setControllerVisibilityListener(listener);
+    if (mediaController != null) mediaController.setVisibilityListener(listener);
+  }
+
+  private class PlaybackControlViewCompat extends MediaController {
+    private VisibilityListener visibilityListener;
+
+    private PlaybackControlViewCompat(Context context) {
+      super(context);
+    }
+
+    @Override
+    public void show(int timeout) {
+      super.show(timeout);
+      notifyVisibilityListener(View.VISIBLE);
+    }
+
+    @Override
+    public void hide() {
+      super.hide();
+      notifyVisibilityListener(View.GONE);
+    }
+
+    private void setVisibilityListener(VisibilityListener listener) {
+      this.visibilityListener = listener;
+    }
+
+    private void notifyVisibilityListener(int visibility) {
+      if (visibilityListener != null) visibilityListener.onVisibilityChange(visibility);
+    }
   }
 
   private class ExoPlayerListener implements ExoPlayer.EventListener {

--- a/src/org/thoughtcrime/securesms/video/VideoPlayer.java
+++ b/src/org/thoughtcrime/securesms/video/VideoPlayer.java
@@ -180,9 +180,15 @@ public class VideoPlayer extends FrameLayout {
 
   private class PlaybackControlViewCompat extends MediaController {
     private VisibilityListener visibilityListener;
+    private static final int DEFAULT_TIMEOUT = 5000;
 
     private PlaybackControlViewCompat(Context context) {
       super(context);
+    }
+
+    @Override
+    public void show() {
+      show(DEFAULT_TIMEOUT);
     }
 
     @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Sony Xperia U, Android 4.4.4 (CyanogenMod)
 * AVD Nexus 5X, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This PR allows to show/hide the action bar in media preview by single-tapping the media. For videos the visibility of the action bar is coupled to the visibility of the playback controls. So the single-tap that usually shows/hides the playback controls now also shows/hides the action bar, too.
Additionally I colored the action bar semi-transparent.

I tested this contribution for both image views and for both video views. Sadly I wasn't able to test `SubsamplingImageView` and `VideoView` under realistic conditions, but only by forcing them to be used on the platforms mentioned above.

### Screenshots
![bildschirmfoto von 2017-05-30 21-37-31](https://cloud.githubusercontent.com/assets/16167751/26602337/768894d8-4583-11e7-81ba-6dcec7dc7d1e.png)
![bildschirmfoto von 2017-05-30 21-35-48](https://cloud.githubusercontent.com/assets/16167751/26602344/78bde348-4583-11e7-9201-68a63a79594b.png)

### Outlook
I plan to implement #5934 on top of this. This would add showing/hiding the status bar on Jelly Bean+ and additionally showing/hiding navigation bar on KitKat+ (immersive mode).
In a separate PR or on request I could add auto-hiding with `Handler.postDelayed(...)`. It's easy but I left it out of this PR for now. That would mean that on entering `MediaPreviewActivity` action bar is shown at first but hides after some seconds.