### PR TITLE
Add a space between group member names

### DIFF
--- a/src/org/thoughtcrime/securesms/ConversationTitleView.java
+++ b/src/org/thoughtcrime/securesms/ConversationTitleView.java
@@ -106,7 +106,7 @@ public class ConversationTitleView extends RelativeLayout {
     this.subtitle.setText(Stream.of(recipient.getParticipants())
                                 .filter(r -> !r.getAddress().serialize().equals(localNumber))
                                 .map(Recipient::toShortString)
-                                .collect(Collectors.joining(",")));
+                                .collect(Collectors.joining(", ")));
 
     this.subtitle.setVisibility(View.VISIBLE);
   }


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Pixel XL, Android 8.0.0
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
Group member names are currently squished together in the conversation activity because there is no space after the comma. This commit adds a space after each comma.

Fixes #7059
// FREEBIE
