### PR TITLE
Use better backup location

### DIFF
--- a/src/org/thoughtcrime/securesms/ImportExportFragment.java
+++ b/src/org/thoughtcrime/securesms/ImportExportFragment.java
@@ -21,14 +21,16 @@ import org.thoughtcrime.securesms.database.PlaintextBackupExporter;
 import org.thoughtcrime.securesms.database.PlaintextBackupImporter;
 import org.thoughtcrime.securesms.service.ApplicationMigrationService;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 
 
 public class ImportExportFragment extends Fragment {
 
-  private static final int SUCCESS    = 0;
-  private static final int NO_SD_CARD = 1;
-  private static final int ERROR_IO   = 2;
+  private static final int SUCCESS        = 0;
+  private static final int NO_SD_CARD     = 1;
+  private static final int ERROR_IO       = 2;
+  private static final int FILE_NOT_FOUND = 3;
 
   private MasterSecret   masterSecret;
   private ProgressDialog progressDialog;
@@ -155,6 +157,7 @@ public class ImportExportFragment extends Fragment {
 
       switch (result) {
         case NO_SD_CARD:
+        case FILE_NOT_FOUND:
           Toast.makeText(context,
                          context.getString(R.string.ImportFragment_no_plaintext_backup_found),
                          Toast.LENGTH_LONG).show();
@@ -180,6 +183,9 @@ public class ImportExportFragment extends Fragment {
       } catch (NoExternalStorageException e) {
         Log.w("ImportFragment", e);
         return NO_SD_CARD;
+      } catch (FileNotFoundException e) {
+        Log.w("ImportFragment", e);
+        return FILE_NOT_FOUND;
       } catch (IOException e) {
         Log.w("ImportFragment", e);
         return ERROR_IO;

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -10,11 +10,13 @@ import org.thoughtcrime.securesms.util.StorageUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
 
 public class PlaintextBackupExporter {
   private static final String TAG = PlaintextBackupExporter.class.getSimpleName();
-
-  private static final String FILENAME = "SignalPlaintextBackup.xml";
 
   public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
@@ -22,21 +24,26 @@ public class PlaintextBackupExporter {
     exportPlaintext(context, masterSecret);
   }
 
-  public static File getPlaintextExportFile() throws NoExternalStorageException {
-    return new File(StorageUtil.getBackupDir(), FILENAME);
+  private static File getTimestampedPlaintextExportFile() throws NoExternalStorageException {
+    DateFormat iso8601DateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    iso8601DateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+    Date   timestamp = new Date(System.currentTimeMillis());
+    String filename  = "SignalPlaintextBackup-" + iso8601DateFormatter.format(timestamp) + ".xml";
+    return new File(StorageUtil.getBackupDir(), filename);
   }
 
   private static void exportPlaintext(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
     int  count      = DatabaseFactory.getSmsDatabase(context).getMessageCount();
-    File exportFile = getPlaintextExportFile();
+    File exportFile = getTimestampedPlaintextExportFile();
     File exportDir  = exportFile.getParentFile();
     if (!exportDir.exists()) {
       if (!exportDir.mkdirs()) {
         Log.w(TAG, "mkdirs() returned false, attempting to continue exporting");
       }
     }
+    Log.w(TAG, "Exporting to " + exportFile.getAbsolutePath());
     XmlBackup.Writer writer = new XmlBackup.Writer(exportFile.getAbsolutePath(), count);
 
 

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -18,10 +18,10 @@ import java.util.TimeZone;
 public class PlaintextBackupExporter {
   private static final String TAG = PlaintextBackupExporter.class.getSimpleName();
 
-  public static void exportPlaintextToSd(Context context, MasterSecret masterSecret)
+  public static File exportPlaintextToSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
-    exportPlaintext(context, masterSecret);
+    return exportPlaintext(context, masterSecret);
   }
 
   private static File getTimestampedPlaintextExportFile() throws NoExternalStorageException {
@@ -32,7 +32,7 @@ public class PlaintextBackupExporter {
     return new File(StorageUtil.getBackupDir(), filename);
   }
 
-  private static void exportPlaintext(Context context, MasterSecret masterSecret)
+  private static File exportPlaintext(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
     int  count      = DatabaseFactory.getSmsDatabase(context).getMessageCount();
@@ -74,5 +74,6 @@ public class PlaintextBackupExporter {
     } while (reader.getCount() > 0);
 
     writer.close();
+    return exportFile;
   }
 }

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupExporter.java
@@ -2,6 +2,7 @@ package org.thoughtcrime.securesms.database;
 
 
 import android.content.Context;
+import android.util.Log;
 
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.database.model.SmsMessageRecord;
@@ -11,6 +12,7 @@ import java.io.File;
 import java.io.IOException;
 
 public class PlaintextBackupExporter {
+  private static final String TAG = PlaintextBackupExporter.class.getSimpleName();
 
   private static final String FILENAME = "SignalPlaintextBackup.xml";
 
@@ -27,8 +29,15 @@ public class PlaintextBackupExporter {
   private static void exportPlaintext(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
-    int count               = DatabaseFactory.getSmsDatabase(context).getMessageCount();
-    XmlBackup.Writer writer = new XmlBackup.Writer(getPlaintextExportFile().getAbsolutePath(), count);
+    int  count      = DatabaseFactory.getSmsDatabase(context).getMessageCount();
+    File exportFile = getPlaintextExportFile();
+    File exportDir  = exportFile.getParentFile();
+    if (!exportDir.exists()) {
+      if (!exportDir.mkdirs()) {
+        Log.w(TAG, "mkdirs() returned false, attempting to continue exporting");
+      }
+    }
+    XmlBackup.Writer writer = new XmlBackup.Writer(exportFile.getAbsolutePath(), count);
 
 
     SmsMessageRecord record;

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -17,11 +17,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class PlaintextBackupImporter {
+  private static final String TAG = PlaintextBackupImporter.class.getSimpleName();
 
   public static void importPlaintextFromSd(Context context, MasterSecret masterSecret)
       throws NoExternalStorageException, IOException
   {
-    Log.w("PlaintextBackupImporter", "importPlaintext()");
+    Log.w(TAG, "importPlaintext()");
     SmsDatabase    db          = DatabaseFactory.getSmsDatabase(context);
     SQLiteDatabase transaction = db.beginTransaction();
 
@@ -64,9 +65,9 @@ public class PlaintextBackupImporter {
         threads.update(threadId, true);
       }
 
-      Log.w("PlaintextBackupImporter", "Exited loop");
+      Log.w(TAG, "Exited loop");
     } catch (XmlPullParserException e) {
-      Log.w("PlaintextBackupImporter", e);
+      Log.w(TAG, e);
       throw new IOException("XML Parsing error!");
     } finally {
       db.endTransaction(transaction);

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -80,7 +80,7 @@ public class PlaintextBackupImporter {
     }
   }
 
-  private static File getPlaintextBackupFile() throws NoExternalStorageException, FileNotFoundException {
+  public static File getPlaintextBackupFile() throws NoExternalStorageException, FileNotFoundException {
     File[] backupFiles = StorageUtil.getBackupDir().listFiles(new FilenameFilter() {
       @Override
       public boolean accept(File dir, String filename) {

--- a/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
+++ b/src/org/thoughtcrime/securesms/database/PlaintextBackupImporter.java
@@ -9,11 +9,14 @@ import android.util.Log;
 import org.thoughtcrime.securesms.crypto.MasterCipher;
 import org.thoughtcrime.securesms.crypto.MasterSecret;
 import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.util.StorageUtil;
 import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -29,7 +32,7 @@ public class PlaintextBackupImporter {
 
     try {
       ThreadDatabase threads         = DatabaseFactory.getThreadDatabase(context);
-      String         filePath        = getPlaintextExportFile().getAbsolutePath();
+      String         filePath        = getPlaintextBackupFile().getAbsolutePath();
       Log.d(TAG, "Importing from " + filePath);
       XmlBackup      backup          = new XmlBackup(filePath);
       MasterCipher   masterCipher    = new MasterCipher(masterSecret);
@@ -77,10 +80,16 @@ public class PlaintextBackupImporter {
     }
   }
 
-  private static File getPlaintextExportFile() throws NoExternalStorageException, FileNotFoundException {
-    File backupFile = PlaintextBackupExporter.getPlaintextExportFile();
-    if (backupFile.exists()) {
-      return backupFile;
+  private static File getPlaintextBackupFile() throws NoExternalStorageException, FileNotFoundException {
+    File[] backupFiles = StorageUtil.getBackupDir().listFiles(new FilenameFilter() {
+      @Override
+      public boolean accept(File dir, String filename) {
+        return filename.startsWith("SignalPlaintextBackup-") && filename.endsWith(".xml");
+      }
+    });
+    if (backupFiles.length >= 1) {
+      Arrays.sort(backupFiles);
+      return backupFiles[backupFiles.length - 1];
     }
 
     File[] historicalBackupFiles = {

--- a/src/org/thoughtcrime/securesms/util/StorageUtil.java
+++ b/src/org/thoughtcrime/securesms/util/StorageUtil.java
@@ -8,6 +8,8 @@ import java.io.File;
 
 public class StorageUtil
 {
+  private static final String BACKUP_SUBDIRECTORY = "Signal";
+
   private static File getSignalStorageDir() throws NoExternalStorageException {
     final File storage = Environment.getExternalStorageDirectory();
 
@@ -31,22 +33,26 @@ public class StorageUtil
   }
 
   public static File getBackupDir() throws NoExternalStorageException {
-    return getSignalStorageDir();
+    return new File(getSignalStorageDir(), BACKUP_SUBDIRECTORY);
   }
 
   public static File getVideoDir() throws NoExternalStorageException {
-    return new File(getSignalStorageDir(), Environment.DIRECTORY_MOVIES);
+    File rootVideoDir = new File(getSignalStorageDir(), Environment.DIRECTORY_MOVIES);
+    return new File(rootVideoDir, BACKUP_SUBDIRECTORY);
   }
 
   public static File getAudioDir() throws NoExternalStorageException {
-    return new File(getSignalStorageDir(), Environment.DIRECTORY_MUSIC);
+    File rootAudioDir = new File(getSignalStorageDir(), Environment.DIRECTORY_MUSIC);
+    return new File(rootAudioDir, BACKUP_SUBDIRECTORY);
   }
 
   public static File getImageDir() throws NoExternalStorageException {
-    return new File(getSignalStorageDir(), Environment.DIRECTORY_PICTURES);
+    File rootImageDir = new File(getSignalStorageDir(), Environment.DIRECTORY_PICTURES);
+    return new File(rootImageDir, BACKUP_SUBDIRECTORY);
   }
 
   public static File getDownloadDir() throws NoExternalStorageException {
-    return new File(getSignalStorageDir(), Environment.DIRECTORY_DOWNLOADS);
+    File rootDownloadDir = new File(getSignalStorageDir(), Environment.DIRECTORY_DOWNLOADS);
+    return new File(rootDownloadDir, BACKUP_SUBDIRECTORY);
   }
 }

--- a/test/androidTest/java/org/thoughtcrime/securesms/database/PlaintextBackupRoundTripTest.java
+++ b/test/androidTest/java/org/thoughtcrime/securesms/database/PlaintextBackupRoundTripTest.java
@@ -1,0 +1,170 @@
+package org.thoughtcrime.securesms.database;
+
+import android.content.Context;
+import android.text.TextUtils;
+import android.util.Log;
+
+import org.thoughtcrime.securesms.ApplicationContext;
+import org.thoughtcrime.securesms.TextSecureTestCase;
+import org.thoughtcrime.securesms.crypto.InvalidPassphraseException;
+import org.thoughtcrime.securesms.crypto.MasterSecret;
+import org.thoughtcrime.securesms.crypto.MasterSecretUtil;
+import org.thoughtcrime.securesms.recipients.Recipient;
+import org.thoughtcrime.securesms.sms.OutgoingTextMessage;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test that messages correctly make it through an export/import cycle.
+ * Should be run on a device with no existing backups and no messages to UNKNOWN,
+ * but where Signal has been opened at least once to initialize the master secret.
+ *
+ * @author Aneesh Agrawal
+ */
+public class PlaintextBackupRoundTripTest extends TextSecureTestCase {
+  private static final String TAG = PlaintextBackupRoundTripTest.class.getSimpleName();
+
+  private Context context;
+  private Recipient recipient;
+  private SmsDatabase smsDatabase;
+  private long threadId;
+  private MasterSecret masterSecret;
+
+  private final List<File> exportedFiles = new ArrayList<>();
+  private final Set<Long> insertedMessageIds = new HashSet<>();
+
+  private void ensureContextIsInitialized() {
+    ((ApplicationContext)context.getApplicationContext()).onCreate();
+  }
+
+  private List<String> performSafetyChecksToAvoidAnyDataLoss() {
+    final List<String> messages = new ArrayList<>();
+
+    try {
+      PlaintextBackupImporter.getPlaintextBackupFile();
+      messages.add("Existing backup(s) found.");
+    } catch (FileNotFoundException e) {
+    } catch (NoExternalStorageException e) {
+      messages.add("External storage is unavailable.");
+    }
+
+    threadId = DatabaseFactory.getThreadDatabase(context).getThreadIdFor(recipient);
+    int numExistingMessages = smsDatabase.getMessageCountForThread(threadId);
+    if (numExistingMessages != 0) {
+      final String address = recipient.getAddress().toString();
+      messages.add(numExistingMessages + " existing messages found to " + address + ".");
+    }
+
+    try {
+      masterSecret = MasterSecretUtil.getMasterSecret(context, MasterSecretUtil.UNENCRYPTED_PASSPHRASE);
+    } catch (InvalidPassphraseException e) {
+      messages.add("Existing passphrase found.");
+    }
+
+    return messages;
+  }
+
+  @Override
+  public void setUp() {
+    super.setUp();
+
+    context = getInstrumentation().getTargetContext();
+    ensureContextIsInitialized();
+    recipient = mock(Recipient.class);
+    when(recipient.getAddress()).thenReturn(Address.UNKNOWN);
+    smsDatabase = DatabaseFactory.getSmsDatabase(context);
+
+    final List<String> messages = performSafetyChecksToAvoidAnyDataLoss();
+    if (!(messages.isEmpty())) {
+      String combined = TextUtils.join("\n", messages);
+      throw new RuntimeException("Aborting " + TAG + " test for safety reasons:\n" + combined);
+    }
+
+    exportedFiles.clear();
+    insertedMessageIds.clear();
+  }
+
+  @Override
+  public void tearDown() {
+    for (long messageId: insertedMessageIds) {
+      smsDatabase.deleteMessage(messageId);
+    }
+    insertedMessageIds.clear();
+
+    for (File backup: exportedFiles) {
+      Log.d(TAG, "Removing backup file " + backup.getAbsolutePath() + " exported during test.");
+      backup.delete();
+    }
+    exportedFiles.clear();
+
+    masterSecret = null;
+    threadId = -1L;
+    smsDatabase = null;
+    recipient = null;
+    context = null;
+  }
+
+  public void testPlaintextBackupRoundTripNoMessages() throws Exception {
+    do_testPlaintextBackupRoundTrip(0);
+  }
+  public void testPlaintextBackupRoundTripOneMessage() throws Exception {
+    do_testPlaintextBackupRoundTrip(1);
+  }
+  public void testPlaintextBackupRoundTripMultipleMessages() throws Exception {
+    do_testPlaintextBackupRoundTrip(10);
+  }
+
+  public void do_testPlaintextBackupRoundTrip(final int numMessages) throws Exception {
+    exportedFiles.add(PlaintextBackupExporter.exportPlaintextToSd(context, masterSecret));
+
+    for (int i = 0; i < numMessages; i++) {
+      insertedMessageIds.add(smsDatabase.insertMessageOutbox(
+        threadId,
+        new OutgoingTextMessage(recipient, "Outgoing message " + i, -1),
+        MmsSmsColumns.Types.BASE_SENDING_TYPE,
+        false,
+        System.currentTimeMillis(),
+        null
+      ));
+      exportedFiles.add(PlaintextBackupExporter.exportPlaintextToSd(context, masterSecret));
+    }
+    assertEquals(
+      "Did not insert the right number of messages.",
+      numMessages,
+      insertedMessageIds.size()
+    );
+    final Set<Long> allInsertedMessageIds = Collections.unmodifiableSet(new HashSet<>(insertedMessageIds));
+
+    for (long messageId: allInsertedMessageIds) {
+      smsDatabase.deleteMessage(messageId);
+      insertedMessageIds.remove(messageId);
+    }
+    assertEquals(
+      "Could not delete all inserted messages.",
+      0,
+      smsDatabase.getMessageCountForThread(threadId)
+    );
+    assertEquals(
+      "Could not delete all inserted messages.",
+      0,
+      insertedMessageIds.size()
+    );
+
+    PlaintextBackupImporter.importPlaintextFromSd(context, masterSecret);
+    assertEquals(
+      "Did not import all messages.",
+      numMessages,
+      smsDatabase.getMessageCountForThread(threadId)
+    );
+    insertedMessageIds.addAll(allInsertedMessageIds);
+  }
+}


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [ ] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)
I tried to sign the CLA in Firefox and Chromium, but it never completes. Looks like a configuration error on the CLA server:
```
Failed to load https://open-whisper-cla.appspot.com/cla-server/form: Response to preflight request doesn't pass access control check: The 'Access-Control-Allow-Origin' header has a value 'https://whispersystems.org' that is not equal to the supplied origin. Origin 'https://signal.org' is therefore not allowed access.
```

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Moto G4, Android 6.0.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->

Provide a better error when we can't find a plaintext backup to import - tested by manually running import with no backups present and looking at the toast.
Place backups and saved files into `Signal` subdirectories - tested by manually importing and exporting, with 0, 1, and multiple exports, as well as saving file attachments. Also added a basic round trip test for export/import functionality, and verified the existing `SaveAttachmentTestCase` continues working.

I'd like to make backups in Signal better, so I thought I would start with some open easy issues.