### PR TITLE
set default characterset to utf-8. Fixes #6374

### DIFF
--- a/src/org/thoughtcrime/securesms/mms/PartParser.java
+++ b/src/org/thoughtcrime/securesms/mms/PartParser.java
@@ -24,7 +24,7 @@ public class PartParser {
           String characterSet = CharacterSets.getMimeName(body.getPart(i).getCharset());
 
           if (characterSet.equals(CharacterSets.MIMENAME_ANY_CHARSET))
-            characterSet = CharacterSets.MIMENAME_ISO_8859_1;
+            characterSet = CharacterSets.MIMENAME_UTF_8;
 
           if (body.getPart(i).getData() != null) {
             partText = new String(body.getPart(i).getData(), characterSet);


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)
--As best I can.  The cla page just hangs on submit, every time, in every browser

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Pixel XL, Android 8.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
This corrects pull request 6892, and resolves the long running issue with Google Project Fi users not being able to view emojis in MMS messages because the character set isn't defined.  Default character set will default to UTF-8.  I tested SMS and MMS messages with emojis on a Google Pixel XL device, on Project Fi.  I also tested existing secure messages were not impacted.  Credit to @FeuRenard for finding the mistake in the original commit

