### PR TITLE
Add staging server warning to "no device found" error

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -441,7 +441,7 @@
     <string name="DeviceProvisioningActivity_content_progress_title">Linking device</string>
     <string name="DeviceProvisioningActivity_content_progress_content">Linking new device...</string>
     <string name="DeviceProvisioningActivity_content_progress_success">Device approved!</string>
-    <string name="DeviceProvisioningActivity_content_progress_no_device">No device found.</string>
+    <string name="DeviceProvisioningActivity_content_progress_no_device">No device found. If you are developing Signal, you\'ll need to use the staging server.</string>
     <string name="DeviceProvisioningActivity_content_progress_network_error">Network error.</string>
     <string name="DeviceProvisioningActivity_content_progress_key_error">Invalid QR code.</string>
     <string name="DeviceProvisioningActivity_sorry_you_have_too_many_devices_linked_already">Sorry, you have too many devices linked already, try removing some</string>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * not applicable
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Extends the "No device found." message with a staging server warning.
