### PR TITLE
Auto dark theme based on time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ dependencies {
         exclude group: 'com.squareup.okhttp', module: 'okhttp'
         exclude group: 'com.squareup.okhttp', module: 'okhttp-urlconnection'
     }
+    compile 'com.luckycatlabs:SunriseSunsetCalculator:1.2'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.assertj:assertj-core:1.7.1'

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -99,11 +99,13 @@
   <string-array name="pref_theme_entries">
       <item>@string/preferences__light_theme</item>
       <item>@string/preferences__dark_theme</item>
+      <item>@string/preferences__autodark_theme</item>
   </string-array>
 
   <string-array name="pref_theme_values" translatable="false">
       <item>light</item>
       <item>dark</item>
+      <item>auto_dark</item>
   </string-array>
 
   <string-array name="pref_led_color_entries">
@@ -305,4 +307,5 @@
         <item>2</item>
     </string-array>
 
+    <string name="preferences__autodark_theme">Auto Dark</string>
 </resources>

--- a/src/org/thoughtcrime/securesms/util/CalendarUtils.java
+++ b/src/org/thoughtcrime/securesms/util/CalendarUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2017 Fernando Garcia Alvarez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thoughtcrime.securesms.util;
+
+import java.util.Calendar;
+
+/**
+ * Utility class to work with calendars
+ *
+ * @author fercarcedo
+ */
+
+public class CalendarUtils {
+  public static boolean afterHoursAndMinutes(Calendar firstCalendar, Calendar secondCalendar) {
+    int firstCalendarHours = firstCalendar.get(Calendar.HOUR_OF_DAY);
+    int firstCalendarMinutes = firstCalendar.get(Calendar.MINUTE);
+    int secondCalendarHours = secondCalendar.get(Calendar.HOUR_OF_DAY);
+    int secondCalendarMinutes = secondCalendar.get(Calendar.MINUTE);
+
+    return (firstCalendarHours > secondCalendarHours)
+                || (firstCalendarHours == secondCalendarHours && firstCalendarMinutes > secondCalendarMinutes);
+  }
+
+  public static boolean beforeHoursAndMinutes(Calendar firstCalendar, Calendar secondCalendar) {
+    int firstCalendarHours = firstCalendar.get(Calendar.HOUR_OF_DAY);
+    int firstCalendarMinutes = firstCalendar.get(Calendar.MINUTE);
+    int secondCalendarHours = secondCalendar.get(Calendar.HOUR_OF_DAY);
+    int secondCalendarMinutes = secondCalendar.get(Calendar.MINUTE);
+
+    return (firstCalendarHours < secondCalendarHours)
+                || (firstCalendarHours == secondCalendarHours && firstCalendarMinutes < secondCalendarMinutes);
+  }
+
+  public static Calendar createFromMillis(long millis) {
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTimeInMillis(millis);
+
+    return calendar;
+  }
+}

--- a/src/org/thoughtcrime/securesms/util/DynamicTheme.java
+++ b/src/org/thoughtcrime/securesms/util/DynamicTheme.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (C) 2017 Fernando Garcia Alvarez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.thoughtcrime.securesms.util;
 
 import android.app.Activity;
@@ -6,7 +21,7 @@ import android.content.Intent;
 import org.thoughtcrime.securesms.R;
 
 public class DynamicTheme {
-
+  public static final String AUTO_DARK = "auto_dark";
   public static final String DARK  = "dark";
   public static final String LIGHT = "light";
 
@@ -31,6 +46,9 @@ public class DynamicTheme {
     String theme = TextSecurePreferences.getTheme(activity);
 
     if (theme.equals(DARK)) return R.style.TextSecure_DarkTheme;
+
+    if (theme.equals(AUTO_DARK))
+      return TimeHelper.isNight(activity) ? R.style.TextSecure_DarkTheme : R.style.TextSecure_LightTheme;
 
     return R.style.TextSecure_LightTheme;
   }

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -109,6 +109,9 @@ public class TextSecurePreferences {
   private static final String MULTI_DEVICE_PROVISIONED_PREF    = "pref_multi_device";
   public  static final String DIRECT_CAPTURE_CAMERA_ID         = "pref_direct_capture_camera_id";
   private static final String ALWAYS_RELAY_CALLS_PREF          = "pref_turn_only";
+  private static final String SUNRISE_TIME_PREF                = "sunrise_time";
+  private static final String SUNSET_TIME_PREF                 = "sunset_time";
+  private static final String TIME_ELAPSED_PREF                = "time_elapsed_sunset_time";
 
   public static int getNotificationPriority(Context context) {
     return Integer.valueOf(getStringPreference(context, NOTIFICATION_PRIORITY_PREF, String.valueOf(NotificationCompat.PRIORITY_HIGH)));
@@ -608,6 +611,30 @@ public class TextSecurePreferences {
 
   public static @NonNull Set<String> getRoamingMediaDownloadAllowed(Context context) {
     return getMediaDownloadAllowed(context, MEDIA_DOWNLOAD_ROAMING_PREF, R.array.pref_media_download_roaming_default);
+  }
+
+  public static long getSunriseTime(Context context) {
+    return getLongPreference(context, SUNRISE_TIME_PREF, -1);
+  }
+
+  public static long getSunsetTime(Context context) {
+    return getLongPreference(context, SUNSET_TIME_PREF, -1);
+  }
+
+  public static long getSunsetLastModifiedTime(Context context) {
+    return getLongPreference(context, TIME_ELAPSED_PREF, -1);
+  }
+
+  public static void setSunriseTime(Context context, long sunriseTimeMillis) {
+    setLongPreference(context, SUNRISE_TIME_PREF, sunriseTimeMillis);
+  }
+
+  public static void setSunsetTime(Context context, long sunsetTimeMillis) {
+    setLongPreference(context, SUNSET_TIME_PREF, sunsetTimeMillis);
+  }
+
+  public static void setSunsetLastModifiedTime(Context context, long sunsetLastModifiedTimeMillis) {
+    setLongPreference(context, TIME_ELAPSED_PREF, sunsetLastModifiedTimeMillis);
   }
 
   private static @NonNull Set<String> getMediaDownloadAllowed(Context context, String key, @ArrayRes int defaultValuesRes) {

--- a/src/org/thoughtcrime/securesms/util/TimeHelper.java
+++ b/src/org/thoughtcrime/securesms/util/TimeHelper.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2017 Fernando Garcia Alvarez
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.thoughtcrime.securesms.util;
+
+import android.content.Context;
+import android.location.Location;
+import android.location.LocationManager;
+
+import com.luckycatlabs.sunrisesunset.SunriseSunsetCalculator;
+
+import java.util.Calendar;
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class to check if it's night or day
+ *
+ * @author fercarcedo
+ */
+
+public class TimeHelper {
+  private static final int FRESHNESS_HOURS = 24;
+
+  private static Calendar sunriseCalendar;
+  private static Calendar sunsetCalendar;
+  private static Calendar lastModifiedDate;
+
+  public static boolean isNight(Context context) {
+    calculateNightTimeIfNecessary(context);
+    Calendar todayCalendar = Calendar.getInstance();
+    return CalendarUtils.afterHoursAndMinutes(todayCalendar, sunsetCalendar)
+            || CalendarUtils.beforeHoursAndMinutes(todayCalendar, sunriseCalendar);
+  }
+
+  private static boolean timeNotSet() {
+    return sunriseCalendar == null || sunsetCalendar == null;
+  }
+
+  private static boolean shouldCalculateNightTime() {
+    return timeNotSet() || freshnessTimeElapsed();
+  }
+
+  private static boolean freshnessTimeElapsed() {
+    Calendar todayCalendar = Calendar.getInstance();
+    long diffSeconds = (todayCalendar.getTimeInMillis() - lastModifiedDate.getTimeInMillis());
+    long diffHours = TimeUnit.SECONDS.toHours(diffSeconds);
+
+    return diffHours > FRESHNESS_HOURS;
+  }
+
+  private static void calculateNightTimeIfNecessary(Context context) {
+    if (timeNotSet()) {
+      loadNightTimeFromSharedPreferences(context);
+    }
+
+    if (shouldCalculateNightTime()) {
+      calculateNightTime(context);
+      storeNightTimeIntoSharedPreferences(context);
+    }
+  }
+
+  private static void loadNightTimeFromSharedPreferences(Context context) {
+    long sunriseTime = TextSecurePreferences.getSunriseTime(context);
+    long sunsetTime = TextSecurePreferences.getSunsetTime(context);
+    long lastModifiedTime = TextSecurePreferences.getSunsetLastModifiedTime(context);
+
+    if (sunriseTime > 0 && sunsetTime > 0 && lastModifiedTime > 0) {
+      sunriseCalendar = CalendarUtils.createFromMillis(sunriseTime);
+      sunsetCalendar = CalendarUtils.createFromMillis(sunsetTime);
+      lastModifiedDate = CalendarUtils.createFromMillis(lastModifiedTime);
+    }
+  }
+
+  private static void storeNightTimeIntoSharedPreferences(Context context) {
+    TextSecurePreferences.setSunriseTime(context, sunriseCalendar.getTimeInMillis());
+    TextSecurePreferences.setSunsetTime(context, sunsetCalendar.getTimeInMillis());
+    TextSecurePreferences.setSunsetLastModifiedTime(context, lastModifiedDate.getTimeInMillis());
+  }
+
+  private static void calculateNightTime(Context context) {
+    Location location = getLastKnownLocation(context);
+
+    if (location != null) {
+      setNightTimeBasedOnLocation(location);
+    } else {
+      setDefaultNightTime();
+    }
+      lastModifiedDate = Calendar.getInstance();
+  }
+
+  private static void setDefaultNightTime() {
+    Calendar todayCalendar = Calendar.getInstance();
+    int currentYear = todayCalendar.get(Calendar.YEAR);
+    int currentMonth = todayCalendar.get(Calendar.MONTH);
+    int currentDay = todayCalendar.get(Calendar.DAY_OF_MONTH);
+
+    sunsetCalendar = Calendar.getInstance();
+    sunsetCalendar.set(currentYear, currentMonth, currentDay, 18, 0);
+
+    sunriseCalendar = Calendar.getInstance();
+    sunriseCalendar.set(currentYear, currentMonth, currentDay, 6, 0);
+  }
+
+  private static void setNightTimeBasedOnLocation(Location location) {
+    SunriseSunsetCalculator sunriseSunsetCalculator = new SunriseSunsetCalculator(
+            new com.luckycatlabs.sunrisesunset.dto.Location(location.getLatitude(), location.getLongitude()),
+            TimeZone.getDefault().getID());
+
+    Calendar todayCalendar = Calendar.getInstance();
+    sunsetCalendar = sunriseSunsetCalculator.getOfficialSunsetCalendarForDate(todayCalendar);
+    sunriseCalendar = sunriseSunsetCalculator.getOfficialSunriseCalendarForDate(todayCalendar);
+  }
+
+  private static Location getLastKnownLocation(Context context) {
+    LocationManager locationManager = (LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+    return locationManager.getLastKnownLocation(LocationManager.PASSIVE_PROVIDER);
+  }
+}


### PR DESCRIPTION
// FREEBIE

### First time contributor checklist
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5, Android 7.1.2 
 * Virtual device Pixel, Android 7.0
 * Virtual device Pixel XL, Android O 
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This pull request adds the option to enable dark theme based on time of day (dark theme gets enabled at night).
I have tested it by reinstalling the app and enabling auto dark theme, coming back to the app at night and seeing its behavior, changing the location of the device and seeing it change.
