### PR TITLE
Update the API level in the build documentation.

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -20,7 +20,7 @@ The following steps should help you (re)build Signal from the command line.
 2. Make sure you have the [Android SDK](https://developer.android.com/sdk/index.html) installed.
 3. Ensure that the following packages are installed from the Android SDK manager:
     * Android SDK Build Tools (see buildToolsVersion in build.gradle)
-    * SDK Platform (API level 22)
+    * SDK Platform (API level 25)
     * Android Support Repository
     * Google Repository
 4. Create a local.properties file at the root of your source checkout and add an sdk.dir entry to it.  For example:


### PR DESCRIPTION
### Contributor checklist
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] My contribution is fully baked and ready to be merged as is

----------

### Description
The `targetSdkVersion` variable was updated in 0f35bc6. This increases the API level in BUILDING.md accordingly.