### PR TITLE
Add support for Unicode variation selectors

### DIFF
--- a/src/org/thoughtcrime/securesms/components/emoji/parsing/EmojiParser.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/parsing/EmojiParser.java
@@ -56,6 +56,10 @@ public class EmojiParser {
           if (Fitzpatrick.fitzpatrickFromUnicode(text, emojiEnd) != null) {
             emojiEnd += 2;
           }
+
+          if (VariationSelectors.match(text.charAt(emojiEnd))) {
+            emojiEnd += 1;
+          }
         }
 
         results.add(new Candidate(i, emojiEnd, drawInfo));

--- a/src/org/thoughtcrime/securesms/components/emoji/parsing/EmojiTree.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/parsing/EmojiTree.java
@@ -56,6 +56,8 @@ public class EmojiTree {
     for (int i=startPosition; i<endPosition; i++) {
       char character = sequence.charAt(i);
 
+      if (VariationSelectors.match(character)) continue;
+
       if (!tree.hasChild(character)) {
         return Matches.IMPOSSIBLE;
       }
@@ -71,6 +73,8 @@ public class EmojiTree {
 
     for (int i=startPosition; i<endPostiion; i++) {
       char character = unicode.charAt(i);
+
+      if (VariationSelectors.match(character)) continue;
 
       if (!tree.hasChild(character)) {
         return null;

--- a/src/org/thoughtcrime/securesms/components/emoji/parsing/VariationSelectors.java
+++ b/src/org/thoughtcrime/securesms/components/emoji/parsing/VariationSelectors.java
@@ -1,0 +1,10 @@
+package org.thoughtcrime.securesms.components.emoji.parsing;
+
+class VariationSelectors {
+  private static final int VS_LOWER_BOUND = 0xFE00;
+  private static final int VS_UPPER_BOUND = 0xFE0F;
+
+  public static boolean match(char c) {
+   return (VS_LOWER_BOUND <= c && c <= VS_UPPER_BOUND);
+  }
+}


### PR DESCRIPTION
// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * AVD, Android 7.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes #6758