### PR TITLE
Remove the last references to BitHub and Coinbase

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,7 +13,6 @@
  * Virtual device W, Android Y.Y.Z
 - [ ] My contribution is fully baked and ready to be merged as is
 - [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
-- [ ] I have made the choice whether I want the [BitHub reward](https://github.com/WhisperSystems/Signal-Android/wiki/BitHub-Rewards) or not by omitting or adding the word `FREEBIE` in the commit message of my first commit
 
 ----------
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,10 +66,6 @@ Please do not try to change too much at once. Big changes are less likely to be 
 ### Merging can sometimes take a while
 If your pull request follows all the advice above but still has not been merged it usually means the developers haven't simply had the time to review it yet. We understand that this might feel frustrating. We are sorry!
 
-### Bithub
-Accepted pull requests will be rewarded with Bitcoins! After your pull request has been merged you will automatically receive an email to the address you have specified as your Git commit email. Follow the instructions in the email to claim your coins. If you wish to submit your contribution for free please add the word `FREEBIE` in your Git commit message. You may wish to explore some previously merged commits to see how it all works.
-
-
 ## How can I contribute?
 Anyone can help by
 - advising new people about the guidelines of this project
@@ -83,6 +79,6 @@ Anyone can help by
 - submitting pull requests
 - testing other people's pull requests
 - spreading the joy of Signal to your friends and family
-- donating money to our [BitHub](https://www.coinbase.com/checkouts/51dac699e660a4d773216b5ad94d6a0b) or through the [Freedom of the Press Foundation's donation page](https://freedom.press/crowdfunding/signal/)
+- donating money through the [Freedom of the Press Foundation's donation page](https://freedom.press/crowdfunding/signal/)
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/WhisperSystems/Signal-Android?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)
----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This change removes the last references to BitHub and Coinbase in the `CONTRIBUTING.md` file and the pull request template. As of 258910504cc2fcc57b8868cb0ea210b21086d314, BitHub is no longer functional.