### PR TITLE
Add back a way to access quick contact from within conversation

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationActivity.java
+++ b/src/org/thoughtcrime/securesms/ConversationActivity.java
@@ -1209,6 +1209,16 @@ public class ConversationActivity extends PassphraseRequiredActionBarActivity
     });
 
     titleView.setOnClickListener(v -> handleConversationSettings());
+    titleView.setOnLongClickListener(v -> {
+      if (recipient.getAddress().isGroup()) return false;
+
+      if (recipient.getContactUri() != null) {
+        ContactsContract.QuickContact.showQuickContact(ConversationActivity.this, titleView, recipient.getContactUri(), ContactsContract.QuickContact.MODE_LARGE, null);
+      } else {
+        handleAddToContacts();
+      }
+      return true;
+    });
     titleView.setOnBackClickedListener(view -> super.onBackPressed());
     unblockButton.setOnClickListener(v -> handleUnblock());
     makeDefaultSmsButton.setOnClickListener(v -> handleMakeDefaultSms());

--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -84,6 +84,12 @@ public class ConversationTitleView extends RelativeLayout {
     this.avatar.setOnClickListener(listener);
   }
 
+  @Override
+  public void setOnLongClickListener(@Nullable OnLongClickListener listener) {
+    this.content.setOnLongClickListener(listener);
+    this.avatar.setOnLongClickListener(listener);
+  }
+
   public void setOnBackClickedListener(@Nullable OnClickListener listener) {
     this.back.setOnClickListener(listener);
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Android 5.1.1
* AVD Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

In Signal 4.10 it was possible to open "quick contact" to directly make a regular phone call to a contact from within a conversation by tapping the avatar next to each message bubble. The avatar has been removed in Signal 4.11, so there is no such option anymore. This PR enables the exact same feature by long tapping the conversation title.

// FREEBIE
