### PR TITLE
Fix crash when no transport options are available

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1469,7 +1469,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void setBlockedUserState(Recipients recipients, boolean isSecureText, boolean isDefaultSms) {
-    if (recipients.isBlocked()) {
+    if (!sendButton.hasEnabledTransports()) {
+      unblockButton.setVisibility(View.GONE);
+      composePanel.setVisibility(View.GONE);
+      makeDefaultSmsButton.setVisibility(View.GONE);
+    } else if (recipients.isBlocked()) {
       unblockButton.setVisibility(View.VISIBLE);
       composePanel.setVisibility(View.GONE);
       makeDefaultSmsButton.setVisibility(View.GONE);
@@ -1485,6 +1489,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   }
 
   private void calculateCharactersRemaining() {
+    if (!sendButton.hasEnabledTransports()) {
+      charactersLeft.setVisibility(View.GONE);
+      return;
+    }
+
     String          messageBody     = composeText.getTextTrimmed();
     TransportOption transportOption = sendButton.getSelectedTransport();
     CharacterState  characterState  = transportOption.calculateCharacters(messageBody);

--- a/src/org/thoughtcrime/securesms/TransportOptions.java
+++ b/src/org/thoughtcrime/securesms/TransportOptions.java
@@ -76,6 +76,10 @@ public class TransportOptions {
     return this.selectedOption.isPresent();
   }
 
+  public boolean hasEnabledTransports() {
+    return !enabledTransports.isEmpty();
+  }
+
   public @NonNull TransportOption getSelectedTransport() {
     if (selectedOption.isPresent()) return selectedOption.get();
 

--- a/src/org/thoughtcrime/securesms/components/SendButton.java
+++ b/src/org/thoughtcrime/securesms/components/SendButton.java
@@ -67,6 +67,10 @@ public class SendButton extends ImageButton
     transportOptions.addOnTransportChangedListener(listener);
   }
 
+  public boolean hasEnabledTransports() {
+    return transportOptions.hasEnabledTransports();
+  }
+
   public TransportOption getSelectedTransport() {
     return transportOptions.getSelectedTransport();
   }
@@ -80,11 +84,11 @@ public class SendButton extends ImageButton
   }
 
   public void setDefaultTransport(TransportOption.Type type) {
-    transportOptions.setDefaultTransport(type);
+    if (transportOptions.hasEnabledTransports()) transportOptions.setDefaultTransport(type);
   }
 
   public void setDefaultSubscriptionId(Optional<Integer> subscriptionId) {
-    transportOptions.setDefaultSubscriptionId(subscriptionId);
+    if (transportOptions.hasEnabledTransports()) transportOptions.setDefaultSubscriptionId(subscriptionId);
   }
 
   @Override


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

There are no transport options available when opening a Signal group while being unregistered, which then triggers an assertion, see #6419.
There are still ways to trigger this bug that are not handled by this PR (i.e. when trying to add an attachment). That would be improved by merging PR #5582.
Adding an extra transport type to prevent this crash seemed to be a bit too much overhead to me.

// FREEBIE