### PR TITLE
Fix group title after group creation through group info request

### DIFF
--- a/src/org/thoughtcrime/securesms/database/GroupDatabase.java
+++ b/src/org/thoughtcrime/securesms/database/GroupDatabase.java
@@ -136,6 +136,7 @@ public class GroupDatabase extends Database {
     contentValues.put(ACTIVE, 1);
 
     databaseHelper.getWritableDatabase().insert(TABLE_NAME, null, contentValues);
+    RecipientFactory.clearCache(context);
     notifyConversationListListeners();
   }
 


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
Groups that are created through a group info request after a new installation are shown as "Unnamed group" . After the group information is received, the displayed title is still not updated until you restart Signal. This is because the title is already cached in the `RecipientFactory`.
This simple one line PR fixes the issue by clearing the cache the same way it is already done for group updates.

### Steps to reproduce
- create a group
- reinstall Signal
- receive a message in that group
- group shows up as "Unnamed group"
- answer to group info request is received: "Group name is now 'some name'"

**Actual result:** Group name is still "Unnamed group" until after you restart Signal
**Expected result:** Group name should change to "some name" immediately




// FREEBIE