### PR TITLE
New group creation with user from conversation

### DIFF
--- a/res/menu/conversation_new_group.xml
+++ b/res/menu/conversation_new_group.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item android:title="@string/text_secure_normal__menu_new_group"
+        android:id="@+id/menu_new_group" />
+
+</menu>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -187,6 +187,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public static final String DISTRIBUTION_TYPE_EXTRA = "distribution_type";
   public static final String TIMING_EXTRA            = "timing";
   public static final String LAST_SEEN_EXTRA         = "last_seen";
+  public static final String INITIAL_RECIPIENT_EXTRA = "last_seen";
 
   private static final int PICK_GALLERY      = 1;
   private static final int PICK_DOCUMENT     = 2;
@@ -486,6 +487,9 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     inflater.inflate(R.menu.conversation, menu);
+    if(isSingleConversation()){
+      inflater.inflate(R.menu.conversation_new_group,menu);
+    }
 
     if (isSingleConversation() && isSecureText) {
       inflater.inflate(R.menu.conversation_secure, menu);
@@ -520,6 +524,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     case R.id.menu_edit_group:                handleEditPushGroup();                             return true;
     case R.id.menu_leave:                     handleLeavePushGroup();                            return true;
     case R.id.menu_invite:                    handleInviteLink();                                return true;
+    case R.id.menu_new_group:                 handleNewGroupWithUser();                          return true;
     case R.id.menu_mute_notifications:        handleMuteNotifications();                         return true;
     case R.id.menu_unmute_notifications:      handleUnmuteNotifications();                       return true;
     case R.id.menu_conversation_settings:     handleConversationSettings();                      return true;
@@ -674,6 +679,15 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } catch (NoSuchAlgorithmException e) {
       throw new AssertionError(e);
     }
+  }
+
+  private void handleNewGroupWithUser() {
+    Intent intent = new Intent(ConversationActivity.this,GroupCreateActivity.class);
+    Recipient primaryRecipient = recipients.getPrimaryRecipient();
+    if(primaryRecipient !=null) {
+      intent.putExtra(INITIAL_RECIPIENT_EXTRA, primaryRecipient.getRecipientId());
+    }
+    startActivity(intent);
   }
 
   private void handleResetSecureSession() {

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -187,7 +187,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public static final String DISTRIBUTION_TYPE_EXTRA = "distribution_type";
   public static final String TIMING_EXTRA            = "timing";
   public static final String LAST_SEEN_EXTRA         = "last_seen";
-  public static final String INITIAL_RECIPIENT_EXTRA = "last_seen";
+  public static final String INITIAL_RECIPIENT_EXTRA = "initial_recipient";
 
   private static final int PICK_GALLERY      = 1;
   private static final int PICK_DOCUMENT     = 2;
@@ -487,7 +487,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     }
 
     inflater.inflate(R.menu.conversation, menu);
-    if(isSingleConversation()){
+    if (isSingleConversation()) {
       inflater.inflate(R.menu.conversation_new_group,menu);
     }
 
@@ -684,7 +684,7 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   private void handleNewGroupWithUser() {
     Intent intent = new Intent(ConversationActivity.this,GroupCreateActivity.class);
     Recipient primaryRecipient = recipients.getPrimaryRecipient();
-    if(primaryRecipient !=null) {
+    if (primaryRecipient !=null) {
       intent.putExtra(INITIAL_RECIPIENT_EXTRA, primaryRecipient.getRecipientId());
     }
     startActivity(intent);

--- a/src/org/thoughtcrime/securesms/GroupCreateActivity.java
+++ b/src/org/thoughtcrime/securesms/GroupCreateActivity.java
@@ -128,6 +128,13 @@ public class GroupCreateActivity extends PassphraseRequiredActionBarActivity
     getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     initializeResources();
     initializeExistingGroup();
+
+    Bundle extras = getIntent().getExtras();
+    if (extras != null && extras.containsKey(ConversationActivity.INITIAL_RECIPIENT_EXTRA)) {
+      Recipient firstRecipient = RecipientFactory.getRecipientForId(this,
+          extras.getLong(ConversationActivity.INITIAL_RECIPIENT_EXTRA), false);
+      addSelectedContacts(firstRecipient);
+    }
   }
 
   @Override


### PR DESCRIPTION
//FREEBIE

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Device Galaxy Note4, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Adds feature to create new group with recipient right from conversation. When you tap "New group" you move to `GroupCreateActivity` with already added recipient.
