### PR TITLE
Change background connection notification icon

### DIFF
--- a/res/drawable/ic_settings_input_antenna_black_24dp.xml
+++ b/res/drawable/ic_settings_input_antenna_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,5c-3.87,0 -7,3.13 -7,7h2c0,-2.76 2.24,-5 5,-5s5,2.24 5,5h2c0,-3.87 -3.13,-7 -7,-7zM13,14.29c0.88,-0.39 1.5,-1.26 1.5,-2.29 0,-1.38 -1.12,-2.5 -2.5,-2.5S9.5,10.62 9.5,12c0,1.02 0.62,1.9 1.5,2.29v3.3L7.59,21 9,22.41l3,-3 3,3L16.41,21 13,17.59v-3.3zM12,1C5.93,1 1,5.93 1,12h2c0,-4.97 4.03,-9 9,-9s9,4.03 9,9h2c0,-6.07 -4.93,-11 -11,-11z"/>
+</vector>

--- a/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
+++ b/src/org/thoughtcrime/securesms/service/MessageRetrievalService.java
@@ -109,7 +109,7 @@ public class MessageRetrievalService extends Service implements InjectableType, 
       builder.setContentText(getString(R.string.MessageRetrievalService_background_connection_enabled));
       builder.setPriority(NotificationCompat.PRIORITY_MIN);
       builder.setWhen(0);
-      builder.setSmallIcon(R.drawable.ic_signal_grey_24dp);
+      builder.setSmallIcon(R.drawable.ic_settings_input_antenna_black_24dp);
       startForeground(FOREGROUND_ID, builder.build());
     }
   }


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Google Pixel, Android 8.1 _without Google Play Services_
 * Virtual Google Pixel, Android 8.1 with Google Play Services (not relevant but tested to make sure it worked anyway)
 * Virtual 'Google Pixel', Android 7.0 _without Google Play Services_
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
This pull request changes the icon for the 'background connection enabled' notification to `ic_settings_input_antenna_black_24dp` so that it can be differentiated from message notifications in the status bar. Fixes #7255 (though _improves the situation_ is perhaps more accurate).

This is what the expanded notification drawer _used_ to look like (sensitive data removed):
![screenshot_20171207-232236](https://user-images.githubusercontent.com/3037552/33751300-045ed41a-dba8-11e7-8eb1-4998c09aee97.png)

Note how this results in _two_ Signal-icon notifications in the status bar when a message notification is also present:
![33751284-dc1cc318-dba7-11e7-9193-91216ddc5194](https://user-images.githubusercontent.com/3037552/33974893-101b76e0-e059-11e7-9802-3ca05f35f668.png)

This pull request changes the background connection icon to `ic_settings_input_antenna_black_24dp` (part of the Material icon set), making the message notification icon different from that of the background connection notification, so that the two can be easily differentiated:
![screenshot_1513222627](https://user-images.githubusercontent.com/3037552/33974926-3c4b86f6-e059-11e7-9c3e-57a36fbb4de7.png)

This change affects only a small number of users (i.e. users whose phones run Android without Google Play Services), and is only particularly relevant to users of Android >= 8.1 (the background connection notification does not appear in the status bar in lower versions).

This contribution comes out of a desire to fix something that has been nagging at me ever since I updated to Android 8.1, and I imagine that I'm not the only user who is bothered by the confusing background connection icon. (It looks like I _always_ have a notification.)

This is my first contribution to the Signal codebase. I'm happy to change the icon if the chosen one seems inappropriate. (I spent awhile combing through the Material icon set and this one seemed ideal, though beauty is in the eye of the beholder!)

The license of the Material icon (Apache 2.0) is compatible with GPLv3, so licensing should not be an issue.

This contribution is a freebie.

