### PR TITLE
CreateProfileActivity uses DynamicTheme

### DIFF
--- a/src/org/thoughtcrime/securesms/CreateProfileActivity.java
+++ b/src/org/thoughtcrime/securesms/CreateProfileActivity.java
@@ -38,6 +38,7 @@ import org.thoughtcrime.securesms.profiles.ProfileMediaConstraints;
 import org.thoughtcrime.securesms.profiles.SystemProfileUtil;
 import org.thoughtcrime.securesms.util.BitmapDecodingException;
 import org.thoughtcrime.securesms.util.BitmapUtil;
+import org.thoughtcrime.securesms.util.DynamicTheme;
 import org.thoughtcrime.securesms.util.IntentUtils;
 import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
@@ -68,6 +69,8 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Inje
 
   private static final int REQUEST_CODE_AVATAR = 1;
 
+  private final DynamicTheme dynamicTheme    = new DynamicTheme();
+
   @Inject SignalServiceAccountManager accountManager;
 
   private InputAwareLayout container;
@@ -85,6 +88,8 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Inje
   public void onCreate(Bundle bundle) {
     super.onCreate(bundle);
 
+    dynamicTheme.onCreate(this);
+
     setContentView(R.layout.profile_create_activity);
 
     getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE);
@@ -96,6 +101,12 @@ public class CreateProfileActivity extends BaseActionBarActivity implements Inje
     initializeProfileAvatar(getIntent().getBooleanExtra(EXCLUDE_SYSTEM, false));
 
     ApplicationContext.getInstance(this).injectDependencies(this);
+  }
+
+  @Override
+  public void onResume() {
+    super.onResume();
+    dynamicTheme.onResume(this);
   }
 
   @Override


### PR DESCRIPTION
Fixes #6981

// FREEBIE

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Motorola Moto G, Android 4.4.4
 * Motorola Droid Turbo, Android 6.0.1
 * Virtual device Nexus 5, API 25
 * Virtual device Nexus 4, API 19
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The CreateProfileActivity now uses a DynamicTheme to respect the user's light / dark theme choice. I modeled the behavior on the ApplicationPreferencesActivity behavior, but did not add a SharedPreferencesListener implementation as it was not obvious whether or where the CreateProfileActivity should subscribe to SharedPreferences changes.

Verified that after changing the theme setting, the profile info screen reflects the theme selected:
1. Tap hamburger button
2. Tap Settings
3. Tap Appearance
4. Tap Theme
5. Select Dark
6. Tap Back
7. Tap my profile name
8. Verify that the profile info screen is using the dark theme
9. Tap Back
10. Tap Appearance
11. Tap Theme
12. Tap Light
13. Tap Back
14. Tap my profile name
15. Verify that the profile info screen is using the light theme