### PR TITLE
Remove race condition that prevents incoming calls from ringing

### DIFF
--- a/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
+++ b/src/org/thoughtcrime/securesms/components/webrtc/WebRtcCallControls.java
@@ -146,11 +146,6 @@ public class WebRtcCallControls extends LinearLayout {
       videoMuteButton.setAlpha(0.3f);
       audioMuteButton.setAlpha(0.3f);
 
-      speakerButton.setChecked(false);
-      bluetoothButton.setChecked(false);
-      videoMuteButton.setChecked(false);
-      audioMuteButton.setChecked(false);
-
       speakerButton.setEnabled(false);
       bluetoothButton.setEnabled(false);
       videoMuteButton.setEnabled(false);


### PR DESCRIPTION
…hone and ringtone playing through speakerphone, fixes #6356, #6406

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Moto E, Android 5.1
 * Moto G4, Android 7.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

There is a race condition between IncomingRinger turning the speakerphone on to play the ringtone and WebRtcCallActivity, which disables and unchecks the "speakerphone" button on the call screen during an incoming call. If your phone can create and display the dialog quickly enough for it to needlessly turn the speakerphone off before IncomingRinger turns the speakerphone on, you get a ringtone. If it takes your phone too long to wake up, create the lockscreen, and then bring up the dialog, then no ringtone (or a very brief ringtone) for you.

This patch removes the "unchecking" of the control buttons for speakerphone, bluetooth, videomute, and audiomute when there's an incoming call. They're still disabled, but they're left in the default states so no extra events get thrown to the listeners.

Sorry for the duplicate PR,  I hadn't authorized the CLA to sync to my github account on the first PR