### PR TITLE
Copy messages with readable formatting.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -204,6 +204,10 @@
     <string name="ConversationFragment_sms">SMS</string>
     <string name="ConversationFragment_deleting">Deleting</string>
     <string name="ConversationFragment_deleting_messages">Deleting messages...</string>
+    <plurals name="ConversationFragment_copy_messages">
+        <item quantity="one">Message copied</item>
+        <item quantity="other">%d messages copied</item>
+    </plurals>
 
     <!-- ConversationListActivity -->
     <string name="ConversationListActivity_search">Search</string>

--- a/src/org/thoughtcrime/securesms/ConversationFragment.java
+++ b/src/org/thoughtcrime/securesms/ConversationFragment.java
@@ -67,9 +67,11 @@ import org.thoughtcrime.securesms.profiles.UnknownSenderView;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.sms.MessageSender;
 import org.thoughtcrime.securesms.sms.OutgoingTextMessage;
+import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask.Attachment;
 import org.thoughtcrime.securesms.util.StickyHeaderDecoration;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.ViewUtil;
 import org.thoughtcrime.securesms.util.task.ProgressDialogAsyncTask;
 
@@ -287,24 +289,58 @@ public class ConversationFragment extends Fragment
       }
     });
 
-    StringBuilder    bodyBuilder = new StringBuilder();
-    ClipboardManager clipboard   = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
-    boolean          first       = true;
+    StringBuilder    bodyBuilder   = new StringBuilder();
+    ClipboardManager clipboard     = (ClipboardManager) getActivity().getSystemService(Context.CLIPBOARD_SERVICE);
+    boolean          first         = true;
+    int              messageCount  = messageRecords.size();
+    String           prevSender    = "";
 
     for (MessageRecord messageRecord : messageList) {
-      String body = messageRecord.getDisplayBody().toString();
 
-      if (body != null) {
+      if( !(messageRecord.getDisplayBody().toString().isEmpty())) {
+        String body   = messageRecord.getDisplayBody().toString();
+        String sender = getSender(messageRecord);
         if (!first) bodyBuilder.append('\n');
+
+        if (messageCount > 1) {
+          if (!TextUtils.equals(prevSender, sender)) {
+            prevSender = sender;
+            if (!first) bodyBuilder.append('\n');
+            String date = DateUtils.getShortDateString(getContext(), locale, messageRecord.getDateSent());
+            bodyBuilder.append(sender + ": [" + date + "]");
+            bodyBuilder.append('\n');
+          }
+          bodyBuilder.append(DateUtils.getShortTimeString(getContext(), locale, messageRecord.getDateSent()) + "  ");
+        }
+
         bodyBuilder.append(body);
         first = false;
       }
     }
-
     String result = bodyBuilder.toString();
 
-    if (!TextUtils.isEmpty(result))
-        clipboard.setText(result);
+    if (!TextUtils.isEmpty(result)){
+      clipboard.setText(result);
+      String copyToastString = getActivity().getResources().getQuantityString(R.plurals.ConversationFragment_copy_messages, messageCount, messageCount);
+      Toast.makeText(getContext(),copyToastString, Toast.LENGTH_SHORT).show();
+    }
+  }
+
+  private String getSender(MessageRecord messageRecord){
+    String msgSender = "";
+    if (messageRecord.isOutgoing()) {
+      msgSender = TextSecurePreferences.getProfileName(getContext()).trim();
+      if (TextUtils.isEmpty(msgSender)){
+        msgSender = Address.fromSerialized(TextSecurePreferences.getLocalNumber(getContext())).toPhoneString().trim();
+      }
+    }
+    else {
+      msgSender = messageRecord.getIndividualRecipient().getProfileName().trim();
+      if (TextUtils.isEmpty(msgSender)) {
+        msgSender = messageRecord.getIndividualRecipient().getAddress().toPhoneString().trim();
+      }
+    }
+    return msgSender;
   }
 
   private void handleDeleteMessages(final Set<MessageRecord> messageRecords) {

--- a/src/org/thoughtcrime/securesms/util/DateUtils.java
+++ b/src/org/thoughtcrime/securesms/util/DateUtils.java
@@ -136,4 +136,16 @@ public class DateUtils extends android.text.format.DateUtils {
       return new SimpleDateFormat(template, locale).toLocalizedPattern();
     }
   }
+
+  public static String getShortTimeString(Context context, Locale locale, long timestamp) {
+    String template = null;
+    if (DateFormat.is24HourFormat(context)) template = "HH:mm";
+    else                                    template = "hh:mm a";
+    return getFormattedDateTime(timestamp, template, locale);
+  }
+
+  public static String getShortDateString(Context context, Locale locale, long timestamp) {
+    String template = "dd MMM yyyy";
+    return getFormattedDateTime(timestamp, template, locale);
+  }
 }


### PR DESCRIPTION
Added newline between messages in copy buffer with sender name and timestamp.

Fixes #7166

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Samsung Galaxy S2, Android 7.1.2, LineageOS 14.1
 * Redmi 3S, Android 6.0.1

- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
While copying messages the message body was attached to buffer without any readable formatting and details.
Hence added following formatting style with timestamps which insert new line between messages and separates senders with empty line.
```
John: [20 Nov 2017]
13:14 Hello!
13:15 Could you copy that?

Alex: [20 Nov 2017]
13:16 Hi!
13:16 Yep, I will try

John: [20 Nov 2017]
13:16 Thank you.
13:17 Please paste here.
```
Where time and date format used from Android's regional settings.
It uses profile name and not names that are personally chosen for recipients.
It uses senders phone number as identity when there is no profile name available.