### PR TITLE
add search for finding newest matching message in a conversation

### DIFF
--- a/res/menu/conversation_search.xml
+++ b/res/menu/conversation_search.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item android:id="@+id/action_search_message"
+        android:title="@string/conversation_fragment__action_search_message"
+        app:actionViewClass="android.support.v7.widget.SearchView"
+        app:showAsAction="always"/>
+
+</menu>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -840,6 +840,10 @@
 
     <!-- conversation_fragment -->
     <string name="conversation_fragment__scroll_to_the_bottom_content_description">Scroll to the bottom</string>
+    <string name="conversation_fragment__action_search_message">Search message</string>
+    <string name="conversation_fragment__no_matching_message_found">No matching message found.</string>
+    <string name="conversation_fragment__no_matching_message_found_so_far">No matching message found so far.</string>
+    <string name="conversation_fragment__searching">Searching …</string>
 
     <!-- country_selection_fragment -->
     <string name="country_selection_fragment__loading_countries">Loading countries...</string>

--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -42,6 +42,7 @@ import android.support.annotation.Nullable;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v4.view.WindowCompat;
 import android.support.v7.app.AlertDialog;
+import android.support.v7.widget.SearchView;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.text.TextWatcher;
@@ -184,7 +185,8 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
                OnKeyboardShownListener,
                AttachmentDrawerListener,
                InputPanel.Listener,
-               InputPanel.MediaListener
+               InputPanel.MediaListener,
+               SearchView.OnQueryTextListener
 {
   private static final String TAG = ConversationActivity.class.getSimpleName();
 
@@ -459,6 +461,11 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
   public boolean onPrepareOptionsMenu(Menu menu) {
     MenuInflater inflater = this.getMenuInflater();
     menu.clear();
+
+    inflater.inflate(R.menu.conversation_search, menu);
+    final MenuItem searchItem = menu.findItem(R.id.action_search_message);
+    final SearchView searchView = (SearchView) MenuItemCompat.getActionView(searchItem);
+    searchView.setOnQueryTextListener(this);
 
     if (isSecureText) {
       if (recipient.getExpireMessages() > 0) {
@@ -1872,6 +1879,17 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     } else if (MediaUtil.isAudioType(contentType)) {
       setMedia(uri, MediaType.AUDIO);
     }
+  }
+
+  @Override
+  public boolean onQueryTextSubmit(String query) {
+    fragment.find(query);
+    return true;
+  }
+
+  @Override
+  public boolean onQueryTextChange(String newText) {
+    return false;
   }
 
 

--- a/src/org/thoughtcrime/securesms/ConversationAdapter.java
+++ b/src/org/thoughtcrime/securesms/ConversationAdapter.java
@@ -403,6 +403,24 @@ public class ConversationAdapter <V extends View & BindableConversationItem>
     viewHolder.setText(getContext().getResources().getQuantityString(R.plurals.ConversationAdapter_n_unread_messages, (position + 1), (position + 1)));
   }
 
+  int findMatchingItem(Cursor cursor, String query, int maxPosition) {
+    query = query.trim().toLowerCase();
+    if (!query.isEmpty()) {
+      if (cursor != null && cursor.moveToFirst()) {
+        while(cursor.moveToNext()) {
+          MessageRecord messageRecord = getRecordFromCursor(cursor);
+          if(messageRecord.getDisplayBody().toString().toLowerCase().contains(query)) {
+            return cursor.getPosition();
+          }
+          if(cursor.getPosition() >= maxPosition) {
+            return -1;
+          }
+        }
+      }
+    }
+    return -1;
+  }
+
   static class LastSeenHeader extends StickyHeaderDecoration {
 
     private final ConversationAdapter adapter;

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -500,6 +500,36 @@ public class ConversationFragment extends Fragment
     }
   }
 
+  public void find(String query) {
+    if (getListAdapter() != null) {
+      final ConversationLoader conversationLoader = new ConversationLoader(getActivity(), threadId, -1, -1);
+      final int maxLoadedPosition = list.getAdapter().getItemCount() - 1;
+
+      final Toast searchingMessage = Toast.makeText(getContext(), R.string.conversation_fragment__searching, Toast.LENGTH_LONG);
+      searchingMessage.show();
+
+      new AsyncTask<String, Void, Integer>() {
+        @Override
+        protected Integer doInBackground(String... query) {
+          return getListAdapter().findMatchingItem(conversationLoader.getCursor(), query[0], maxLoadedPosition);
+        }
+
+        @Override
+        protected void onPostExecute(Integer matchingPosition) {
+          searchingMessage.cancel();
+          if (matchingPosition >= 0) {
+            list.scrollToPosition(matchingPosition);
+          } else if (maxLoadedPosition == PARTIAL_CONVERSATION_LIMIT) {
+            list.scrollToPosition(maxLoadedPosition);
+            Toast.makeText(getContext(), R.string.conversation_fragment__no_matching_message_found_so_far, Toast.LENGTH_SHORT).show();
+          } else {
+            Toast.makeText(getContext(), R.string.conversation_fragment__no_matching_message_found, Toast.LENGTH_SHORT).show();
+          }
+        }
+      }.execute(query);
+    }
+  }
+
   public interface ConversationFragmentListener {
     void setThreadId(long threadId);
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * GT-I9300 (Galaxy SIII), LineageOS 14.1 (Android 7.1)
 * Nexus 4 Api 25 Emulator (Android 7.1.1)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

This PR addresses a part of #1232: Searching a text within a conversation. So the use case “You have sent me your address some time ago and I don’t want to scroll through the whole chat history.” is addressed, but the case “Someone has sent me that address, I don’t remember in which conversation.” is not.

Iterating through all messages is not a very fast solution, but still better than manual searching. That’s why only the loaded part of the conversation (500 messages by default) is searched, to get a fast feedback whether the information you’re looking for is in the conversation or not; if no match is found the user can decide to load the whole conversation and search again. If you don’t think that the user experience with this patch is good enough, I’m fine if you don’t want to merge this PR, but I considered this patch quite useful during the last month, so I wanted to share it.
