### PR TITLE
Fix ConversationAdapterTest#testGetItemIdEquals()

### DIFF
--- a/test/unitTest/java/org/thoughtcrime/securesms/ConversationAdapterTest.java
+++ b/test/unitTest/java/org/thoughtcrime/securesms/ConversationAdapterTest.java
@@ -25,12 +25,12 @@ public class ConversationAdapterTest extends BaseUnitTest {
 
   @Test
   public void testGetItemIdEquals() throws Exception {
-    when(cursor.getString(anyInt())).thenReturn("SMS::1::1");
+    when(cursor.getString(anyInt())).thenReturn(null).thenReturn("SMS::1::1");
     long firstId = adapter.getItemId(cursor);
-    when(cursor.getString(anyInt())).thenReturn("MMS::1::1");
+    when(cursor.getString(anyInt())).thenReturn(null).thenReturn("MMS::1::1");
     long secondId = adapter.getItemId(cursor);
     assertNotEquals(firstId, secondId);
-    when(cursor.getString(anyInt())).thenReturn("MMS::2::1");
+    when(cursor.getString(anyInt())).thenReturn(null).thenReturn("MMS::2::1");
     long thirdId = adapter.getItemId(cursor);
     assertNotEquals(secondId, thirdId);
   }


### PR DESCRIPTION
Regression introduced at cb670d67

Fixes #6652

// FREEBIE

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit
