### PR TITLE
Periodically "prod" the message pipe, when GCM is disabled

### DIFF
--- a/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
+++ b/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
@@ -1,9 +1,14 @@
 package org.thoughtcrime.securesms.service;
 
 import android.app.Service;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.os.IBinder;
+import android.os.SystemClock;
 import android.support.annotation.Nullable;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -45,6 +50,8 @@ public class MessageRetrievalService extends Service implements InjectableType, 
   private NetworkRequirement         networkRequirement;
   private NetworkRequirementProvider networkRequirementProvider;
 
+  private ProdAlarmReceiver prodAlarmReceiver = null;
+
   @Inject
   public SignalServiceMessageReceiver receiver;
 
@@ -68,6 +75,7 @@ public class MessageRetrievalService extends Service implements InjectableType, 
     retrievalThread.start();
 
     setForegroundIfNecessary();
+    enableProddingIfNecessary();
   }
 
   public int onStartCommand(Intent intent, int flags, int startId) {
@@ -88,6 +96,11 @@ public class MessageRetrievalService extends Service implements InjectableType, 
       retrievalThread.stopThread();
     }
 
+    if (prodAlarmReceiver != null) {
+      prodAlarmReceiver.stop();
+      unregisterReceiver(prodAlarmReceiver);
+    }
+
     sendBroadcast(new Intent("org.thoughtcrime.securesms.RESTART"));
   }
 
@@ -101,6 +114,14 @@ public class MessageRetrievalService extends Service implements InjectableType, 
   @Override
   public IBinder onBind(Intent intent) {
     return null;
+  }
+
+  private void enableProddingIfNecessary() {
+    if (TextSecurePreferences.isGcmDisabled(this)) {
+      prodAlarmReceiver = new ProdAlarmReceiver();
+      registerReceiver(prodAlarmReceiver,
+                       new IntentFilter(ProdAlarmReceiver.WAKE_UP_THREADS_ACTION));
+    }
   }
 
   private void setForegroundIfNecessary() {
@@ -184,6 +205,72 @@ public class MessageRetrievalService extends Service implements InjectableType, 
     return pipe;
   }
 
+  public class ProdAlarmReceiver extends BroadcastReceiver {
+
+    private final int PRODDING_TIMEOUT_SECONDS = 60;
+
+    private int pipes;
+
+    public static final String WAKE_UP_THREADS_ACTION = "org.thoughtcrime.securesms.ProdAlarReceiver.WAKE_UP_THREADS";
+
+    private void setOrCancelAlarm(Context context, boolean set) {
+      Intent        intent        = new Intent(WAKE_UP_THREADS_ACTION);
+      PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, intent, 0);
+      AlarmManager  alarmManager  = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+
+      alarmManager.cancel(pendingIntent);
+
+      if (set) {
+        Log.w(TAG, "Setting repeating alarm to prod the message pipe.");
+
+        alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP,
+                                  SystemClock.elapsedRealtime() + TimeUnit.SECONDS.toMillis(PRODDING_TIMEOUT_SECONDS),
+                                  TimeUnit.SECONDS.toMillis(PRODDING_TIMEOUT_SECONDS),
+                                  pendingIntent);
+      } else {
+        Log.w(TAG, "Canceling message pipe prodding alarm.");
+      }
+    }
+
+    public synchronized void incrementPipes() {
+      if (pipes < 0) {
+        return;
+      }
+
+      pipes++;
+
+      if (pipes == 1) {
+        setOrCancelAlarm(MessageRetrievalService.this, true);
+      }
+    }
+
+    public synchronized void decrementPipes() {
+      if (pipes < 0) {
+        return;
+      }
+
+      pipes--;
+
+      assert (pipes >= 0);
+
+      if (pipes == 0) {
+        setOrCancelAlarm(MessageRetrievalService.this, false);
+      }
+    }
+
+    public synchronized void stop() {
+      pipes = -1;
+      setOrCancelAlarm(MessageRetrievalService.this, false);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+      Log.w(TAG, "Prodding the message pipe.");
+      SignalServiceMessagePipe.prod();
+    }
+
+  }
+
   private class MessageRetrievalThread extends Thread implements Thread.UncaughtExceptionHandler {
 
     private AtomicBoolean stopThread = new AtomicBoolean(false);
@@ -203,6 +290,10 @@ public class MessageRetrievalService extends Service implements InjectableType, 
         pipe = receiver.createMessagePipe();
 
         SignalServiceMessagePipe localPipe = pipe;
+
+        if (prodAlarmReceiver != null) {
+          prodAlarmReceiver.incrementPipes();
+        }
 
         try {
           while (isConnectionNecessary() && !stopThread.get()) {
@@ -230,6 +321,11 @@ public class MessageRetrievalService extends Service implements InjectableType, 
           Log.w(TAG, e);
         } finally {
           Log.w(TAG, "Shutting down pipe...");
+
+          if (prodAlarmReceiver != null) {
+            prodAlarmReceiver.decrementPipes();
+          }
+
           shutdown(localPipe);
         }
 


### PR DESCRIPTION
Added an `AlarmManager` alarm, to periodically "prod" the
`SignalServiceMessagePipe`, waking any threads that may be
stuck in blocking wait, while the device sleeping.

Fixes #6644
// FREEBIE

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Xiaomi Mi 4, Android 7.1.2 (LineageOS 14.1, w/o GCM support)
 * Motorola Moto G3, Android 7.1.2 (LineageOS 14.1, w/o GCM support)
 * Motorola Moto G (3rd gen), Android 6.0.1 (with GCM support)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

This pull request implements a fix to the problems described in #6644, using the facilities implemented in WhisperSystems/libsignal-service-java#45.  Please see the referenced pull request for a detailed description of the problem and most of the proposed solution.

As far as this pull request is concerned, a periodic alarm is set up, to "prod" and awaken the pipe, which, in the absence of GCM, will generally be trapped in blocking wait.  The period is set to 60s, because that's the smallest period allowed by `AlarmManager`.  As a result the keep-alive period on the socket's side had to be increased to match.

Note that in the proposed solution:

*) Allowance is made for the co-existence of more than one pipes, or, at least more than one `MessageRetrievalThread`s, which, as far as I could determine, can be the case.

*) Prods are only enabled in the absence of GCM.  If it is deemed, that they would be beneficial on GCM-enabled devices as well (see the relevant discussion in WhisperSystems/libsignal-service-java#45), this can trivially be accommodated, by unconditionally creating and registering the alarm receiver.

