### PR TITLE
Adjust string "Message notifications" in notification preferences

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1204,7 +1204,7 @@
     <string name="preferences_app_protection__app_access">App access</string>
     <string name="preferences_app_protection__communication">Communication</string>
     <string name="preferences_chats__chats">Chats</string>
-    <string name="preferences_notifications__message_notifications">Message notifications</string>
+    <string name="preferences_notifications__messages">Messages</string>
     <string name="preferences_notifications__events">Events</string>
     <string name="preferences_notifications__in_chat_sounds">In-chat sounds</string>
     <string name="preferences_notifications__show">Show</string>

--- a/res/xml/preferences_notifications.xml
+++ b/res/xml/preferences_notifications.xml
@@ -2,7 +2,7 @@
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceCategory android:title="@string/preferences_notifications__message_notifications">
+    <PreferenceCategory android:title="@string/preferences_notifications__messages">
 
         <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
                             android:key="pref_key_enable_notifications"


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * LG Nexus 5X, Android 7.1.2
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
With the restructuring of the notification preferences screen in https://github.com/WhisperSystems/Signal-Android/commit/13d785894a90cb1dae353ff2d3ad7a70c6f7ac00, the logical structure of the chosen wording got slightly off.

**Prior to this PR:**
- Settings
   - Notifications
      - Message notifications
      - Events

**After this PR:**
- Settings
   - Notifications
      - Messages
      - Events