### PR TITLE
Display the absolute time as an alternative to the relative time

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1164,6 +1164,8 @@
     <string name="preferences_chats__message_text_size">Message font size</string>
     <string name="preferences_events__contact_joined_signal">Contact joined Signal</string>
     <string name="preferences_notifications__priority">Priority</string>
+    <string name="preferences_chats__use_absolute_time">Use absolute time</string>
+    <string name="preferences_chats__use_absolute_time_instead_of_relative_one">Use absolute time in local time zone instead of relative time</string>
     
     <!-- **************************************** -->
     <!-- menus -->

--- a/res/xml/preferences_chats.xml
+++ b/res/xml/preferences_chats.xml
@@ -55,6 +55,12 @@
                 android:key="pref_enter_sends"
                 android:summary="@string/preferences__pressing_the_enter_key_will_send_text_messages"
                 android:title="@string/preferences__pref_enter_sends_title"/>
+
+        <org.thoughtcrime.securesms.components.SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:key="pref_absolute_time"
+                android:title="@string/preferences_chats__use_absolute_time"
+                android:summary="@string/preferences_chats__use_absolute_time_instead_of_relative_one" />
     </PreferenceCategory>
 
     <PreferenceCategory android:layout="@layout/preference_divider"/>

--- a/src/org/thoughtcrime/securesms/ConversationItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationItem.java
@@ -436,7 +436,12 @@ public class ConversationItem extends LinearLayout
 
     insecureImage.setVisibility(messageRecord.isSecure() ? View.GONE : View.VISIBLE);
     bodyText.setCompoundDrawablesWithIntrinsicBounds(0, 0, messageRecord.isKeyExchange() ? R.drawable.ic_menu_login : 0, 0);
-    dateText.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getTimestamp()));
+
+    if (TextSecurePreferences.isAbsoluteTimeEnabled(getContext())) {
+      dateText.setText(DateUtils.getAbsoluteTimeSpanString(locale, messageRecord.getTimestamp()));
+    } else {
+      dateText.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getTimestamp()));
+    }
 
     if (messageRecord.isFailed()) {
       setFailedStatusIcons();

--- a/src/org/thoughtcrime/securesms/ConversationListItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationListItem.java
@@ -44,6 +44,7 @@ import org.thoughtcrime.securesms.mms.GlideRequests;
 import org.thoughtcrime.securesms.recipients.Recipient;
 import org.thoughtcrime.securesms.recipients.RecipientModifiedListener;
 import org.thoughtcrime.securesms.util.DateUtils;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.ViewUtil;
 
@@ -112,6 +113,8 @@ public class ConversationListItem extends RelativeLayout
                    @NonNull GlideRequests glideRequests, @NonNull Locale locale,
                    @NonNull Set<Long> selectedThreads, boolean batchMode)
   {
+    final CharSequence date;
+
     this.selectedThreads  = selectedThreads;
     this.recipient        = thread.getRecipient();
     this.threadId         = thread.getThreadId();
@@ -127,7 +130,11 @@ public class ConversationListItem extends RelativeLayout
 //    this.subjectView.setTypeface(read ? LIGHT_TYPEFACE : BOLD_TYPEFACE);
 
     if (thread.getDate() > 0) {
-      CharSequence date = DateUtils.getBriefRelativeTimeSpanString(getContext(), locale, thread.getDate());
+      if (TextSecurePreferences.isAbsoluteTimeEnabled(getContext())) {
+        date = DateUtils.getAbsoluteTimeSpanString(locale, thread.getDate());
+      } else {
+        date = DateUtils.getBriefRelativeTimeSpanString(getContext(), locale, thread.getDate());
+      }
       dateView.setText(unreadCount == 0 ? date : color(getResources().getColor(R.color.textsecure_primary_dark), date));
       dateView.setTypeface(unreadCount == 0 ? LIGHT_TYPEFACE : BOLD_TYPEFACE);
     }

--- a/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
+++ b/src/org/thoughtcrime/securesms/ConversationUpdateItem.java
@@ -25,6 +25,7 @@ import org.thoughtcrime.securesms.recipients.RecipientModifiedListener;
 import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.GroupUtil;
 import org.thoughtcrime.securesms.util.IdentityUtil;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.util.concurrent.ListenableFuture;
 import org.whispersystems.libsignal.util.guava.Optional;
@@ -113,7 +114,11 @@ public class ConversationUpdateItem extends LinearLayout
     else                                     icon.setImageResource(R.drawable.ic_call_missed_grey600_24dp);
 
     body.setText(messageRecord.getDisplayBody());
-    date.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getDateReceived()));
+    if (TextSecurePreferences.isAbsoluteTimeEnabled(getContext())) {
+      date.setText(DateUtils.getAbsoluteTimeSpanString(locale, messageRecord.getDateReceived()));
+    } else {
+      date.setText(DateUtils.getExtendedRelativeTimeSpanString(getContext(), locale, messageRecord.getDateReceived()));
+    }
     date.setVisibility(View.VISIBLE);
   }
 

--- a/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
+++ b/src/org/thoughtcrime/securesms/MediaPreviewActivity.java
@@ -45,6 +45,7 @@ import org.thoughtcrime.securesms.util.DateUtils;
 import org.thoughtcrime.securesms.util.DynamicLanguage;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask;
 import org.thoughtcrime.securesms.util.SaveAttachmentTask.Attachment;
+import org.thoughtcrime.securesms.util.TextSecurePreferences;
 import org.thoughtcrime.securesms.util.Util;
 import org.thoughtcrime.securesms.video.VideoPlayer;
 
@@ -111,18 +112,22 @@ public class MediaPreviewActivity extends PassphraseRequiredActionBarActivity im
   }
 
   private void initializeActionBar() {
-    final CharSequence relativeTimeSpan;
+    final CharSequence timeSpan;
 
     if (date > 0) {
-      relativeTimeSpan = DateUtils.getExtendedRelativeTimeSpanString(this,dynamicLanguage.getCurrentLocale(),date);
+      if (TextSecurePreferences.isAbsoluteTimeEnabled(this)) {
+        timeSpan = DateUtils.getAbsoluteTimeSpanString(dynamicLanguage.getCurrentLocale(), date);
+      } else {
+        timeSpan = DateUtils.getExtendedRelativeTimeSpanString(this, dynamicLanguage.getCurrentLocale(), date);
+      }
     } else {
-      relativeTimeSpan = getString(R.string.MediaPreviewActivity_draft);
+      timeSpan = getString(R.string.MediaPreviewActivity_draft);
     }
 
     if (outgoing) getSupportActionBar().setTitle(getString(R.string.MediaPreviewActivity_you));
     else          getSupportActionBar().setTitle(recipient.toShortString());
 
-    getSupportActionBar().setSubtitle(relativeTimeSpan);
+    getSupportActionBar().setSubtitle(timeSpan);
   }
 
   @Override

--- a/src/org/thoughtcrime/securesms/util/DateUtils.java
+++ b/src/org/thoughtcrime/securesms/util/DateUtils.java
@@ -51,6 +51,10 @@ public class DateUtils extends android.text.format.DateUtils {
     return new SimpleDateFormat(localizedPattern, locale).format(new Date(time));
   }
 
+  public static String getAbsoluteTimeSpanString(final Locale locale, final long timestamp) {
+    return new SimpleDateFormat("yyyy-MM-dd HH:mm:ss", locale).format(new Date(timestamp));
+  }
+
   public static String getBriefRelativeTimeSpanString(final Context c, final Locale locale, final long timestamp) {
     if (isWithin(timestamp, 1, TimeUnit.MINUTES)) {
       return c.getString(R.string.DateUtils_just_now);

--- a/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
+++ b/src/org/thoughtcrime/securesms/util/TextSecurePreferences.java
@@ -107,6 +107,7 @@ public class TextSecurePreferences {
   public  static final String MEDIA_DOWNLOAD_ROAMING_PREF      = "pref_media_download_roaming";
 
   public  static final String SYSTEM_EMOJI_PREF                = "pref_system_emoji";
+  public  static final String ABSOLUTE_TIME_PREF               = "pref_absolute_time";
   private static final String MULTI_DEVICE_PROVISIONED_PREF    = "pref_multi_device";
   public  static final String DIRECT_CAPTURE_CAMERA_ID         = "pref_direct_capture_camera_id";
   private static final String ALWAYS_RELAY_CALLS_PREF          = "pref_turn_only";
@@ -682,6 +683,10 @@ public class TextSecurePreferences {
 
   public static boolean isSystemEmojiPreferred(Context context) {
     return getBooleanPreference(context, SYSTEM_EMOJI_PREF, false);
+  }
+
+  public static boolean isAbsoluteTimeEnabled(Context context) {
+    return getBooleanPreference(context, ABSOLUTE_TIME_PREF, false);
   }
 
   public static @NonNull Set<String> getMobileMediaDownloadAllowed(Context context) {


### PR DESCRIPTION
<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * OnePlus 3T, Android 8.0.0
 * Virtual device, Nexus One API 26
 * Virtual device, Nexus One API 27
- [x] My contribution is fully baked and ready to be merged as is
- [ ] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
Describe briefly what your pull request proposes to fix. Especially if you have more than one commit, it is helpful to give a summary of what your contribution as a whole is trying to solve.
Also, please describe shortly how you tested that your fix actually works.
-->
This patch introduces the option to switch from relative time to absolute
time in Conversation{Item,ListItem,UpdateItem} and MediaPreviewActivity.

The configuration option is available in Settings / Chat and media / Chats.
Default setting is false (the relative time). By changing to true, the relative
time will be switched to the absolute time.

This Pull Request is extending parts of the code where relative time is being
called by get{Brief,Extended}RelativeTimeSpanString.

First, the check against the preferences is executed.
TextSecurePreferences.isAbsoluteTimeEnabled(getContext())

If absolute time is enabled, getAbsoluteTimeSpanString (instead of
get{Brief,Extended}RelativeTimeSpanString) is called.

getAbsoluteTimeSpanString is defined in DateUtils and formats date to
"yyyy-MM-dd HH:mm:ss".