### PR TITLE
Change read receipt icon from dark blue to green

### DIFF
--- a/res/layout/delivery_status_view.xml
+++ b/res/layout/delivery_status_view.xml
@@ -38,7 +38,7 @@
                android:paddingBottom="2dp"
                android:visibility="gone"
                android:contentDescription="@string/conversation_item_sent__message_read"
-               android:tint="@color/blue_800"
+               android:tint="#79E857"
                tools:visibility="visible"/>
 
 </merge>


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [ ] I have tested my contribution on these devices:
 * Device A, Android X.Y.Z
 * Device B, Android Z.Y
 * Virtual device W, Android Y.Y.Z
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

----------

### Description

This PR is a very simple minor change (and has therefore not been tested and may need a slight tweak for aesthetics). This fixes #7112 and should be considerably more readable/usable.