### PR TITLE
Fixes an issue that was causing the per recipient notification sound …

### DIFF
--- a/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
+++ b/src/org/thoughtcrime/securesms/RecipientPreferenceActivity.java
@@ -362,8 +362,8 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
       final Uri toneUri = recipient.getRingtone();
 
       if (toneUri == null) {
-        ringtonePreference.setSummary(R.string.preferences__default);
-        ringtonePreference.setCurrentRingtone(Uri.parse(TextSecurePreferences.getNotificationRingtone(getContext())));
+        ringtonePreference.setSummary(R.string.preferences__none);
+        ringtonePreference.setCurrentRingtone(null);
       } else if (toneUri.toString().isEmpty()) {
         ringtonePreference.setSummary(R.string.preferences__silent);
         ringtonePreference.setCurrentRingtone(null);
@@ -430,11 +430,7 @@ public class RecipientPreferenceActivity extends PassphraseRequiredActionBarActi
     private class RingtoneChangeListener implements Preference.OnPreferenceChangeListener {
       @Override
       public boolean onPreferenceChange(Preference preference, Object newValue) {
-        Uri value = (Uri)newValue;
-
-        if (Settings.System.DEFAULT_NOTIFICATION_URI.equals(value)) {
-          value = null;
-        }
+        final Uri value = (Uri)newValue;
 
         new AsyncTask<Uri, Void, Void>() {
           @Override


### PR DESCRIPTION
…to not be able to be set to "none" and "default" was functioning as none.

Fixes #7115

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Nexus 5X, Android 8.0.0
 * Virtual Device Samsung S8, Android 7.1.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
- [x] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit

FREEBIE
----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
The original error was that users were not able to set "none" for the per recipient notification sound. Upon investigation I found that the app was setting the "default" uri to null which caused issues because the default uri on devices isn't null and is valid while none corresponds to a null uri. This makes sense too because the default sound plays noise therefore must have a uri that references the sound file on the device while the none setting doesn't play any noise and so can have a null uri.
