### PR TITLE
Fixes #7293. Custom ringtones are now resolved for calls from system …

### DIFF
--- a/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
+++ b/src/org/thoughtcrime/securesms/service/WebRtcCallService.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.media.AudioManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -67,6 +68,7 @@ import org.webrtc.SurfaceViewRenderer;
 import org.webrtc.VideoRenderer;
 import org.webrtc.VideoTrack;
 import org.whispersystems.libsignal.IdentityKey;
+import org.whispersystems.libsignal.util.guava.Optional;
 import org.whispersystems.signalservice.api.SignalServiceAccountManager;
 import org.whispersystems.signalservice.api.SignalServiceMessageSender;
 import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException;
@@ -539,8 +541,10 @@ public class WebRtcCallService extends Service implements InjectableType, PeerCo
 
       sendMessage(WebRtcViewModel.State.CALL_INCOMING, recipient, localVideoEnabled, remoteVideoEnabled, bluetoothAvailable, microphoneEnabled);
       startCallCardActivity();
+
+      Optional<Uri> ringtone = recipient.ringtoneForIncomingCall(getContentResolver());
       audioManager.initializeAudioForCall();
-      audioManager.startIncomingRinger();
+      audioManager.startIncomingRinger(ringtone);
 
       registerPowerButtonReceiver();
 

--- a/src/org/thoughtcrime/securesms/webrtc/audio/SignalAudioManager.java
+++ b/src/org/thoughtcrime/securesms/webrtc/audio/SignalAudioManager.java
@@ -4,11 +4,13 @@ package org.thoughtcrime.securesms.webrtc.audio;
 import android.content.Context;
 import android.media.AudioManager;
 import android.media.SoundPool;
+import android.net.Uri;
 import android.os.Build;
 import android.support.annotation.NonNull;
 
 import org.thoughtcrime.securesms.R;
 import org.thoughtcrime.securesms.util.ServiceUtil;
+import org.whispersystems.libsignal.util.guava.Optional;
 
 public class SignalAudioManager {
 
@@ -42,7 +44,7 @@ public class SignalAudioManager {
     }
   }
 
-  public void startIncomingRinger() {
+  public void startIncomingRinger(@NonNull Optional<Uri> ringtone) {
     AudioManager audioManager = ServiceUtil.getAudioManager(context);
     boolean      speaker      = !audioManager.isWiredHeadsetOn() && !audioManager.isBluetoothScoOn();
 
@@ -50,7 +52,7 @@ public class SignalAudioManager {
     audioManager.setMicrophoneMute(false);
     audioManager.setSpeakerphoneOn(speaker);
 
-    incomingRinger.start();
+    incomingRinger.start(ringtone);
   }
 
   public void startOutgoingRinger(OutgoingRinger.Type type) {


### PR DESCRIPTION
…contacts.

<!-- You can remove this first section if you have contributed before -->
### First time contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [x] I have read [how to contribute](https://github.com/WhisperSystems/Signal-Android/blob/master/CONTRIBUTING.md) to this project
- [x] I have signed the [Contributor License Agreement](https://whispersystems.org/cla/)

### Contributor checklist
<!-- replace the empty checkboxes [ ] below with checked ones [x] accordingly -->
- [ ] I am following the [Code Style Guidelines](https://github.com/WhisperSystems/Signal-Android/wiki/Code-Style-Guidelines)
- [x] I have tested my contribution on these devices:
 * Virtual device Nexus 4, Android 7.1 (API 25)
 * Virtual device Nexus, Android 7.0 (API 24)
 * Motorola Moto G, Android 5.1
- [x] My contribution is fully baked and ready to be merged as is
- [x] I ensure that all the open issues my contribution fixes are mentioned in the commit message of my first commit using the `Fixes #1234` [syntax](https://help.github.com/articles/closing-issues-via-commit-messages/)

----------

### Description
<!--
This patch ensures that custom ringtones are used for incoming calls, if a custom ringtone is set for the corresponding system contact.
![device_ringtone_selection](https://user-images.githubusercontent.com/5368734/34546728-1d3e4192-f0f6-11e7-8401-0c9a95b5125f.png)
If the ringtone for the contact is set to:
- none => no ringtone is played. 
- default ringtone => default ringtone is played.
- custom ringtone => custom ringtone is played.