### PR TITLE
Fix plaintext export XML escaping

### DIFF
--- a/src/org/thoughtcrime/securesms/database/XmlBackup.java
+++ b/src/org/thoughtcrime/securesms/database/XmlBackup.java
@@ -191,7 +191,7 @@ public class XmlBackup {
       stringBuilder.append(OPEN_TAG_SMS);
       appendAttribute(stringBuilder, PROTOCOL, item.getProtocol());
       appendAttribute(stringBuilder, ADDRESS, escapeXML(item.getAddress()));
-      appendAttribute(stringBuilder, CONTACT_NAME, item.getContactName());
+      appendAttribute(stringBuilder, CONTACT_NAME, escapeXML(item.getContactName()));
       appendAttribute(stringBuilder, DATE, item.getDate());
       appendAttribute(stringBuilder, READABLE_DATE, item.getReadableDate());
       appendAttribute(stringBuilder, TYPE, item.getType());


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 5 API 23, Android 6.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Fixes the **reason** for #6830 by escaping the contact name too.
I was able to reproduce the error message by using a `&` inside the contact name.
`<` and `>` leads to other errors but also the XmlPullParserException. 

Tested several export and imports successfully.
